### PR TITLE
Scenario PostDeserialize: reenable airspace awareness sanity checks

### DIFF
--- a/resources/scenarios/a80.json
+++ b/resources/scenarios/a80.json
@@ -2649,7 +2649,7 @@
           0,
           0
         ],
-        "receiving_controller": "C43",
+        "receiving_controller": "ATL_CTR",
         "to_center": true
       }
     ]

--- a/resources/scenarios/a90.json
+++ b/resources/scenarios/a90.json
@@ -2680,7 +2680,7 @@
           0,
           0
         ],
-        "receiving_controller": "C37",
+        "receiving_controller": "BOS_CTR",
         "to_center": true
       }
     ],

--- a/resources/scenarios/aus.json
+++ b/resources/scenarios/aus.json
@@ -1333,7 +1333,7 @@
                                     0,
                                     0
                                 ],
-                                "receiving_controller": "C50",
+                                "receiving_controller": "HOU_50_CTR",
                                 "to_center": true
                             },
                             {
@@ -1345,7 +1345,7 @@
                                     0,
                                     8999
                                 ],
-                                "receiving_controller": "1U",
+                                "receiving_controller": "I90_U_APP",
                                 "to_center": false
                             },
                             {
@@ -1357,7 +1357,7 @@
                                     9000,
                                     99000
                                 ],
-                                "receiving_controller": "C80",
+                                "receiving_controller": "HOU_80_CTR",
                                 "to_center": true
                             },
                             {
@@ -1368,7 +1368,7 @@
                                     0,
                                     0
                                 ],
-                                "receiving_controller": "C96",
+                                "receiving_controller": "HOU_96_CTR",
                                 "to_center": true
                             },
                             {
@@ -1379,7 +1379,7 @@
                                     0,
                                     13000
                                 ],
-                                "receiving_controller": "1N",
+                                "receiving_controller": "SAT_N_APP",
                                 "to_center": false
                             }
                         ]

--- a/resources/scenarios/c90.json
+++ b/resources/scenarios/c90.json
@@ -3435,7 +3435,7 @@
                             0,
                             0
                         ],
-                        "receiving_controller": "C81",
+                        "receiving_controller": "CHI_81_CTR",
                         "to_center": true
                     }
                 ]

--- a/resources/scenarios/cle.json
+++ b/resources/scenarios/cle.json
@@ -3112,7 +3112,7 @@
                                         0,
                                         0
                                     ],
-                                    "receiving_controller": "C66",
+                                    "receiving_controller": "CLE_CTR",
                                     "to_center": true
                                 }
                             ]

--- a/resources/scenarios/d10.json
+++ b/resources/scenarios/d10.json
@@ -3127,7 +3127,7 @@
                     0,
                     0
                 ],
-                "receiving_controller": "C32",
+                "receiving_controller": "FTW_32_CTR",
                 "to_center": true
             },
             {
@@ -3148,7 +3148,7 @@
                     0,
                     12000
                 ],
-                "receiving_controller": "1H",
+                "receiving_controller": "ACT_H_APP",
                 "to_center": false
             },
             {
@@ -3169,7 +3169,7 @@
                     12001,
                     99000
                 ],
-                "receiving_controller": "C96",
+                "receiving_controller": "FTW_96_CTR",
                 "to_center": true
             },
             {
@@ -3187,7 +3187,7 @@
                     0,
                     0
                 ],
-                "receiving_controller": "C83",
+                "receiving_controller": "FTW_83_CTR",
                 "to_center": true
             },
             {
@@ -3210,7 +3210,7 @@
                     0,
                     0
                 ],
-                "receiving_controller": "C53",
+                "receiving_controller": "FTW_53_CTR",
                 "to_center": true
             }
         ]

--- a/resources/scenarios/jfk.json
+++ b/resources/scenarios/jfk.json
@@ -2848,13 +2848,13 @@
       "frequency": 132175,
       "full_name": "New York center",
       "scope_char": "C",
-      "sector_id": "N34"
+      "sector_id": "C34"
     },
     "NY_F_CTR": {
       "frequency": 128300,
       "full_name": "New York center",
       "scope_char": "C",
-      "sector_id": "N66"
+      "sector_id": "C66"
     },
     "NY_LE_DEP": {
       "frequency": 126800,
@@ -3744,7 +3744,7 @@
           99999
         ],
         "to_center": true,
