### PR TITLE
STARSPane: rework global leader line handling and polish leader line details

### DIFF
--- a/eventstream.go
+++ b/eventstream.go
@@ -191,6 +191,7 @@ const (
 	RejectedPointOutEvent
 	IdentEvent
 	HandoffControllEvent
+	SetGlobalLeaderLineEvent
 	NumEventTypes
 )
 
@@ -198,7 +199,8 @@ func (t EventType) String() string {
 	return []string{"InitiatedTrack", "DroppedTrack", "PushedFlightStrip", "PointOut",
 		"OfferedHandoff", "AcceptedHandoff", "CanceledHandoff", "RejectedHandoff",
 		"RadioTransmission", "StatusMessage", "ServerBroadcastMessage",
-		"AcknowledgedPointOut", "RejectedPointOut", "Ident", "HandoffControll"}[t]
+		"AcknowledgedPointOut", "RejectedPointOut", "Ident", "HandoffControll",
+		"SetGlobalLeaderLine"}[t]
 }
 
 type Event struct {
@@ -207,7 +209,8 @@ type Event struct {
 	FromController        string
 	ToController          string // For radio transmissions, the controlling controller.
 	Message               string
-	RadioTransmissionType RadioTransmissionType // For radio transmissions only
+	RadioTransmissionType RadioTransmissionType     // For radio transmissions only
+	LeaderLineDirection   *CardinalOrdinalDirection // SetGlobalLeaderLineEvent
 }
 
 func (e *Event) String() string {

--- a/sim.go
+++ b/sim.go
@@ -2010,6 +2010,12 @@ func (s *Sim) SetGlobalLeaderLine(token, callsign string, dir *CardinalOrdinalDi
 		},
 		func(ctrl *Controller, ac *Aircraft) []RadioTransmission {
 			ac.GlobalLeaderLineDirection = dir
+			s.eventStream.Post(Event{
+				Type:                SetGlobalLeaderLineEvent,
+				Callsign:            ac.Callsign,
+				FromController:      callsign,
+				LeaderLineDirection: dir,
+			})
 			return nil
 		})
 }

--- a/world.go
+++ b/world.go
@@ -269,10 +269,6 @@ func (w *World) AmendFlightPlan(callsign string, fp FlightPlan) error {
 }
 
 func (w *World) SetGlobalLeaderLine(callsign string, dir *CardinalOrdinalDirection, success func(any), err func(error)) {
-	if ac := w.Aircraft[callsign]; ac != nil && ac.TrackingController == w.Callsign {
-		ac.GlobalLeaderLineDirection = dir
-	}
-
 	w.pendingCalls = append(w.pendingCalls,
 		&PendingCall{
 			Call:      w.simProxy.SetGlobalLeaderLine(callsign, dir),


### PR DESCRIPTION
For global leader lines, we need to be aware of when they are set since (AFAICT) if a global leader line direction is set for an aircraft, it overrides a controller's local per-aircraft leader line direction and similarly, if a controller sets a per-ac leader line direction, it overrides a global leader line direction.

Therefore:
- Setting the global leader line direction for an aircraft now posts an event to EventStream; STARSPane pays attention to this.
- STARSAircraftState now stores a bool UseGlobalLeaderLine to indicate whether to use the local or global one if both are set.

Other fixes:
- [Multifunc]L5* clears the 'controlled by other controllers' leader line direction setting (4-98)
- Leader line commands now use calculateController to look up TCPs (and not World GetController!)
- Cleaned up the code that distinguishes between setting a per-aircraft leader line direction specified using ACID ([Multifunc]L(#) (ACID)) and a per-controller leader line specified via TCP ([Multifunc]L(TCP)(#)).