### PR TITLE
STARSPane: draw controller ids and not question marks in observer mode

### DIFF
--- a/stars.go
+++ b/stars.go
@@ -5378,8 +5378,7 @@ func (sp *STARSPane) drawTracks(aircraft []*Aircraft, ctx *PaneContext, transfor
 		trackId := "*"
 		if ac.TrackingController != "" {
 			trackId = "?"
-			octrl := ctx.world.GetControllerByCallsign(ctx.world.Callsign)
-			if ctrl := ctx.world.GetControllerByCallsign(ac.TrackingController); ctrl != nil && octrl != nil {
+			if ctrl := ctx.world.GetControllerByCallsign(ac.TrackingController); ctrl != nil {
 				trackId = ctrl.Scope
 			}
 		}


### PR DESCRIPTION
Fixes #206.

This seems fairly straightforward but I'm wondering if you remember if there was a reason for the check with `octrl` there...