### PR TITLE
Fix regression in handling of track history

### DIFF
--- a/world.go
+++ b/world.go
@@ -546,8 +546,8 @@ func (w *World) GetUpdates(eventStream *EventStream, onErr func(error)) {
 
 	w.checkPendingRPCs(eventStream)
 
-	// Wait in seconds between update fetches; no less than 100ms
-	rate := clamp(1/w.SimRate, 0.1, 1)
+	// Wait in seconds between update fetches; no less than 50ms
+	rate := clamp(1/w.SimRate, 0.05, 1)
 	if d := time.Since(w.lastUpdateRequest); d > time.Duration(rate*float32(time.Second)) {
 		if w.updateCall != nil {
 			lg.Warnf("GetUpdates still waiting for %s on last update call", d)


### PR DESCRIPTION
The updated handling of track history in 8460812c10838 inadvertently introduced a regression, where (for example) the PTLs for aircraft in a turn would only be updated at the history rate (~5s) and not every time the radar supplied us with a new track (~1s).

With this fix now we always store the most recent and the second most recent returns from the radar regardless of the track history rate used to display track tails. These are then used to calculate the aircraft heading and such, which fixes the regression...