-        "receiving_controller": "C66"
+        "receiving_controller": "NY_F_CTR"
       },
       {
         "fixes": [
@@ -3760,7 +3760,7 @@
           99999
         ],
         "to_center": true,
-        "receiving_controller": "C66"
+        "receiving_controller": "NY_F_CTR"
       },
       {
         "fixes": [
@@ -3772,7 +3772,7 @@
           99999
         ],
         "to_center": true,
-        "receiving_controller": "B17"
+        "receiving_controller": "BOS_E_CTR"
       }
   ],
   "scratchpads": {

--- a/resources/scenarios/lib.json
+++ b/resources/scenarios/lib.json
@@ -2514,112 +2514,112 @@
         "fixes": ["MERIT", "BAYYS", "GREKI"],
         "altitude_range": [13000, 999000],
         "to_center": true,
-        "receiving_controller": "B19"
+        "receiving_controller": "BOS_SW_CTR"
       },
       {
         "fixes": ["DIXIE"],
         "altitude_range": [0, 8000],
         "to_center": false,
         "aircraft_type": ["J"],
-        "receiving_controller": "MY"
+        "receiving_controller": "WRI_APP"
       },
       {
         "fixes": ["DIXIE"],
         "altitude_range": [0, 6000],
         "to_center": false,
         "aircraft_type": ["P", "T"],
-        "receiving_controller": "MY"
+        "receiving_controller": "WRI_APP"
       },
       {
         "fixes": ["DIXIE"],
         "altitude_range": [11000, 999999],
         "to_center": true,
-        "receiving_controller": "C68"
+        "receiving_controller": "NY_68_CTR"
       },
       {
         "fixes": ["WHITE"],
         "altitude_range": [9000, 999999],
         "to_center": true,
-        "receiving_controller": "C68"
+        "receiving_controller": "NY_68_CTR"
       },
       {
         "fixes": ["RBV"],
         "altitude_range": [14000, 999999],
         "to_center": true,
         "aircraft_type": ["J"],
-        "receiving_controller": "C55"
+        "receiving_controller": "NY_55_CTR"
       },
       {
         "fixes": ["ARD"],
         "altitude_range": [14000, 999999],
         "to_center": true,
         "aircraft_type": ["P", "T"],
-        "receiving_controller": "C55"
+        "receiving_controller": "NY_55_CTR"
       },
       {
         "fixes": ["COATE", "GAYEL", "NEION"],
         "altitude_range": [16000, 999999],
         "to_center": true,
         "aircraft_type": ["J"],
-        "receiving_controller": "C35"
+        "receiving_controller": "NY_35_CTR"
       },
       {
         "fixes": ["COATE"],
         "altitude_range": [11000, 14000],
         "to_center": true,
-        "receiving_controller": "C51"
+        "receiving_controller": "NY_51_CTR"
       },
       {
         "fixes": ["GAYEL"],
         "altitude_range": [14000, 14000],
         "to_center": true,
         "aircraft_type": ["P", "T"],
-        "receiving_controller": "C51"
+        "receiving_controller": "NY_51_CTR"
       },
       {
         "fixes": ["HAAYS"],
         "altitude_range": [12000, 12000],
         "to_center": true,
-        "receiving_controller": "C51"
+        "receiving_controller": "NY_51_CTR"
       },
       {
         "fixes": ["COATE"],
         "altitude_range": [8000, 10000],
-        "receiving_controller": "AVP TODO"
+        "receiving_controller": "AVP_N_APP"
       },
       {
-        "fixes": ["SAX V118 LVZ"],
+        "fixes": ["SAX"],
         "altitude_range": [8000, 8000],
-        "receiving_controller": "AVP TODO"
+        "receiving_controller": "AVP_N_APP"
       },
       {
         "fixes": ["HAAYS"],
         "altitude_range": [9000, 10000],
-        "receiving_controller": "AVP TODO"
+        "receiving_controller": "AVP_N_APP"
       },
       {
         "fixes": ["PARKE", "ELIOT"],
         "altitude_range": [14000, 99999],
         "to_center": true,
-        "receiving_controller": "C39"
+        "receiving_controller": "NY_39_CTR"
       },
       {
         "fixes": ["NEWEL", "ZIMMZ"],
         "altitude_range": [17000, 99999],
         "to_center": true,
-        "receiving_controller": "C39"
+        "receiving_controller": "NY_39_CTR"
       },
       {
         "fixes": ["BIGGY"],
         "altitude_range": [14000, 99999],
         "to_center": true,
-        "receiving_controller": "C55"
+        "receiving_controller": "NY_55_CTR"
       },
       {
         "fixes": ["LANNA"],
         "altitude_range": [17000, 99999],
         "to_center": true,
-        "receiving_controller": "C55"
+        "receiving_controller": "NY_55_CTR"
       }
     ],
   "scratchpads": {
@@ -2830,10 +2830,17 @@
       "facility_id": "5"
     },
     "AVP_S_APP": {
-      "frequency": 126470,
+      "frequency": 126300,
       "full_name": "Wilkes Barre Approach",
       "scope_char": "7",
       "sector_id": "1E",
+      "facility_id": "7"
+    },
+    "AVP_N_APP": {
+      "frequency": 120950,
+      "full_name": "Wilkes Barre Approach",
+      "scope_char": "7",
+      "sector_id": "1B",
       "facility_id": "7"
     },
     "ABE_APP": {

--- a/resources/scenarios/m98.json
+++ b/resources/scenarios/m98.json
@@ -971,7 +971,7 @@
         "airspace_awareness": [
           {
             "fixes": ["ALO"],
-            "receiving_controller": "C05",
+            "receiving_controller": "MSP_05_CTR",
             "to_center": true
           }
         ],

--- a/resources/scenarios/n90.json
+++ b/resources/scenarios/n90.json
@@ -3489,7 +3489,7 @@
           999000
         ],
         "to_center": true,
