### PR TITLE
Rework handling of keyboard input for DCB spinners

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -125,6 +125,7 @@ var (
 	ErrSTARSIllegalTrack      = NewSTARSError("ILL TRK")
 	ErrSTARSIllegalValue      = NewSTARSError("ILL VALUE")
 	ErrSTARSNoFlight          = NewSTARSError("NO FLIGHT")
+	ErrSTARSRangeLimit        = NewSTARSError("RANGE LIMIT")
 )
 
 var starsErrorRemap = map[error]*STARSError{

--- a/ui.go
+++ b/ui.go
@@ -182,6 +182,8 @@ var (
 		`Fixed a bug where go-arounds would sometimes not contact departure`,
 		`Fixed a bug where live weather would occasionally cause vice to crash`,
 		`Fixed a bug where aircraft TAS would be too high at high altitudes`,
+		`Added support for ATC chat`,
+		`Improved handling of keyboard input when spinners in the STARS DCB are active`,
 	}
 )
 

--- a/website/index.html
+++ b/website/index.html
@@ -716,6 +716,12 @@ how it simulates aircraft or the STARS interface.
           <section class="docs-section" id="releases">
             <h2 class="section-heading">Release History</h2>
 
+            <h3>0.10.23 (TODO)</h3>
+            <ul>
+              <li>Added ATC chat functionality.</li>
+              <li>Improved handling of keyboard input when spinners in the STARS DCB are active.</li>
+            </ul>
+
             <h3>0.10.22 (28 April 2024)</h3>
             <ul>
               <li>Fixed bug where <i>vice</i> would sometimes crash when
@@ -1408,15 +1414,15 @@ how it simulates aircraft or the STARS interface.
                   <tr><td><code>[INIT CNTL]</code></td><td>[F3] or [CTRL][SHIFT]</td></tr>
                   <tr><td><code>[TERM CNTL]</code></td><td>[F4]</td></tr>
                   <tr><td><code>[HND OFF]</code></td><td>[F5]</td></tr>
-                  <tr><td><code>[VP]</code></td><td>[F6]</td></tr>
+                  <tr><td><code>[FLT DATA]</code></td><td>[F6]</td></tr>
                   <tr><td><code>[MULTIFUNC]</code></td><td>[F7]</td></tr>
-                  <tr><td><code>[FLT DATA]</code></td><td>[F9]</td></tr>
+                  <tr><td><code>[VP]</code></td><td>[F9]</td></tr>
                   <tr><td><code>[CA]</code></td><td>[F11]</td></tr>
                   <tr><td><code>[CNTR]</code></td><td>[Ctrl-F1]</td></tr>
                   <tr><td><code>[MAPS]</code></td><td>[Ctrl-F2]</td></tr>
-                  <tr><td><code>[BRITE]</code></td><td>[Ctrl-F4]</td></tr>
-                  <tr><td><code>[LDR]</code></td><td>[Ctrl-F5]</td></tr>
-                  <tr><td><code>[CHARSIZE]</code></td><td>[Ctrl-F6]</td></tr>
+                  <tr><td><code>[BRITE]</code></td><td>[Ctrl-F3]</td></tr>
+                  <tr><td><code>[LDR]</code></td><td>[Ctrl-F4]</td></tr>
+                  <tr><td><code>[CHARSIZE]</code></td><td>[Ctrl-F5]</td></tr>
                   <tr><td><code>[DCB-SHIFT]</code></td><td>[Ctrl-F7]</td></tr>
                   <tr><td><code>[DCB]</code></td><td>[Ctrl-F8]</td></tr>
                   <tr><td><code>[RNGRING]</code></td><td>[Ctrl-F9]</td></tr>


### PR DESCRIPTION
Now there is a DCBSpinner interface and implementations of it encapsulate the sometimes-esoteric logic about which values are valid, how keyboard input is interpreted, etc. When a spinner is active (either due to clicking the DCB or due to an associated keyboard command like ctrl F9 for range rings), keyboard input from the user is passed along to set the associated value.

This also includes some updates to DCB f-key mappings to match CRC STARS. (Ctrl-F3: BRITE, Ctrl-F4: leader line length, Ctrl-F5: char size, F9: VFR plan)

Fixes #107 and #116.