### PR TITLE
Don't show arrival airport for specified airports 

### DIFF
--- a/airport.go
+++ b/airport.go
@@ -32,7 +32,8 @@ type Airport struct {
 	ApproachRegions   map[string]*ApproachRegion `json:"approach_regions"`
 	ConvergingRunways []ConvergingRunways        `json:"converging_runways"`
 
-	ATPAVolumes map[string]*ATPAVolume `json:"atpa_volumes"`
+	ATPAVolumes           map[string]*ATPAVolume `json:"atpa_volumes"`
+	OmitArrivalScratchpad bool                   `json:"omit_arrival_scratchpad"`
 }
 
 type ConvergingRunways struct {

--- a/resources/scenarios/ewr.json
+++ b/resources/scenarios/ewr.json
@@ -2,6 +2,7 @@
   "tracon": "N90",
   "airports": {
     "KEWR": {
+      "omit_arrival_scratchpad": true,
       "name": "Newark",
       "approaches": {
         "I11": {

--- a/stars.go
+++ b/stars.go
@@ -6172,8 +6172,15 @@ func (sp *STARSPane) formatDatablocks(ctx *PaneContext, ac *Aircraft) []STARSDat
 		alt := fmt.Sprintf("%03d", (state.TrackAltitude()+50)/100)
 		sp := fmt.Sprintf("%3s", ac.Scratchpad)
 
-		field1 := [2]string{alt, Select(ac.Scratchpad != "", sp, ap)}
-
+		field1 := [2]string{}
+		field1[0] = alt
+		if ac.Scratchpad != "" {
+			field1[1] = sp
+		} else if airport := ctx.world.GetAirport(ac.FlightPlan.ArrivalAirport); airport != nil && !airport.OmitArrivalScratchpad {
+			field1[1] = ap
+		} else {
+			field1[1] = alt
+		}
 		dbs[0].Lines[1].Text = field1[0] + field2 + field3 + field4
 		dbs[1].Lines[1].Text = field1[1] + field2 + field3 + field4
 
@@ -6226,11 +6233,13 @@ func (sp *STARSPane) formatDatablocks(ctx *PaneContext, ac *Aircraft) []STARSDat
 			field3 = append(field3, ac.SecondaryScratchpad)
 		}
 		if len(field3) == 1 {
-			ap := ac.FlightPlan.ArrivalAirport
-			if len(ap) == 4 {
-				ap = ap[1:] // drop the leading K
+			if ap := ctx.world.GetAirport(ac.FlightPlan.ArrivalAirport); ap != nil && !ap.OmitArrivalScratchpad {
+				ap := ac.FlightPlan.ArrivalAirport
+				if len(ap) == 4 {
+					ap = ap[1:] // drop the leading K
+				}
+				field3 = append(field3, ap)
 			}
-			field3 = append(field3, ap)
 		}
 
 		field4 := "  "


### PR DESCRIPTION
For #162.
`omit_arrival_scratchpad` can now be specified in the airport struct.