-        "receiving_controller": "B19"
+        "receiving_controller": "BOS_SW_CTR"
       },
       {
         "fixes": [
@@ -3503,7 +3503,7 @@
         "aircraft_type": [
           "J"
         ],
-        "receiving_controller": "MY"
+        "receiving_controller": "WRI_APP"
       },
       {
         "fixes": [
@@ -3518,7 +3518,7 @@
           "P",
           "T"
         ],
-        "receiving_controller": "MY"
+        "receiving_controller": "WRI_APP"
       },
       {
         "fixes": [
@@ -3529,7 +3529,7 @@
           999999
         ],
         "to_center": true,
-        "receiving_controller": "C68"
+        "receiving_controller": "NY_68_CTR"
       },
       {
         "fixes": [
@@ -3540,7 +3540,7 @@
           999999
         ],
         "to_center": true,
-        "receiving_controller": "C68"
+        "receiving_controller": "NY_68_CTR"
       },
       {
         "fixes": [
@@ -3554,7 +3554,7 @@
         "aircraft_type": [
           "J"
         ],
-        "receiving_controller": "C55"
+        "receiving_controller": "NY_55_CTR"
       },
       {
         "fixes": [
@@ -3569,7 +3569,7 @@
           "P",
           "T"
         ],
-        "receiving_controller": "C55"
+        "receiving_controller": "NY_55_CTR"
       },
       {
         "fixes": [
@@ -3585,7 +3585,7 @@
         "aircraft_type": [
           "J"
         ],
-        "receiving_controller": "C35"
+        "receiving_controller": "NY_35_CTR"
       },
       {
         "fixes": [
@@ -3596,7 +3596,7 @@
           14000
         ],
         "to_center": true,
-        "receiving_controller": "C51"
+        "receiving_controller": "NY_51_CTR"
       },
       {
         "fixes": [
@@ -3611,7 +3611,7 @@
           "P",
           "T"
         ],
-        "receiving_controller": "C51"
+        "receiving_controller": "NY_51_CTR"
       },
       {
         "fixes": [
@@ -3622,7 +3622,7 @@
           12000
         ],
         "to_center": true,
-        "receiving_controller": "C51"
+        "receiving_controller": "NY_51_CTR"
       },
       {
         "fixes": [
@@ -3632,17 +3632,17 @@
           8000,
           10000
         ],
-        "receiving_controller": "AVP TODO"
+        "receiving_controller": "AVP_N_APP"
       },
       {
         "fixes": [
-          "SAX V118 LVZ"
+          "SAX"
         ],
         "altitude_range": [
           8000,
           8000
         ],
-        "receiving_controller": "AVP TODO"
+        "receiving_controller": "AVP_N_APP"
       },
       {
         "fixes": [
@@ -3652,7 +3652,7 @@
           9000,
           10000
         ],
-        "receiving_controller": "AVP TODO"
+        "receiving_controller": "AVP_N_APP"
       },
       {
         "fixes": [
@@ -3664,7 +3664,7 @@
           99999
         ],
         "to_center": true,
-        "receiving_controller": "C39"
+        "receiving_controller": "NY_39_CTR"
       },
       {
         "fixes": [
@@ -3676,7 +3676,7 @@
           99999
         ],
         "to_center": true,
-        "receiving_controller": "C39"
+        "receiving_controller": "NY_39_CTR"
       },
       {
         "fixes": [
@@ -3687,7 +3687,7 @@
           99999
         ],
         "to_center": true,
-        "receiving_controller": "C55"
+        "receiving_controller": "NY_55_CTR"
       },
       {
         "fixes": [
@@ -3698,7 +3698,7 @@
           99999
         ],
         "to_center": true,
-        "receiving_controller": "C55"
+        "receiving_controller": "NY_55_CTR"
       },
       {
         "fixes": [
@@ -3713,7 +3713,7 @@
           99999
         ],
         "to_center": true,
-        "receiving_controller": "C66"
+        "receiving_controller": "NY_66_CTR"
       },
       {
         "fixes": [
@@ -3729,7 +3729,7 @@
           99999
         ],
         "to_center": true,
-        "receiving_controller": "C66"
+        "receiving_controller": "NY_66_CTR"
       },
       {
         "fixes": [
@@ -3741,7 +3741,7 @@
           99999
         ],
         "to_center": true,
-        "receiving_controller": "B17"
+        "receiving_controller": "BOS_17_CTR"
       }
     ],
   "scratchpads": {
@@ -3945,6 +3945,22 @@
       "sector_id": "1E",
       "facility_id": "7"
     },
+    "BOS_SW_CTR": {
+      "frequency": 134000,
+      "full_name": "Boston center",
+      "scope_char": "C",
+      "sector_id": "B19",
+      "facility_id": "B",
+      "eram_facility": true
+    },
+    "BOS_17_CTR": {
+      "frequency": 133450,
+      "full_name": "Boston center",
+      "scope_char": "C",
+      "sector_id": "B17",
+      "facility_id": "B",
+      "eram_facility": true
+    },
     "BOS_CTR": {
       "frequency": 134700,
       "full_name": "Boston center",
@@ -4103,6 +4119,20 @@
       "full_name": "Kennedy tower",
       "scope_char": "T",
       "sector_id": "2W"
+    },
+    "WRI_APP": {
+      "frequency": 126470,
+      "full_name": "McGuire approach",
+      "scope_char": "5",
+      "sector_id": "1Y",
+      "facility_id": "5"
+    },
+    "AVP_N_APP": {
+      "frequency": 120950,
+      "full_name": "Wilkes Barre Approach",
+      "scope_char": "7",
+      "sector_id": "1B",
+      "facility_id": "7"
     }
   },
   "default_scenario": "N90 Combined. Coney: JFK Belmont: LGA",

--- a/scenario.go
+++ b/scenario.go
@@ -207,6 +207,13 @@ func (s *Scenario) PostDeserialize(sg *ScenarioGroup, e *ErrorLogger) {
 		}
 	}
 
+	// Make sure all of the controllers used in airspace awareness will be there.
+	for _, aa := range sg.STARSFacilityAdaptation.AirspaceAwareness {
+		if !slices.Contains(s.VirtualControllers, aa.ReceivingController) {
+			s.VirtualControllers = append(s.VirtualControllers, aa.ReceivingController)
+		}
+	}
+
 	sort.Slice(s.ArrivalRunways, func(i, j int) bool {
 		if s.ArrivalRunways[i].Airport == s.ArrivalRunways[j].Airport {
 			return s.ArrivalRunways[i].Runway < s.ArrivalRunways[j].Runway
@@ -677,26 +684,20 @@ func (sg *ScenarioGroup) PostDeserialize(e *ErrorLogger, simConfigurations map[s
 	for _, aa := range sg.STARSFacilityAdaptation.AirspaceAwareness {
 		e.Push("stars_adaptation")
 
-		// FIXME: disabled for now due to some errors in lib.json
-		/*
-			for _, fix := range aa.Fix {
-				if _, ok := sg.locate(fix); !ok {
-					e.ErrorString(fix + ": fix unknown")
-				}
+		for _, fix := range aa.Fix {
+			if _, ok := sg.locate(fix); !ok {
+				e.ErrorString(fix + ": fix unknown")
 			}
-		*/
+		}
 
 		if aa.AltitudeRange[0] > aa.AltitudeRange[1] {
 			e.ErrorString("lower end of \"altitude_range\" %d above upper end %d",
 				aa.AltitudeRange[0], aa.AltitudeRange[1])
 		}
 
-		// FIXME: disabled pending resolving sector id vs controller callsign
-		/*
-			if _, ok := sg.ControlPositions[aa.ReceivingController]; !ok {
-				e.ErrorString(aa.ReceivingController + ": controller unknown")
-			}
-		*/
+		if _, ok := sg.ControlPositions[aa.ReceivingController]; !ok {
+			e.ErrorString(aa.ReceivingController + ": controller unknown")
+		}
 
 		for _, t := range aa.AircraftType {
 			if t != "J" && t != "T" && t != "P" {


### PR DESCRIPTION
Fixed up the errors in scenarios that they found.

Also, added code to ensure that all controllers used for those handoffs will be present in the signon list.