### PR TITLE
D01 and COS Scenario updates

### DIFF
--- a/resources/scenarios/cos revised.json
+++ b/resources/scenarios/cos revised.json
@@ -1,0 +1,951 @@
+{
+  "tracon": "COS",
+  "airports": {
+    "KCOS": {
+      "approaches": {
+        "I7L": {
+          "runway": "17L",
+          "type": "ILS",
+          "tower_controller": "COS_E_TWR",
+          "waypoints": [
+            "ADANE/arc11BRK MOGAL/a10000 AWONE/a9000 ROCCK/iaf/a8700 HUMPE/a7540"
+          ]
+        },
+        "RY7L": {
+          "runway": "17L",
+          "type": "RNAV",
+          "full_name": "RNAV Y Runway 17L",
+          "tower_controller": "COS_E_TWR",
+          "waypoints": [
+            "ADANE OLAPE/iaf NUBSE/a9500/iaf ROCCK/iaf/a8700 JESLO/a7500"
+          ]
+        },
+        "RZ7L": {
+          "runway": "17L",
+          "type": "RNAV",
+          "full_name": "RNAV Z Runway 17L",
+          "tower_controller": "COS_E_TWR",
+          "waypoints": [
+              "ADANE/iaf REEFF/a9000+/if SOGKO/a9000+/s180/arc8.200000CFBWR ROCCK/a8700+",
+	      "FSHER/iaf WIPUN/a10000+/if ZIVAD/a9000+/s180/arc4.100000CFBWT SOGKO/a9000+/arc8.200000CFBWR ROCCK/a8700+",
+	      "LUFSE/iaf JONOL/a9100+/if ROCCK/a8700+"
+          ]
+        },
+        "RY7R": {
+          "runway": "17R",
+          "type": "RNAV",
+          "full_name": "RNAV Y Runway 17R",
+          "tower_controller": "COS_W_TWR",
+          "waypoints": [
+            "LUFSE HIDAN/iaf FEBLA/if/a9500 CEMKA/a8700 KAGHU/a7240 LAXLY/a6860"
+          ]
+        },
+        "I5L": {
+          "runway": "35L",
+          "type": "ILS",
+          "tower_controller": "COS_W_TWR",
+          "waypoints": [
+              "DRAKE/iaf/a8000/arc22.7BRK MIDAY/a8000 N38.41.39.9,W104.42.58.8"
+          ]
+        },
+        "RY5L": {
+          "runway": "35L",
+          "tower_controller": "COS_W_TWR",
+          "full_name": "RNAV Y Runway 35L",
+          "type": "RNAV",
+          "waypoints": [
+            "DRAKE/a8100 ASHLL/iaf/a8100 MIDAY/if/a8100 KUSAC/a8100"
+          ]
+        },
+        "RZ5L": {
+          "runway": "35L",
+          "type": "RNAV",
+          "tower_controller": "COS_W_TWR",
+          "full_name": "RNAV Z Runway 35L",
+          "waypoints": [
+            "DRAKE/iaf/a9000 WOVID/if/a9000 HUNSI/s180/arc3.9 KUSAC/a8100",
+            "FSHER/iaf/a9000 MIDAY/if/a8100 KUSAC/a8100"
+          ]
+        },
+        "I5R": {
+          "runway": "35R",
+          "type": "ILS",
+          "tower_controller": "COS_E_TWR",
+          "waypoints": [
+            "DRAKE/iaf/a8100/arc22.7BRK FALUR/a8100 CEGIX/a8100"
+          ]
+        },
+        "RY5R": {
+          "runway": "35R",
+          "type": "ILS",
+          "tower_controller": "COS_E_TWR",
+          "full_name": "RNAV Y Runway 35R",
+          "waypoints": [
+            "DRAKE/a8100 HABUK/iaf/a8100 FALUR/a8100 CEGIX/a8100",
+            "PUB HABUK/iaf/a8100 FALUR/a8100 CEGIX/a8100"
+          ]
+        },
+        "RZ5R": {
+          "runway": "35R",
+          "type": "RNAV",
+          "tower_controller": "COS_E_TWR",
+          "full_name": "RNAV Z Runway 35R",
+          "waypoints": [
+            "DRAKE/iaf/a8100 JODUM/if/a8100/s180 ZIRKU/a8100/arc4 CEGIX/a8100",
+            "FSHER/iaf FALUR/if/a8100 CEGIX/a8100"
+          ]
+        }
+      },
+      "departure_routes": {
+        "35L": {
+          "LUFSE": {
+            "cleared_altitude": 10000,
+            "waypoints": "_COS17R/h352"
+          },
+	  "BYEBI": {
+            "cleared_altitude": 10000,
+            "waypoints": "_COS17R/h352"
+          },
+	  "DRAKE": {
+            "cleared_altitude": 10000,
+            "waypoints": "_COS17R/h352"
+          },
+	  "JEWLS": {
+            "cleared_altitude": 10000,
+            "waypoints": "_COS17R/h352"
+          },
+          "PUB": {
+            "cleared_altitude": 10000,
+            "waypoints": "_COS17R/h352"
+          },
+          "BRK": {
+            "cleared_altitude": 10000,
+            "waypoints": "_COS17R/h352"
+          },
+          "HBU": {
+            "cleared_altitude": 10000,
+            "waypoints": "_COS17R/h352"
+          },
+          "LAA": {
+            "cleared_altitude": 10000,
+            "waypoints": "_COS17R/h352"
+          },
+          "BRESH": {
+            "cleared_altitude": 10000,
+            "waypoints": "_COS17R/h352"
+          },
+          "ALS": {
+            "cleared_altitude": 10000,
+            "waypoints": "_COS17R/h352"
+          },
+          "DVV": {
+            "cleared_altitude": 10000,
+            "waypoints": "_COS17R/h352"
+          },
+          "FQF": {
+            "cleared_altitude": 10000,
+            "waypoints": "_COS17R/h352"
+          }
+        },
+        "35R": {
+          "LUFSE": {
+            "cleared_altitude": 10000,
+            "waypoints": "_COS17L/h010"
+          },
+	  "BYEBI": {
+            "cleared_altitude": 10000,
+            "waypoints": "_COS17L/h010"
+          },
+	  "DRAKE": {
+            "cleared_altitude": 10000,
+            "waypoints": "_COS17L/h010"
+          },
+	  "JEWLS": {
+            "cleared_altitude": 10000,
+            "waypoints": "_COS17L/h010"
+          },
+          "PUB": {
+            "cleared_altitude": 10000,
+            "waypoints": "_COS17L/h010"
+          },
+          "BRK": {
+            "cleared_altitude": 10000,
+            "waypoints": "_COS17L/h010"
+          },
+          "HBU": {
+            "cleared_altitude": 10000,
+            "waypoints": "_COS17L/h010"
+          },
+          "LAA": {
+            "cleared_altitude": 10000,
+            "waypoints": "_COS17L/h010"
+          },
+          "BRESH": {
+            "cleared_altitude": 10000,
+            "waypoints": "_COS17L/h010"
+          },
+          "ALS": {
+            "cleared_altitude": 10000,
+            "waypoints": "_COS17L/h010"
+          },
+          "DVV": {
+            "cleared_altitude": 10000,
+            "waypoints": "_COS17L/h010"
+          },
+          "FQF": {
+            "cleared_altitude": 10000,
+            "waypoints": "_COS17L/h010"
+          }
+        },
+          "17L": {
+            "LUFSE": {
+              "cleared_altitude": 10000,
+              "waypoints": "_COS35R/h150"
+            },
+	    "BYEBI": {
+              "cleared_altitude": 10000,
+              "waypoints": "_COS35R/h150"
+            },
+	    "DRAKE": {
+              "cleared_altitude": 10000,
+              "waypoints": "_COS35R/h150"
+            },
+	    "JEWLS": {
+              "cleared_altitude": 10000,
+              "waypoints": "_COS35R/h150"
+            },
+            "PUB": {
+              "cleared_altitude": 10000,
+              "waypoints": "_COS35R/h150"
+            },
+            "BRK": {
+              "cleared_altitude": 10000,
+              "waypoints": "_COS35R/h150"
+            },
+            "HBU": {
+              "cleared_altitude": 10000,
+              "waypoints": "_COS35R/h150"
+            },
+            "LAA": {
+              "cleared_altitude": 10000,
+              "waypoints": "_COS35R/h150"
+            },
+            "BRESH": {
+              "cleared_altitude": 10000,
+              "waypoints": "_COS35R/h150"
+            },
+            "ALS": {
+              "cleared_altitude": 10000,
+              "waypoints": "_COS35R/h150"
+            },
+            "DVV": {
+              "cleared_altitude": 10000,
+              "waypoints": "_COS35R/h150"
+            },
+            "FQF": {
+              "cleared_altitude": 10000,
+              "waypoints": "_COS35R/h150"
+            }
+          },
+          "17R": {
+            "LUFSE": {
+              "cleared_altitude": 10000,
+              "waypoints": "_COS35L/h172"
+            },
+	    "BYEBI": {
+              "cleared_altitude": 10000,
+              "waypoints": "_COS35L/h172"
+            },
+	    "DRAKE": {
+              "cleared_altitude": 10000,
+              "waypoints": "_COS35L/h172"
+            },
+	    "JEWLS": {
+              "cleared_altitude": 10000,
+              "waypoints": "_COS35L/h172"
+            },
+            "PUB": {
+              "cleared_altitude": 10000,
+              "waypoints": "_COS35L/h172"
+            },
+            "BRK": {
+              "cleared_altitude": 10000,
+              "waypoints": "_COS35L/h172"
+            },
+            "HBU": {
+              "cleared_altitude": 10000,
+              "waypoints": "_COS35L/h172"
+            },
+            "LAA": {
+              "cleared_altitude": 10000,
+              "waypoints": "_COS35L/h172"
+            },
+            "BRESH": {
+              "cleared_altitude": 10000,
+              "waypoints": "_COS35L/h172"
+            },
+            "ALS": {
+              "cleared_altitude": 10000,
+              "waypoints": "_COS35L/h172"
+            },
+            "DVV": {
+              "cleared_altitude": 10000,
+              "waypoints": "_COS35L/h172"
+            },
+            "FQF": {
+              "cleared_altitude": 10000,
+              "waypoints": "_COS35L/h172"
+            }
+          }
+        },
+      "departures": [
+        {
+          "airlines": [
+            {
+              "fleet": "fastGA",
+              "icao": "N"
+            },
+            {
+              "icao": "EDV"
+            },
+            {
+              "icao": "JIA"
+            },
+            {
+              "icao": "DPJ"
+            }
+          ],
+          "altitude": 39000,
+          "destination": "KSAT",
+          "route": "BRK BRESH TBE",
+          "exit": "BRESH"
+        },
+        {
+          "airlines": [
+            {
+              "fleet": "tncmShort",
+              "icao": "AAL"
+            },
+            {
+              "icao": "SKW"
+            },
+            {
+              "icao": "ENY"
+            }
+          ],
+          "altitude": 39000,
+          "destination": "KDFW",
+          "route": "BRK BRESH EZEEE",
+          "exit": "BRESH"
+        },
+        {
+          "airlines": [
+            {
+              "fleet": "fastGA",
+              "icao": "N"
+            }
+          ],
+          "altitude": 12000,
+          "destination": "KAPA",
+          "route": "ADANE BYEBI DUNNN5",
+          "exit": "BYEBI"
+        },
+        {
+          "airlines": [
+            {
+              "fleet": "fastGA",
+              "icao": "N"
+            }
+          ],
+          "altitude": 28000,
+          "destination": "KBZN",
+          "route": "BRK FQF DEN YAMMI",
+          "exit": "FQF"
+        },
+        {
+          "airlines": [
+            {
+              "icao": "SWA"
+            }
+          ],
+          "altitude": 13000,
+          "destination": "KDEN",
+          "route": "ADANE LUFSE JEFEL FQF",
+          "exit": "LUFSE"
+        },
+        {
+          "airlines": [
+            {
+              "fleet": "fastGA",
+              "icao": "N"
+            },
+            {
+              "icao": "EDV"
+            },
+            {
+              "icao": "JIA"
+            },
+            {
+              "icao": "DPJ"
+            }
+          ],
+          "altitude": 32000,
+          "destination": "KLAX",
+          "route": "DRAKE V83 PUB",
+          "exit": "DRAKE"
+        },
+        {
+          "airlines": [
+            {
+              "fleet": "fastGA",
+              "icao": "N"
+            },
+            {
+              "icao": "EDV"
+            },
+            {
+              "icao": "JIA"
+            },
+            {
+              "icao": "DPJ"
+            }
+          ],
+          "altitude": 33000,
+          "destination": "KOMA",
+          "route": "BRK JEWLS GLD",
+          "exit": "JEWLS"
+        }
+      ],
+      "exit_categories": {
+        "LUFSE": "North",
+        "BEYBI": "North",
+        "DRAKE": "North",
+        "JEWLS": "North",
+        "PUB": "North",
+        "BRK": "North",
+        "HBU": "North",
+        "LAA": "North",
+        "BRESH": "North",
+        "ALS": "North",
+        "DVV": "North",
+        "FQF": "North"
+      },
+      "tower_list": 2
+    }
+  },
+  "airspace": {
+    "boundaries": {
+        "COS_ARSPC": [
+          "N038.26.11.374,W105.00.19.171",
+          "N038.26.12.761,W104.47.57.346",
+          "N038.29.59.368,W104.02.39.906",
+          "N038.51.10.101,W104.05.07.177",
+          "N039.11.47.794,W104.15.09.750",
+          "N039.10.10.235,W104.19.35.234",
+          "N039.10.03.135,W104.42.08.723",
+          "N039.06.24.947,W104.46.38.464",
+          "N039.07.44.790,W105.05.10.501",
+          "N038.58.43.397,W105.03.24.043",
+          "N038.42.03.669,W104.57.03.532",
+          "N038.32.15.763,W104.59.04.738",
+          "N038.26.09.863,W105.00.13.293"
+        ],
+        "COS_OUTER": [
+          "N038.26.34.226,W104.45.05.685",
+          "N038.21.59.856,W104.44.59.588",
+          "N038.23.03.192,W104.32.54.325",
+          "N038.29.29.348,W104.09.01.186"
+          ]
+    },
+    "volumes": {
+        "COS_APP": [
+            {
+                "boundaries": [
+                    "COS_ARSPC"
+                ],
+                "lower": 0,
+                "upper": 17000
+            },
+            {
+              "boundaries": [
+                  "COS_OUTER"
+              ],
+              "lower": 11000,
+              "upper": 12000
+          }
+        ]
+        }
+    },
+  "arrival_groups": {
+    "OZZZY5": [
+      {
+        "airlines": {
+          "KCOS": [
+            {
+              "airport": "KMCI",
+              "icao": "SWA"
+            },
+            {
+              "airport": "KOMA",
+              "fleet": "fastGA",
+              "icao": "N"
+            },
+            {
+              "airport": "KDFW",
+              "fleet": "tncmShort",
+              "icao": "AAL"
+            }
+          ]
+        },
+        "cruise_altitude": 34000,
+        "initial_altitude": 18000,
+        "description": "",
+        "initial_controller": "DEN_29_CTR",
+        "initial_speed": 270,
+        "route": "HGO OZZZY",
+        "waypoints": "HGO/a17000 N038.51.21.568,W103.55.28.472/ho OZZZY/a14000/s250"
+      }
+    ],
+    "DEBERRY5": [
+      {
+        "airlines": {
+          "KCOS": [
+            {
+              "airport": "KSAT",
+              "icao": "JIA"
+            },
+            {
+              "airport": "KPHX",
+              "icao": "EDV"
+            },
+            {
+              "airport": "KABQ",
+              "fleet": "fastGA",
+              "icao": "N"
+            }
+          ]
+        },
+        "cruise_altitude": 23000,
+        "initial_altitude": 12000,
+        "assigned_altitude": 11000,
+        "description": "",
+        "initial_controller": "PUB_APP",
+        "initial_speed": 210,
+        "route": "OPSHN FSHER BRK",
+        "waypoints": "OPSHN/s250 FSHER/s250/ho BRK"
+      }
+    ],
+    "DEN": [
+      {
+        "airlines": {
+          "KCOS": [
+            {
+              "airport": "KAPA",
+              "icao": "N"
+            },
+            {
+              "airport": "KGXY",
+              "icao": "N"
+            },
+            {
+              "airport": "KBJC",
+              "icao": "N"
+            },
+            {
+              "airport": "KFNL",
+              "icao": "N"
+            }
+          ]
+        },
+        "cruise_altitude": 11000,
+        "initial_altitude": 11000,
+        "description": "",
+        "initial_controller": "DEN_A_APP",
+        "initial_speed": 160,
+        "route": "LUFSE ADANE BRK",
+        "waypoints": "N039.19.52.813,W104.24.24.065 LUFSE/ho ADANE BRK"
+      }
+    ],
+    "PUB": [
+      {
+        "airlines": {
+          "KCOS": [
+            {
+              "airport": "KPUB",
+              "icao": "N"
+            }
+          ]
+        },
+        "cruise_altitude": 11000,
+        "initial_altitude": 11000,
+        "description": "",
+        "initial_controller": "PUB_APP",
+        "initial_speed": 160,
+        "route": "KCOS",
+        "waypoints": "N038.18.27.106,W104.38.51.298 N038.21.18.080,W104.38.42.427/ho"
+      }
+    ],
+    "DEN.NW": [
+      {
+        "airlines": {
+          "KCOS": [
+            {
+              "airport": "KBJC",
+              "icao": "N"
+            },
+            {
+              "airport": "KFNL",
+              "icao": "N"
+            },
+            {
+              "airport": "KGXY",
+              "icao": "N"
+            }
+          ]
+        },
+        "cruise_altitude": 11000,
+        "initial_altitude": 11000,
+        "description": "",
+        "initial_controller": "DEN_A_APP",
+        "initial_speed": 160,
+        "route": "ADANE BRK",
+        "waypoints": "N039.17.29.606,W104.42.09.739 N039.13.10.370,W104.35.00.860/ho ADANE BRK"
+      }
+    ]
+  },
+  "control_positions": {
+    "COS_APP": {
+      "frequency": 124000,
+      "full_name": "Springs approach",
+      "scope_char": "A",
+      "sector_id": "2A"
+    },
+    "COS_V_APP": {
+      "frequency": 120600,
+      "full_name": "Springs approach",
+      "scope_char": "V",
+      "sector_id": "2V"
+    },
+    "COS_W_TWR": {
+      "frequency": 119900,
+      "full_name": "Springs tower",
+      "scope_char": "T",
+      "sector_id": "2WT"
+    },
+    "COS_E_TWR": {
+      "frequency": 135150,
+      "full_name": "Springs tower",
+      "scope_char": "T",
+      "sector_id": "2ET"
+    },
+    "DEN_A_APP": {
+      "frequency": 132750,
+      "full_name": "Denver approach",
+      "scope_char": "A",
+      "sector_id": "1A"
+    },
+    "DEN_29_CTR": {
+      "frequency": 132225,
+      "full_name": "Denver center",
+      "facility_id": "C",
+      "eram_facility": true,
+      "scope_char": "C",
+      "sector_id": "29"
+    },
+    "PUB_APP": {
+      "frequency": 120100,
+      "full_name": "Pueblo Approach",
+      "facility_id": "1",
+      "scope_char": "P",
+      "sector_id": "1P"
+    }
+  },
+  "default_scenario": "North VMC",
+  "fixes": {
+    "_COS": "38.805801,-104.700996",
+    "_COS35R": "N038.46.41.554,W104.41.09.122",
+    "_COS35L": "N038.47.36.280,W104.42.58.381",
+    "_COS17L": "N038.49.00.367,W104.41.08.408",
+    "_COS17R": "N038.49.27.489,W104.42.59.589"
+  },
+  "name": "KCOS",
+  "primary_airport": "KCOS",
+  "scenarios": {
+    "North VMC": {
+      "approach_airspace": [
+        "COS_APP"
+      ],
+      "departure_airspace": [
+        "COS_APP"
+      ],
+      "arrival_runways": [
+        {
+          "airport": "KCOS",
+          "runway": "35L"
+        },
+        {
+          "airport": "KCOS",
+          "runway": "35R"
+        }
+      ],
+      "arrivals": {
+        "DEBERRY5": {
+          "KCOS": 6
+        },
+        "OZZZY5": {
+          "KCOS": 8
+        },
+        "DEN": {
+          "KCOS": 2
+        },
+        "DEN.NW": {
+          "KCOS": 2
+        },
+        "PUB": {
+          "KCOS": 2
+        }
+      },
+      "solo_controller": "COS_APP",
+      "controllers": [
+        "COS_W_TWR",
+        "COS_E_TWR",
+        "COS_APP",
+        "DEN_A_APP",
+        "DEN_29_CTR",
+        "PUB_APP"
+      ],
+      "default_maps": [ "COS NORTH" ],
+      "departure_runways": [
+        {
+          "airport": "KCOS",
+          "rate": 10,
+          "runway": "35R"
+        },
+        {
+          "airport": "KCOS",
+          "rate": 10,
+          "runway": "35L"
+        }
+      ],
+      "wind": {
+        "direction": 300,
+        "gust": 0,
+        "speed": 15
+      }
+    },
+    "South VMC": {
+      "approach_airspace": [
+        "COS_APP"
+      ],
+      "departure_airspace": [
+        "COS_APP"
+      ],
+      "arrival_runways": [
+        {
+          "airport": "KCOS",
+          "runway": "17L"
+        },
+        {
+          "airport": "KCOS",
+          "runway": "17R"
+        }
+      ],
+      "arrivals": {
+        "DEBERRY5": {
+          "KCOS": 6
+        },
+        "OZZZY5": {
+          "KCOS": 8
+        },
+        "DEN": {
+          "KCOS": 2
+        },
+        "DEN.NW": {
+          "KCOS": 2
+        },
+        "PUB": {
+          "KCOS": 2
+        }
+      },
+      "solo_controller": "COS_APP",
+      "controllers": [
+        "COS_W_TWR",
+        "COS_E_TWR",
+        "COS_APP",
+        "DEN_A_APP",
+        "DEN_29_CTR",
+        "PUB_APP"
+      ],
+      "default_maps": [ "COS SOUTH" ],
+      "departure_runways": [
+        {
+          "airport": "KCOS",
+          "rate": 10,
+          "runway": "17R"
+        },
+        {
+          "airport": "KCOS",
+          "rate": 10,
+          "runway": "17L"
+        }
+      ],
+      "wind": {
+        "direction": 170,
+        "gust": 5,
+        "speed": 10
+      }
+    }
+  },
+  "stars_config": {
+  "center": "N038.47.36.733,W104.35.10.501",
+  "inhibit_ca_volumes": [
+    {
+        "name": "COS NO CA",
+        "type": "circle",
+        "floor": 0,
+        "ceiling": 9500,
+        "radius": 10,
+        "center": "N038.47.52.142,W104.42.03.065"
+    }
+  ],
+  "radar_sites": {
+    "COS": {
+      "char": "A",
+      "position": "N038.47.36.733,W104.35.10.501",
+      "elevation": 6075,
+      "primary_range": 60,
+      "secondary_range": 120,
+      "silence_angle": 30,
+      "slope_angle": 0.3
+    }
+  },
+  "range": 30,
+  "scratchpads": {
+    "LUFSE": "LUF",
+    "BYEBI": "APA",
+    "DRAKE": "DRA",
+    "JEWLS": "JEW",
+    "PUB": "PUB",
+    "BRK": "BRK",
+    "HBU": "HBU",
+    "LAA": "LAA",
+    "BRESH": "BSH",
+    "ALS": "ALS",
+    "DVV": "DVV",
+    "FQF": "FQF"
+  },
+  "stars_maps": [
+    {
+      "group": 0,
+      "label": "NORTH",
+      "name": "COS NORTH"
+    },
+    {
+        "group": 0,
+        "label": "SOUTH",
+        "name": "COS SOUTH"
+    },
+    {
+        "group": 1,
+        "label": "MVA",
+        "name": "COS MVA"
+    },
+    {
+        "group": 0,
+        "label": "ODO",
+        "name": "COS ODO"
+    },
+    {
+        "group": 1,
+        "label": "EOVM",
+        "name": "COS EOVM"
+    },
+    {
+        "group": 0,
+        "label": "AFF RTE",
+        "name": "COS AFF RTE"
+    },
+    {
+        "group": 0,
+        "label": "AFF TFR",
+        "name": "COS AFF TFR"
+    },
+    {
+        "group": 1,
+        "label": "CLASS C",
+        "name": "COS CLASS C"
+    },
+    {
+        "group": 0,
+        "label": "DEN FIX",
+        "name": "COS DEN FIX"
+    },
+    {
+        "group": 1,
+        "label": "DME ARC",
+        "name": "COS DME ARC"
+    },
+    {
+        "group": 1,
+        "label": "GPS",
+        "name": "COS GPS"
+    },
+    {
+        "group": 0,
+        "label": "MID",
+        "name": "COS MID"
+    },
+    {
+        "group": 0,
+        "label": "RNP N",
+        "name": "COS RNPZ N"
+    },
+    {
+        "group": 0,
+        "label": "RNP S",
+        "name": "COS RNPZ S"
+    },
+    {
+        "group": 0,
+        "label": "RNV STAR",
+        "name": "COS RNV STR"
+    },
+    {
+      "group": 0,
+      "label": "STDMS",
+      "name": "COS STDMS"
+    },
+    {
+      "group": 0,
+      "label": "TOWER",
+      "name": "COS TOWER"
+    },
+    {
+      "group": 0,
+      "label": "VR",
+      "name": "COS VR"
+    },
+    {
+      "group": 0,
+      "label": "Z 17L",
+      "name": "COS Z 17L"
+    },
+    {
+      "group": 0,
+      "label": "Z 17R",
+      "name": "COS Z 17R"
+    },
+    {
+      "group": 0,
+      "label": "Z 35L",
+      "name": "COS Z 35L"
+    },
+    {
+      "group": 0,
+      "label": "Z 35L",
+      "name": "COS Z 35R"
+    }
+  ],
+  "video_map_file": "videomaps/ZDV-videomaps.json.zst"
+  }
+}

--- a/resources/scenarios/d01 revised.json
+++ b/resources/scenarios/d01 revised.json
@@ -1,0 +1,3540 @@
+{
+  "tracon": "D01",
+  "airports": {
+    "KDEN": {
+      "approaches": {
+        "I7": {
+          "runway": "7",
+          "tower_controller": "DEN_W_TWR",
+          "type": "ILS",
+          "waypoints": [
+            "SARAH/a9000 ASURE/a8000 TAILR/a7000 SUNKE/a5740"
+          ]
+        },
+	"R7": {
+          "runway": "7",
+          "tower_controller": "DEN_W_TWR",
+          "type": "RNAV",
+          "waypoints": [
+            "HAITR/a11000/s210 DWLLT/arc8.5 MNCHH TAILR/faf",
+	    "BBOOK/a11000/s210 BEEKY/arc9.1 TAILR/faf",
+	    "SARAH/a9000 TAILR/faf"
+          ]
+        },
+        "I8": {
+          "runway": "8",
+          "tower_controller": "DEN_E_TWR",
+          "type": "ILS",
+          "waypoints": [
+            "LIPPS/a10000 OWNER/a7000"
+          ]
+        },
+        "I6L": {
+          "runway": "16L",
+          "tower_controller": "DEN_N_TWR",
+          "type": "ILS",
+          "waypoints": [
+            "JEEPR/a10000 JOBOB/a10000 KUURT/a9000 KIKME/a8000 LEETS/a7000 LUWEE/a5820",
+            "KIPPR/a12000/s210 HAYLY JAPEE JDIZL JEEPR JEEPR/a10000 JOBOB/a10000 KUURT/a9000 KIKME/a8000 LEETS/a7000 LUWEE/a5820",
+            "TSHNR/a13000/s210 JAPEE JDIZL JEEPR JEEPR/a10000 JOBOB/a10000 KUURT/a9000 KIKME/a8000 LEETS/a7000 LUWEE/a5820",
+            "KAILE/a11000/s210 BJETN BJETN/a10000/s210 JEEPR JEEPR/a10000 JOBOB/a10000 KUURT/a9000 KIKME/a8000 LEETS/a7000 LUWEE/a5820"
+          ]
+        },
+        "I6R": {
+          "runway": "16R",
+          "tower_controller": "DEN_N_TWR",
+          "type": "ILS",
+          "waypoints": [
+            "SHRED/a10000 SAKIC/a10000 NEWLN/a9000 MERYN/a8000 JETSN/a7000",
+            "KIPPR/a12000/s210 HAYLY SKIMJ SEEYU SHRED/a10000 SAKIC/a10000 NEWLN/a9000 MERYN/a8000 JETSN/a7000",
+            "TSHNR/a13000/s210 SKIMJ SEEYU SHRED/a10000 SAKIC/a10000 NEWLN/a9000 MERYN/a8000 JETSN/a7000",
+            "KAILE/a11000/s210 SHROM SHRED/a10000 SAKIC/a10000 NEWLN/a9000 MERYN/a8000 JETSN/a7000"
+          ]
+        },
+	"R6R": {
+          "runway": "16R",
+          "tower_controller": "DEN_N_TWR",
+          "type": "RNAV",
+          "waypoints": [
+            "CLFFF/a11000 HELBY/arc9.8 APASE",
+            "KIPPR/a12000/s210 HAYLY PECIY BUDUJ ZOREG HAROS/s210 APASE",
+            "TSHNR/a13000/s210 PECIY BUDUJ ZOREG HAROS/s210 APASE",
+            "KAILE/a11000/s210 OGINE ZOREG HAROS/s210 APASE"
+          ]
+        },
+        "I7L": {
+          "runway": "17L",
+          "tower_controller": "DEN_E_TWR",
+          "type": "ILS",
+          "waypoints": [
+            "GWENS/a9000 GRIFS/a9000 HALTR/a9000 HHOLT/a8000 IRINE/a7000",
+            "TSHNR/a13000/s210 KLING GAPPY GIRTH GOLFN GWENS/a9000 GRIFS/a9000 HALTR/a9000 HHOLT/a8000 IRINE/a7000",
+            "KIPPR/a12000/s210 GAPPY GIRTH GOLFN GWENS/a9000 GRIFS/a9000 HALTR/a9000 HHOLT/a8000 IRINE/a7000",
+            "WAHUU/a9000/s210 GOLFN GWENS/a9000 GRIFS/a9000 HALTR/a9000 HHOLT/a8000 IRINE/a7000",
+            "KAILE/a11000/s210 OVVAL GWENS/a9000 GRIFS/a9000 HALTR/a9000 HHOLT/a8000 IRINE/a7000"
+          ]
+        },
+        "I7R": {
+          "runway": "17R",
+          "tower_controller": "DEN_C_TWR",
+          "type": "ILS",
+          "waypoints": [
+            "HOOPE/a11000 JAPEX/a9600 JOMAG/a9000 JOSEE/a8000 JOULE/a7000",
+            "KIPPR/a12000/s210 TARIE HALDO HEETT HISSY/a12000 HOOPE/a11000 JAPEX/a9600 JOMAG/a9000 JOSEE/a8000 JOULE/a7000",
+            "TSHNR/a13000/s210 KLING HALDO HEETT HISSY/a12000 HOOPE/a11000 JAPEX/a9600 JOMAG/a9000 JOSEE/a8000 JOULE/a7000",
+            "KAILE/a11000/s210 OVVAL HOOPE/a11000 JAPEX/a9600 JOMAG/a9000 JOSEE/a8000 JOULE/a7000"
+          ]
+        },
+	"R7R": {
+          "runway": "17R",
+          "tower_controller": "DEN_C_TWR",
+          "type": "RNAV",
+          "waypoints": [
+            "HOOPE JNKBX JOULE",
+            "QWIKE/a11000/s210 STAAM/arc4.3 DAVTE PAYOG/arc4.3 JNKBX JOULE"
+          ]
+        },
+        "I25": {
+          "runway": "25",
+          "tower_controller": "DEN_W_TWR",
+          "type": "ILS",
+          "waypoints": [
+            "ETHAL/a10000 GASTI/a7000"
+          ]
+        },
+        "I26": {
+          "runway": "26",
+          "tower_controller": "DEN_E_TWR",
+          "type": "ILS",
+          "waypoints": [
+            "FUZZZ/a9000 GRASP/a7000 FEETS/a5820"
+          ]
+        },
+	"R26": {
+          "runway": "26",
+          "tower_controller": "DEN_E_TWR",
+          "type": "RNAV",
+          "waypoints": [
+            "FUZZZ JPBAG GRASP",
+	    "JIBAT/a11000/s210 HOTDG/arc8.8 JPBAG GRASP",
+	    "CAPTJ/a11000/s210 BCALN/arc8.7 JPBAG GRASP"
+          ]
+        },
+        "I4L": {
+          "runway": "34L",
+          "tower_controller": "DEN_N_TWR",
+          "type": "ILS",
+          "waypoints": [
+            "KALHR/a10000 MERKL/a10000 RNOLD/a9000 WINTR/a7000 WOGIN/a6040",
+            "BOSSS/a12000/s210 PAAAS AJAKS COGGG/a10000 KALHR/a10000 MERKL/a10000 RNOLD/a9000 WINTR/a7000 WOGIN/a6040",
+            "LDORA/a13000/s210 FLUFF AJAKS COGGG/a10000 KALHR/a10000 MERKL/a10000 RNOLD/a9000 WINTR/a7000 WOGIN/a6040",
+            "TELLR/a11000/s210 ALPNE COGGG/a10000 KALHR/a10000 MERKL/a10000 RNOLD/a9000 WINTR/a7000 WOGIN/a6040"
+          ]
+        },
+        "I4R": {
+          "runway": "34R",
+          "tower_controller": "DEN_N_TWR",
+          "type": "ILS",
+          "waypoints": [
+            "BFREE/a10000 BOOBU/a10000 BENGL/a10000 BOENG/a9000 CORDE/a7000",
+            "BOSSS/a12000/s210 PAAAS BREKK BFREE/a10000 BOOBU/a10000 BENGL/a10000 BOENG/a9000 CORDE/a7000",
+            "LDORA/a13000/s210 FLUFF BREKK BFREE/a10000 BOOBU/a10000 BENGL/a10000 BOENG/a9000 CORDE/a7000",
+            "TELLR/a11000/s210 BHAPY BFREE/a10000 BOOBU/a10000 BENGL/a10000 BOENG/a9000 CORDE/a7000"
+          ]
+        },
+	"R4R": {
+          "runway": "34R",
+          "tower_controller": "DEN_N_TWR",
+          "type": "RNAV",
+          "waypoints": [
+            "HIMOM/a11000/s210 MCMUL/arc4.3 KUGLN/arc4.6 BSAYN CORDE",
+            "BOOBU BENGL BOENG BSAYN CORDE"
+          ]
+        },
+        "I5L": {
+          "runway": "35L",
+          "tower_controller": "DEN_C_TWR",
+          "type": "ILS",
+          "waypoints": [
+            "CRUUP/a11000 CHOLA/a10000 CELBI/a9000 DYMON/a7000 DAPGE/a6120",
+            "BOSSS/a12000/s210 EPICC CPPER CHAPP/a12000 CRUUP/a11000 CHOLA/a10000 CELBI/a9000 DYMON/a7000 DAPGE/a6120",
+            "LDORA/a13000/s210 KARVE CPPER CHAPP/a12000 CRUUP/a11000 CHOLA/a10000 CELBI/a9000 DYMON/a7000 DAPGE/a6120",
+            "TELLR/a11000/s210 VAIIL CRUUP/a11000 CHOLA/a10000 CELBI/a9000 DYMON/a7000 DAPGE/a6120"
+          ]
+        },
+        "I5R": {
+          "runway": "35R",
+          "tower_controller": "DEN_E_TWR",
+          "type": "ILS",
+          "waypoints": [
+            "DORRY/a9000 DEANE/a9000 DRUMM/a9000 FRONZ/a7000 NOEEE/a6120",
+            "LDORA/a13000/s210 DASHY DRATS DITSE DORRY/a9000 DEANE/a9000 DRUMM/a9000 FRONZ/a7000 NOEEE/a6120",
+            "BOSSS/a12000/s210 DRATS DITSE DORRY/a9000 DEANE/a9000 DRUMM/a9000 FRONZ/a7000 NOEEE/a6120",
+            "TELLR/a11000/s210 VAIIL DORRY/a9000 DEANE/a9000 DRUMM/a9000 FRONZ/a7000 NOEEE/a6120",
+            "PURRL/a9000/s210 DOVVE DORRY/a9000 DEANE/a9000 DRUMM/a9000 FRONZ/a7000 NOEEE/a6120"
+          ]
+        },
+	"R5R": {
+          "runway": "35R",
+          "tower_controller": "DEN_E_TWR",
+          "type": "RNAV",
+          "waypoints": [
+            "DORRY DEANE DRUMM FRONZ",
+	    "DOGGG/a11000/s210 MSIMS/arc10.2 FRONZ"
+          ]
+        }
+      },
+      "departure_routes": {
+        "8": {
+          "TEHRU,HBU": {
+            "cleared_altitude": 23000,
+            "sid": "BAYLR6",
+            "waypoints": "_DEN_26/h083"
+          },
+          "CHUWY": {
+            "cleared_altitude": 23000,
+            "sid": "CHUWY1",
+            "waypoints": "ROYYL/a10000- TURBN CHICN/a14000+ VELAA/a16000+ YOKES/a17000+ LNGWD"
+          },
+          "WERNR,CONNR": {
+            "cleared_altitude": 23000,
+            "sid": "CONNR7",
+            "waypoints": "_DEN_26/h083"
+          },
+          "VOAXA": {
+            "cleared_altitude": 23000,
+            "sid": "COORZ6",
+            "waypoints": "_DEN_26/h083"
+          },
+          "DDRTH": {
+            "cleared_altitude": 23000,
+            "sid": "DDRTH1",
+            "waypoints": "ROYYL/a10000- TURBN CHICN/a14000+ FAARM/a16000+ YAMMI/a17000+"
+          },
+          "EEONS,WYNDM": {
+            "cleared_altitude": 23000,
+            "sid": "EEONS8",
+            "waypoints": "ROYYL/a10000- SHOBO/a12000- LUPTN/a14000+ MRENE EEONS"
+          },
+          "EMMYS,ZIRKL": {
+            "cleared_altitude": 23000,
+            "sid": "EMMYS8",
+            "waypoints": "TIGHT/a10000- HAAHN/a12000- GASSS/a14000+ SNIPR EMMYS"
+          },
+          "GAETR,DUUZE": {
+            "cleared_altitude": 23000,
+            "sid": "EPKEE7",
+            "waypoints": "KIDNG/a10000- PIDLE APUUU/a14000+ EPKEE/a15000+ POIZN"
+          },
+          "SHAYK,EXTAN": {
+            "cleared_altitude": 23000,
+            "sid": "EXTAN7",
+            "waypoints": "KIDNG/a10000- KMBEL BHIGH MMESA/a14000+ FALUJ EXTAN"
+          },
+          "JOBBA,SAABR": {
+            "cleared_altitude": 23000,
+            "sid": "HHOTH2",
+            "waypoints": "ROYYL/a10000- TURBN CHICN/a14000+ KKIMM/a16000+ BRYCC/a17000+ HHOTH"
+          },
+          "JOPLN,VRONI": {
+            "cleared_altitude": 23000,
+            "sid": "SABTH2",
+            "waypoints": "KIDNG/a10000- TWWIN FIGTR/a14000+ PACMN/a16000+ SHOJO/a18000+ SABTH"
+          },
+          "SLEEK": {
+            "cleared_altitude": 23000,
+            "sid": "SLEEK2",
+            "waypoints": "KIDNG/a10000- TWWIN FIGTR/a14000+ SEGAH/a16000+ BCORP/a17000+ STAKR/a18000+ AZARO"
+          },
+          "DAAYE,RAITT": {
+            "cleared_altitude": 23000,
+            "sid": "SMMUR2",
+            "waypoints": "KIDNG/a10000- TWWIN FIGTR/a14000+ WEPON/a16000+ SOLAR/a17000+ SMMUR"
+          },
+          "SUDDZ": {
+            "cleared_altitude": 23000,
+            "sid": "SUDDZ1",
+            "waypoints": "KIDNG/a10000- TWWIN FIGTR/a14000+ HANGR/a16000+ SCAGS/a18000+ FRNKE/a23000+"
+          },
+          "XXWNG1": {
+            "cleared_altitude": 23000,
+            "sid": "XXWNG1",
+            "waypoints": "ROYYL/a10000- TURBN CHICN/a14000+ FAARM/a16000+ RIKKK/a17000+"
+          },
+          "CHNGY": {
+            "cleared_altitude": 23000,
+            "sid": "ZIMMR3",
+            "waypoints": "_DEN_26/h83"  
+          }
+        },
+        "17L": {
+          "TEHRU,HBU": {
+            "cleared_altitude": 23000,
+            "sid": "BAYLR6",
+            "waypoints": "GOROC BRKEM/a10000- WAKIR/a11000+ TUULO/a14000+ HLTON MTSUI/a16000+ BAYLR/a17000+ BOBBA"
+          },
+          "CHUWY": {
+            "cleared_altitude": 23000,
+            "sid": "CHUWY1",
+            "waypoints": "_DEN_35R/h173"
+          },
+          "WERNR,CONNR": {
+            "cleared_altitude": 23000,
+            "sid": "CONNR7",
+            "waypoints": "FOAMS/a10000- TAVRN/a12000+ VONNN/a14000+ TEEBO/a16000+ CONNR/a17000+ WERNR"
+          },
+          "VOAXA": {
+            "cleared_altitude": 23000,
+            "sid": "COORZ6",
+            "waypoints": "FOAMS/a10000- IPALE/a12000+ MOLSN/a14000+ BULLT/a16000+ COORZ/a17000+"
+          },
+          "DDRTH": {
+            "cleared_altitude": 23000,
+            "sid": "DDRTH1",
+            "waypoints": "_DEN_35R/h173"
+          },
+          "EEONS,WYNDM": {
+            "cleared_altitude": 23000,
+            "sid": "EEONS8",
+            "waypoints": "GISTT/a7000+ KIDNG/a10000- KAYGG LUPTN/a14000+ MRENE EEONS"
+          },
+          "EMMYS,ZIRKL": {
+            "cleared_altitude": 23000,
+            "sid": "EMMYS8",
+            "waypoints": "GISTT/a7000+ KIDNG/a10000- TWEDT GASSS/a14000+ SNIPR EMMYS"
+          },
+          "GAETR,DUUZE": {
+            "cleared_altitude": 23000,
+            "sid": "EPKEE7",
+            "waypoints": "GISTT/a7000+ MLHOS/a10000- SMTHR/a11000 SMPSN APUUU/a14000+ EPKEE/a15000+ POIZN"
+          },
+          "SHAYK,EXTAN": {
+            "cleared_altitude": 23000,
+            "sid": "EXTAN7",
+            "waypoints": "GISTT/a7000+ BGONE/a10000- OLDDD MMESA/a14000+ FALUJ EXTAN"
+          },
+          "JOBBA,SAABR": {
+            "cleared_altitude": 23000,
+            "sid": "HHOTH2",
+            "waypoints": "_DEN_35R/h173"
+          },
+          "JOPLN,VRONI": {
+            "cleared_altitude": 23000,
+            "sid": "SABTH2",
+            "waypoints": "RAYDR/a10000- JSMNN/a17000+ SHOJO/a18000+ SABTH"
+          },
+          "SLEEK": {
+            "cleared_altitude": 23000,
+            "sid": "SLEEK2",
+            "waypoints": "RAYDR/a10000- BCORP/a17000+ STAKR/a18000+ AZARO"
+          },
+          "DAAYE,RAITT": {
+            "cleared_altitude": 23000,
+            "sid": "SMMUR2",
+            "waypoints": "RAYDR/a10000- SIGHT/a10000+ SOLAR/a17000+ SMMUR"
+          },
+          "SUDDZ": {
+            "cleared_altitude": 23000,
+            "sid": "SUDDZ1",
+            "waypoints": "RAYDR/a10000- CHOZN/a12000 FLYYR/a16000 SCAGS/a18000+ FRNKE/a23000+"
+          },
+          "XXWNG1": {
+            "cleared_altitude": 23000,
+            "sid": "XXWNG1",
+            "waypoints": "_DEN_35R/h173"
+          },
+          "CHNGY": {
+            "cleared_altitude": 23000,
+            "sid": "ZIMMR3",
+            "waypoints": "MUGBE/a10000- RALFI/a12000+ RAPDS/a14000+ PCKNS/a16000+ ZIMMR/a17000+"
+          }
+        },
+        "25": {
+          "TEHRU,HBU": {
+            "cleared_altitude": 23000,
+            "sid": "BAYLR6",
+            "waypoints": "BRKEM/a10000- WAKIR/a11000+ TUULO/a14000+ HLTON MTSUI/a16000+ BAYLR/a17000+ BOBBA"
+          },
+          "CHUWY": {
+            "cleared_altitude": 23000,
+            "sid": "CHUWY1",
+            "waypoints": "MUGBE/a10000- WAZEE LODOE/a12000+ RINKR/a14000+ ELCEE/a16000+ YOKES/a17000+ LNGWD"
+          },
+          "WERNR,CONNR": {
+            "cleared_altitude": 23000,
+            "sid": "CONNR7",
+            "waypoints": "FOAMS/a10000- TAVRN/a12000+ VONNN/a14000+ TEEBO/a16000+ CONNR/a17000+ WERNR"
+          },
+          "VOAXA": {
+            "cleared_altitude": 23000,
+            "sid": "COORZ6",
+            "waypoints": "FOAMS/a10000- IPALE/a12000+ MOLSN/a14000+ BULLT/a16000+ COORZ/a17000+"
+          },
+          "DDRTH": {
+            "cleared_altitude": 23000,
+            "sid": "DDRTH1",
+            "waypoints": "MUGBE/a10000- WAZEE LODOE/a12000+ RINKR/a14000+ HERDR/a16000+ TROTO YAMMI/a17000+"
+          },
+          "EEONS,WYNDM": {
+            "cleared_altitude": 23000,
+            "sid": "EEONS8",
+            "waypoints": "_DEN_7/h263"
+          },
+          "EMMYS,ZIRKL": {
+            "cleared_altitude": 23000,
+            "sid": "EMMYS8",
+            "waypoints": "_DEN_7/h263"
+          },
+          "GAETR,DUUZE": {
+            "cleared_altitude": 23000,
+            "sid": "EPKEE7",
+            "waypoints": "_DEN_7/h263"
+          },
+          "SHAYK,EXTAN": {
+            "cleared_altitude": 23000,
+            "sid": "EXTAN7",
+            "waypoints": "_DEN_7/h263"
+          },
+          "JOBBA,SAABR": {
+            "cleared_altitude": 23000,
+            "sid": "HHOTH2",
+            "waypoints": "MUGBE/a10000- WAZEE LODOE/a12000+ RINKR/a14000+ TAGKO/a16000+ BRYCC/a17000+ HHOTH"
+          },
+          "JOPLN,VRONI": {
+            "cleared_altitude": 23000,
+            "sid": "SABTH2",
+            "waypoints": "BRKEM/a10000- LENNN/a10000+ TIKLR CIROS/a14000+ ICECI/a16000+ SHOJO/a18000+ SABTH"
+          },
+          "SLEEK": {
+            "cleared_altitude": 23000,
+            "sid": "SLEEK2",
+            "waypoints": "BRKEM/a10000- LENNN/a10000+ TIKLR CIROS/a14000+ WEPON/a16000 STAKR/a18000+ AZARO"
+          },
+          "DAAYE,RAITT": {
+            "cleared_altitude": 23000,
+            "sid": "SMMUR2",
+            "waypoints": "BRKEM/a10000- LENNN/a10000+ TIKLR CIROS/a14000+ RKYMT/a16000+ SOLAR/a17000+ SMMUR "
+          },
+          "SUDDZ": {
+            "cleared_altitude": 23000,
+            "sid": "SUDDZ1",
+            "waypoints": "BRKEM/a10000- LENNN/a11000 TIKLR CIROS/a16000 RKYMT/a18000 SCAGS/a21000 FRNKE"
+          },
+          "XXWNG1": {
+            "cleared_altitude": 23000,
+            "sid": "XXWNG1",
+            "waypoints": "MUGBE/a10000- WAZEE LODOE/a13000 RINKR/a15000 HERDR/a17000 RIKKK/a17000+"
+          },
+          "CHNGY": {
+            "cleared_altitude": 23000,
+            "sid": "ZIMMR3",
+            "waypoints": "MUGBE/a10000- RALFI/a12000+ RAPDS/a14000+ PCKNS/a16000+ ZIMMR/a17000+"  
+          }
+        },
+        "34L": {
+          "TEHRU,HBU": {
+            "cleared_altitude": 23000,
+            "sid": "BAYLR6",
+            "waypoints": "BRKEM/a10000- WAKIR/a11000+ TUULO/a14000+ HLTON MTSUI/a16000+ BAYLR/a17000+ BOBBA"
+          },
+          "CHUWY": {
+            "cleared_altitude": 23000,
+            "sid": "CHUWY1",
+            "waypoints": "NKATA/a10000- YOKES/a17000+ LNGWD"
+          },
+          "WERNR,CONNR": {
+            "cleared_altitude": 23000,
+            "sid": "CONNR7",
+            "waypoints": "FOAMS/a10000- TAVRN/a12000+ VONNN/a14000+ TEEBO/a16000+ CONNR/a17000+ WERNR"
+          },
+          "VOAXA": {
+            "cleared_altitude": 23000,
+            "sid": "COORZ6",
+            "waypoints": "FOAMS/a10000- IPALE/a12000+ MOLSN/a14000+ BULLT/a16000+ COORZ/a17000+"
+          },
+          "DDRTH": {
+            "cleared_altitude": 23000,
+            "sid": "DDRTH1",
+            "waypoints": "NKATA/a10000- KAYOO/a11000- YAMMI/a17000+"
+          },
+          "EEONS,WYNDM": {
+            "cleared_altitude": 23000,
+            "sid": "EEONS8",
+            "waypoints": "NUGGS HIDEF/a10000- SHOBO/a12000- LUPTN/a14000+ MRENE EEONS"
+          },
+          "EMMYS,ZIRKL": {
+            "cleared_altitude": 23000,
+            "sid": "EMMYS8",
+            "waypoints": "NUGGS HIDEF/a10000- BRSTO/a12000- GASSS/a14000+ SNIPR EMMYS"
+          },
+          "GAETR,DUUZE": {
+            "cleared_altitude": 23000,
+            "sid": "EPKEE7",
+            "waypoints": "KIDNG/a10000- PIDLE APUUU/a14000+ EPKEE/a15000+ POIZN"
+          },
+          "SHAYK,EXTAN": {
+            "cleared_altitude": 23000,
+            "sid": "EXTAN7",
+            "waypoints": "KIDNG/a10000- KMBEL BHIGH MMESA/a14000+ FALUJ EXTAN"
+          },
+          "JOBBA,SAABR": {
+            "cleared_altitude": 23000,
+            "sid": "HHOTH2",
+            "waypoints": "NKATA/a10000- HAWKR CCLYD/a13000+ BRYCC/a17000+ HHOTH"
+          },
+          "JOPLN,VRONI": {
+            "cleared_altitude": 23000,
+            "sid": "SABTH2",
+            "waypoints": "_DEN_16R/h353"
+          },
+          "SLEEK": {
+            "cleared_altitude": 23000,
+            "sid": "SLEEK2",
+            "waypoints": "_DEN_16R/h353"
+          },
+          "DAAYE,RAITT": {
+            "cleared_altitude": 23000,
+            "sid": "SMMUR2",
+            "waypoints": "_DEN_16R/h353"
+          },
+          "SUDDZ": {
+            "cleared_altitude": 23000,
+            "sid": "SUDDZ1",
+            "waypoints": "_DEN_16R/h353"
+          },
+          "XXWNG1": {
+            "cleared_altitude": 23000,
+            "sid": "XXWNG1",
+            "waypoints": "NKATA/a10000- HAWKR BNITA/a13000+ RIKKK/a17000+"
+          },
+          "CHNGY": {
+            "cleared_altitude": 23000,
+            "sid": "ZIMMR3",
+            "waypoints": "MUGBE/a10000- RALFI/a12000+ RAPDS/a14000+ PCKNS/a16000+ ZIMMR/a17000+"
+          }
+        },
+        "34R": {
+          "TEHRU,HBU": {
+            "cleared_altitude": 23000,
+            "sid": "BAYLR6",
+            "waypoints": "BRKEM/a10000- WAKIR/a11000+ TUULO/a14000+ HLTON MTSUI/a16000+ BAYLR/a17000+ BOBBA"
+          },
+          "CHUWY": {
+            "cleared_altitude": 23000,
+            "sid": "CHUWY1",
+            "waypoints": "NKATA/a10000- YOKES/a17000+ LNGWD"
+          },
+          "WERNR,CONNR": {
+            "cleared_altitude": 23000,
+            "sid": "CONNR7",
+            "waypoints": "FOAMS/a10000- TAVRN/a12000+ VONNN/a14000+ TEEBO/a16000+ CONNR/a17000+ WERNR"
+          },
+          "VOAXA": {
+            "cleared_altitude": 23000,
+            "sid": "COORZ6",
+            "waypoints": "FOAMS/a10000- IPALE/a12000+ MOLSN/a14000+ BULLT/a16000+ COORZ/a17000+"
+          },
+          "DDRTH": {
+            "cleared_altitude": 23000,
+            "sid": "DDRTH1",
+            "waypoints": "NKATA/a10000- KAYOO/a11000- YAMMI/a17000+"
+          },
+          "EEONS,WYNDM": {
+            "cleared_altitude": 23000,
+            "sid": "EEONS8",
+            "waypoints": "NUGGS HIDEF/a10000- SHOBO/a12000- LUPTN/a14000+ MRENE EEONS"
+          },
+          "EMMYS,ZIRKL": {
+            "cleared_altitude": 23000,
+            "sid": "EMMYS8",
+            "waypoints": "NUGGS HIDEF/a10000- BRSTO/a12000- GASSS/a14000+ SNIPR EMMYS"
+          },
+          "GAETR,DUUZE": {
+            "cleared_altitude": 23000,
+            "sid": "EPKEE7",
+            "waypoints": "KIDNG/a10000- PIDLE APUUU/a14000+ EPKEE/a15000+ POIZN"
+          },
+          "SHAYK,EXTAN": {
+            "cleared_altitude": 23000,
+            "sid": "EXTAN7",
+            "waypoints": "KIDNG/a10000- KMBEL BHIGH MMESA/a14000+ FALUJ EXTAN"
+          },
+          "JOBBA,SAABR": {
+            "cleared_altitude": 23000,
+            "sid": "HHOTH2",
+            "waypoints": "NKATA/a10000- HAWKR CCLYD/a13000+ BRYCC/a17000+ HHOTH"
+          },
+          "JOPLN,VRONI": {
+            "cleared_altitude": 23000,
+            "sid": "SABTH2",
+            "waypoints": "_DEN_16L/h353"
+          },
+          "SLEEK": {
+            "cleared_altitude": 23000,
+            "sid": "SLEEK2",
+            "waypoints": "_DEN_16L/h353"
+          },
+          "DAAYE,RAITT": {
+            "cleared_altitude": 23000,
+            "sid": "SMMUR2",
+            "waypoints": "_DEN_16L/h353"
+          },
+          "SUDDZ": {
+            "cleared_altitude": 23000,
+            "sid": "SUDDZ1",
+            "waypoints": "_DEN_16L/h353"
+          },
+          "XXWNG1": {
+            "cleared_altitude": 23000,
+            "sid": "XXWNG1",
+            "waypoints": "NKATA/a10000- HAWKR BNITA/a13000+ RIKKK/a17000+"
+          },
+          "CHNGY": {
+            "cleared_altitude": 23000,
+            "sid": "ZIMMR3",
+            "waypoints": "MUGBE/a10000- RALFI/a12000+ RAPDS/a14000+ PCKNS/a16000+ ZIMMR/a17000+"
+          }
+        },
+        "16L" : {
+          "TEHRU,HBU": {
+            "cleared_altitude": 23000,
+            "sid": "BAYLR6",
+            "waypoints": "GOROC BRKEM/a10000- WAKIR/a11000+ TUULO/a16000 HLTON MTSUI/a16000+ BAYLR/a17000+ BOBBA"
+          },
+          "CHUWY": {
+            "cleared_altitude": 23000,
+            "sid": "CHUWY1",
+            "waypoints": "_DEN_34R/h173"
+          },
+          "WERNR,CONNR": {
+            "cleared_altitude": 23000,
+            "sid": "CONNR7",
+            "waypoints": "FOAMS/a10000- TAVRN/a12000+ VONNN/a14000+ TEEBO/a16000+ CONNR/a17000+ WERNR"
+          },
+          "VOAXA": {
+            "cleared_altitude": 23000,
+            "sid": "COORZ6",
+            "waypoints": "FOAMS/a10000- IPALE/a12000+ MOLSN/a14000+ BULLT/a16000+ COORZ/a17000+"
+          },
+          "DDRTH": {
+            "cleared_altitude": 23000,
+            "sid": "DDRTH1",
+            "waypoints": "_DEN_34R/h173"
+          },
+          "EEONS,WYNDM": {
+            "cleared_altitude": 23000,
+            "sid": "EEONS8",
+            "waypoints": "GISTT/a7000+ KIDNG/a10000- KAYGG LUPTN/a14000+ MRENE EEONS"
+          },
+          "EMMYS,ZIRKL": {
+            "cleared_altitude": 23000,
+            "sid": "EMMYS8",
+            "waypoints": "GISTT/a7000+ KIDNG/a10000- TWEDT GASSS/a14000+ SNIPR EMMYS"
+          },
+          "GAETR,DUUZE": {
+            "cleared_altitude": 23000,
+            "sid": "EPKEE7",
+            "waypoints": "GISTT/a7000+ MLHOS/a10000- SMTHR/a12000- SMPSN APUUU/a14000+ EPKEE/a15000+ POIZN"
+          },
+          "SHAYK,EXTAN": {
+            "cleared_altitude": 23000,
+            "sid": "EXTAN7",
+            "waypoints": "GISTT/a7000+ BGONE/a10000- OLDDD MMESA/a14000+ FALUJ EXTAN"
+          },
+          "JOBBA,SAABR": {
+            "cleared_altitude": 23000,
+            "sid": "HHOTH2",
+            "waypoints": "_DEN_34R/h173"
+          },
+          "JOPLN,VRONI": {
+            "cleared_altitude": 23000,
+            "sid": "SABTH2",
+            "waypoints": "BOGEI/a10000- SHOJO/a18000+ SABTH"
+          },
+          "SLEEK": {
+            "cleared_altitude": 23000,
+            "sid": "SLEEK2",
+            "waypoints": "BOGEI/a10000- BCORP/a17000+ STAKR/a18000+ AZARO"
+          },
+          "DAAYE,RAITT": {
+            "cleared_altitude": 23000,
+            "sid": "SMMUR2",
+            "waypoints": "BOGEI/a10000- SIGHT/a10000+ SOLAR/a17000+ SMMUR"
+          },
+          "SUDDZ": {
+            "cleared_altitude": 23000,
+            "sid": "SUDDZ1",
+            "waypoints": "BOGEI/a10000- CHOZN/a12000 FLYYR/a14000 CONRD/a19000 SCAGS/a21000 FRNKE/a23000"
+          },
+          "XXWNG": {
+            "cleared_altitude": 23000,
+            "sid": "XXWNG1",
+            "waypoints": "_DEN_34R/h173"
+          },
+          "CHNGY": {
+            "cleared_altitude": 23000,
+            "sid": "ZIMMR3",
+            "waypoints": "MUGBE/a10000- RALFI/a12000+ RAPDS/a14000+ PCKNS/a16000+ ZIMMR/a17000+"
+          }
+        }
+        },
+        "departures": [
+          {
+            "airlines": [
+              {
+                "icao": "SWA"
+              }
+            ],
+            "altitude": 37000,
+            "destination": "KALB",
+            "exit": "CHUWY",
+            "route": "CHUWY ONL VIO DKK ALB"
+          },
+          {
+            "airlines": [
+              {
+                "icao": "SWA"
+              },
+              {
+                "fleet": "short",
+                "icao": "UAL"
+              },
+              {
+                "fleet": "short",
+                "icao": "AAL"
+              },
+              {
+                "icao": "FFT"
+              }
+            ],
+            "altitude": 38000,
+            "destination": "KPHX",
+            "exit": "DAAYE",
+            "route": "DAAYE GUP EAGUL6"
+          },
+          {
+            "airlines": [
+              {
+                "icao": "SWA"
+              },
+              {
+                "fleet": "short",
+                "icao": "UAL"
+              },
+              {
+                "icao": "FFT"
+              }
+            ],
+            "altitude": 40000,
+            "destination": "KLAS",
+            "exit": "WERNR",
+            "route": "WERNR ZAKRY GGAPP CHOWW2"
+          },
+          {
+            "airlines": [
+              {
+                "icao": "SKW"
+              },
+              {
+                "fleet": "short",
+                "icao": "UAL"
+              },
+              {
+                "fleet": "short",
+                "icao": "DAL"
+              }
+            ],
+            "altitude": 38000,
+            "destination": "KSLC",
+            "exit": "CHNGY",
+            "route": "CHNGY EKR LEEHY5"
+          },
+          {
+            "airlines": [
+              {
+                "icao": "FFT"
+              },
+              {
+                "icao": "SCX"
+              },
+              {
+                "fleet": "short",
+                "icao": "UAL"
+              }
+            ],
+            "altitude": 37000,
+            "destination": "KMSP",
+            "exit": "CHUWY",
+            "route": "CHUWY SSWAN TORGY3"
+          },
+          {
+            "airlines": [
+              {
+                "icao": "SWA"
+              },
+              {
+                "fleet": "short",
+                "icao": "UAL"
+              },
+              {
+                "fleet": "short",
+                "icao": "DAL"
+              },
+              {
+                "icao": "SKW"
+              }
+            ],
+            "altitude": 38000,
+            "destination": "KLAX",
+            "exit": "TEHRU",
+            "route": "TEHRU JASSE Q90 DNERO ANJLL4"
+          },
+          {
+            "airlines": [
+              {
+                "icao": "SWA"
+              },
+              {
+                "icao": "ASA"
+              },
+              {
+                "icao": "FFT"
+              },
+              {
+                "fleet": "short",
+                "icao": "UAL"
+              },
+              {
+                "fleet": "short",
+                "icao": "DAL"
+              }
+            ],
+            "altitude": 34000,
+            "destination": "KSEA",
+            "exit": "DDRTH",
+            "route": "DDRTH DBS PDT CHINS5"
+          },
+          {
+            "airlines": [
+              {
+                "icao": "ASH"
+              },
+              {
+                "fleet": "short",
+                "icao": "AAL"
+              },
+              {
+                "fleet": "short",
+                "icao": "UAL"
+              },
+              {
+                "icao": "FFT"
+              }
+            ],
+            "altitude": 33000,
+            "destination": "KDFW",
+            "exit": "SLEEK",
+            "route": "SLEEK EZEEE MDANO VKTRY2"
+          },
+          {
+            "airlines": [
+              {
+                "icao": "SWA"
+              },
+              {
+                "fleet": "short",
+                "icao": "UAL"
+              },
+              {
+                "fleet": "short",
+                "icao": "DAL"
+              }
+            ],
+            "altitude": 35000,
+            "destination": "KATL",
+            "exit": "SHAYK",
+            "route": "SHAYK SLN BUM FAM HITMN NEWBB IHAVE MTHEW CHPPR1"
+          },
+          {
+            "airlines": [
+              {
+                "icao": "SWA"
+              },
+              {
+                "icao": "FFT"
+              },
+              {
+                "fleet": "short",
+                "icao": "UAL"
+              }
+            ],
+            "altitude": 40000,
+            "destination": "KSAN",
+            "exit": "TEHRU",
+            "route": "TEHRU PUNDL Q86 TTRUE LUCKI1"
+          },
+          {
+            "airlines": [
+              {
+                "icao": "SWA"
+              },
+              {
+                "icao": "FFT"
+              },
+              {
+                "fleet": "short",
+                "icao": "UAL"
+              }
+            ],
+            "altitude": 38000,
+            "destination": "KSFO",
+            "exit": "VOAXA",
+            "route": "VOAXA Q136  OAL INYOE DYAMD5"
+          },
+          {
+            "airlines": [
+              {
+                "icao": "SWA"
+              },
+              {
+                "icao": "JBU"
+              },
+              {
+                "fleet": "short",
+                "icao": "DAL"
+              },
+              {
+                "fleet": "short",
+                "icao": "UAL"
+              }
+            ],
+            "altitude": 37000,
+            "destination": "KLGA",
+            "exit": "ZIRKL",
+            "route": "ZIRKL MCK LNK J60 DJB YNG ETG MIP4"
+          },
+          {
+            "airlines": [
+              {
+                "icao": "SWA"
+              },
+              {
+                "icao": "SWA"
+              },
+              {
+                "fleet": "short",
+                "icao": "UAL"
+              }
+            ],
+            "altitude": 33000,
+            "destination": "KIAH",
+            "exit": "SLEEK",
+            "route": "SLEEK NOSEW MQP DRLLR5"
+          },
+          {
+            "airlines": [
+              {
+                "icao": "SWA"
+              },
+              {
+                "icao": "FFT"
+              },
+              {
+                "fleet": "short",
+                "icao": "UAL"
+              }
+            ],
+            "altitude": 38000,
+            "destination": "KPDX",
+            "exit": "DDRTH",
+            "route": "DDRTH DBS BEAMO JKNOX HHOOD4"
+          },
+          {
+            "airlines": [
+              {
+                "icao": "SWA"
+              },
+              {
+                "icao": "FFT"
+              },
+              {
+                "fleet": "short",
+                "icao": "UAL"
+              }
+            ],
+            "altitude": 35000,
+            "destination": "KSTL",
+            "exit": "SHAYK",
+            "route": "SHAYK SLN BUM KAYLA3"
+          }
+        ],
+        "exit_categories": {
+          "HBU": "WEST",
+          "TEHRU": "WEST",
+          "CHUWY": "NORTH",
+          "CONNR": "WEST",
+          "WERNR": "WEST",
+          "VOAXA": "WEST",
+          "DDRTH": "NORTH",
+          "EEONS": "EAST",
+          "WYNDM": "EAST",
+          "EMMYS": "EAST",
+          "ZIRKL": "EAST",
+          "GAETR": "EAST",
+          "DUUZE": "EAST",
+          "SHAYK": "EAST",
+          "EXTAN": "EAST",
+          "JOBBA": "NORTH",
+          "SAABR": "NORTH",
+          "JOPLN": "SOUTH",
+          "VRONI": "SOUTH",
+          "SLEEK": "SOUTH",
+          "DAAYE": "SOUTH",
+          "RAITT": "SOUTH",
+          "SUDDZ": "SOUTH",
+          "XXWNG": "NORTH",
+          "CHNGY": "WEST"
+        },
+        "tower_list": 4
+      }
+    },
+    "arrival_groups": {
+      "AALLE3": [
+        {
+          "airlines": {
+            "KDEN": [
+              {
+                "airport": "KMSP",
+                "icao": "SCX"
+              },
+              {
+                "airport": "KMSP",
+                "fleet": "short",
+                "icao": "DAL"
+              },
+              {
+                "airport": "KMSP",
+                "icao": "FFT"
+              },
+              {
+                "airport": "KMSP",
+                "icao": "SWA"
+              },
+              {
+                "airport": "KORD",
+                "fleet": "short",
+                "icao": "AAL"
+              },
+              {
+                "airport": "KMDW",
+                "icao": "SWA"
+              },
+              {
+                "airport": "KORD",
+                "fleet": "short",
+                "icao": "UAL"
+              },
+              {
+                "airport": "KDSM",
+                "icao": "FFT"
+              },
+              {
+                "airport": "KDTW",
+                "fleet": "short",
+                "icao": "DAL"
+              },
+              {
+                "airport": "KMKE",
+                "icao": "FFT"
+              },
+              {
+                "airport": "KMKE",
+                "fleet": "short",
+                "icao": "UAL"
+              }
+            ]
+          },
+          "cruise_altitude": 36000,
+          "initial_altitude": 20000,
+          "initial_controller": "DEN_17_CTR",
+          "initial_speed": 290,
+          "star": "AALLE3",
+          "runway_waypoints": {
+            "KDEN": {
+                "7": "HEDDD/a18000 DEELO/a16000 JEPHF/a14000/s250 HAZLT HAITR/a11000/s210/h263",
+                "8": "HEDDD/a18000 DEELO/a16000 JEPHF/a14000/s250 HAZLT HAITR/a11000/s210/h263",
+                "16L": "HEDDD/a18000 HIGUN/a14000/s210 KIPPR/a12000/s210/h265",
+                "16R": "HEDDD/a18000 HIGUN/a14000/s210 KIPPR/a12000/s210/h265",
+                "17L": "HEDDD/a18000 HIGUN/a14000/s210 KIPPR/a12000/s210/h265",
+                "17R": "HEDDD/a18000 HIGUN/a14000/s210 KIPPR/a12000/s210/h265",
+                "25": "HEDDD/a18000 CRUNK/a14000/h222",
+                "26": "HEDDD/a18000 CRUNK/a14000/h222",
+                "34L": "HEDDD/a18000 DEELO/a16000 JEPHF/a14000/s250 HAZLT GRILA HIMOM/a11000/s210/h173",
+                "34R": "HEDDD/a18000 DEELO/a16000 JEPHF/a14000/s250 HAZLT GRILA HIMOM/a11000/s210/h173",
+                "35L": "HEDDD/a18000 DEELO/a16000 FULLA/a14000/s250 FFFAT DOGGG/a11000/s210/h173",
+		"35R": "HEDDD/a18000 DEELO/a16000 FULLA/a14000/s250 FFFAT DOGGG/a11000/s210/h173"
+            }
+          },
+          "speed_restriction": 250,
+          "waypoints": "AALLE/a19000/ho HEDDD/a18000"
+        }
+      ],
+      "CLASH4": [
+        {
+          "airlines" : {
+            "KDEN": [
+              {
+                "airport": "KMCO",
+                "fleet": "short",
+                "icao": "UAL"
+              },
+              {
+                "airport": "KMCO",
+                "icao": "SWA"
+              },
+              {
+                "airport": "KMCO",
+                "icao": "FFT"
+              },
+              {
+                "airport": "KMIA",
+                "fleet": "short",
+                "icao": "AAL"
+              },
+              {
+                "airport": "KMIA",
+                "icao": "FFT"
+              },
+              {
+                "airport": "KMIA",
+                "icao": "NKS"
+              },
+              {
+                "airport": "KIAH",
+                "fleet": "short",
+                "icao": "UAL"
+              },
+              {
+                "airport": "KHOU",
+                "icao": "SWA"
+              },
+              {
+                "airport": "KDFW",
+                "icao": "JIA"
+              },
+              {
+                "airport": "KDFW",
+                "fleet": "short",
+                "icao": "AAL"
+              },
+              {
+                "airport": "KDFW",
+                "fleet": "short",
+                "icao": "UAL"
+              },
+              {
+                "airport": "KDFW",
+                "icao": "FFT"
+              },
+              {
+                "airport": "KDAL",
+                "icao": "SWA"
+              },
+              {
+                "airport": "KSAT",
+                "icao": "SWA"
+              },
+              {
+                "airport": "KAUS",
+                "icao": "SWA"
+              },
+              {
+                "airport": "KATL",
+                "fleet": "short",
+                "icao": "UAL"
+              },
+              {
+                "airport": "KATL",
+                "fleet": "short",
+                "icao": "DAL"
+              },
+              {
+                "airport": "KATL",
+                "icao": "FFT"
+              }
+            ]
+          },
+          "cruise_altitude": 36000,
+          "initial_altitude": 20000,
+          "initial_controller": "DEN_17_CTR",
+          "initial_speed": 290,
+          "star": "CLASH4",
+          "runway_waypoints": {
+            "KDEN": {
+                "7": "EVRLY/a18000/s250 JURKY/a16000 ROOTZ/a14000/s250 RPIDS BBOOK/a11000/s210/h263",
+                "8": "EVRLY/a18000/s250 JURKY/a16000 ROOTZ/a14000/s250 RPIDS BBOOK/a11000/s210/h263",
+                "16R": "EVRLY/a18000/s250 JURKY/a16000 ROOTZ/a14000/s250 RPIDS RDDVL CLFFF/a11000/s210/h353",
+                "16L" :"EVRLY/a18000/s250 JURKY/a16000 JAAAM/a14000/s250 HUDPI QWIKE/a11000/s210/h353",
+                "17L" :"EVRLY/a18000/s250 JURKY/a16000 JAAAM/a14000/s250 HUDPI QWIKE/a11000/s210/h353",
+                "17R" :"EVRLY/a18000/s250 JURKY/a16000 JAAAM/a14000/s250 HUDPI QWIKE/a11000/s210/h353",
+                "25": "EVRLY/a18000/s250 ERVNN/a14000 FIDLS/a13000/s210/h351",
+                "26": "EVRLY/a18000/s250 ERVNN/a14000 FIDLS/a13000/s210/h351",
+                "34L": "EVRLY/a18000/s250 RECRD/a15000 TWNSN/a13000/s210 PNBAL/a11000 ROCCS/a10000 EBBLR/a9000/s210/h260",
+                "34R": "EVRLY/a18000/s250 RECRD/a15000 TWNSN/a13000/s210 PNBAL/a11000 ROCCS/a10000 EBBLR/a9000/s210/h260",
+                "35L": "EVRLY/a18000/s250 RECRD/a15000 TWNSN/a13000/s210 PNBAL/a11000 ROCCS/a10000 PURRL/a9000/s210/h298",
+                "35R": "EVRLY/a18000/s250 RECRD/a15000 TWNSN/a13000/s210 PNBAL/a11000 ROCCS/a10000 PURRL/a9000/s210/h298"
+            }
+          },
+          "speed_restriction": 250,
+          "waypoints": "CLASH/a19000/ho EVRLY/a18000"
+        }
+      ],
+      "FLATI3": [
+        {
+          "airlines": {
+            "KDEN": [
+              {
+                "airport": "KSLC",
+                "fleet": "short",
+                "icao": "DAL"
+              },
+              {
+                "airport": "KSLC",
+                "icao": "FFT"
+              },
+              {
+                "airport": "KBOI",
+                "icao": "SKW"
+              },
+              {
+                "airport": "KSEA",
+                "fleet": "short",
+                "icao": "DAL"
+              },
+              {
+                "airport": "KSEA",
+                "icao": "ASA"
+              },
+              {
+                "airport": "KPDX",
+                "icao": "FFT"
+              },
+              {
+                "airport": "KPDX",
+                "icao": "ASA"
+              },
+              {
+                "airport": "KPDX",
+                "fleet": "short",
+                "icao": "UAL"
+              },
+              {
+                "airport": "CYVR",
+                "fleet": "short",
+                "icao": "ACA"
+              },
+              {
+                "airport": "RJAA",
+                "icao" : "ANA"
+              },
+              {
+                "airport": "RJAA",
+                "icao" : "JAL"
+              },
+              {
+                "airport": "RJAA",
+                "fleet": "long",
+                "icao": "UAL"
+              },
+              {
+                "airport": "VHHH",
+                "icao": "CPA"
+              } 
+            ]
+          },
+          "cruise_altitude": 35000,
+          "initial_altitude": 21000,
+          "initial_controller": "DEN_17_CTR",
+          "initial_speed": 290,
+          "star": "FLATI3",
+          "runway_waypoints": {
+            "KDEN": {
+                "7": "ELLDO/a18000/s250 MLVVA/a14000/h132",
+                "8": "ELLDO/a18000/s250 MLVVA/a14000/h132",
+                "16L": "ELLDO/a18000/s250 BSAFE/a15000 BDUNN/a14000/s210 TSHNR/a13000/s210/h099",
+                "16R": "ELLDO/a18000/s250 BSAFE/a15000 BDUNN/a14000/s210 TSHNR/a13000/s210/h099",
+                "17L": "ELLDO/a18000/s250 BSAFE/a15000 BDUNN/a14000/s210 TSHNR/a13000/s210/h099",
+                "17R": "ELLDO/a18000/s250 BSAFE/a15000 BDUNN/a14000/s210 TSHNR/a13000/s210/h099",
+                "25": "ELLDO/a18000/s250 TOTTT/a16000 YESSS SKEWD/a14000/s250 LEKEE/a12000 XCUTV CAPTJ/a11000/s210/h083",
+                "26": "ELLDO/a18000/s250 TOTTT/a16000 YESSS SKEWD/a14000/s250 LEKEE/a12000 XCUTV CAPTJ/a11000/s210/h083",
+                "34L": "ELLDO/a18000/s250 TOTTT/a16000 BAACK/a15000 BABAA/a13000/s250 HIMOM/a11000/s210/h173",
+                "34R": "ELLDO/a18000/s250 TOTTT/a16000 BAACK/a15000 BABAA/a13000/s250 HIMOM/a11000/s210/h173",
+                "35L": "ELLDO/a18000/s250 TOTTT/a16000 BAACK/a15000 BABAA/a13000/s250 HIMOM/a11000/s210/h173",
+                "35R": "ELLDO/a18000/s250 TOTTT/a16000 YESSS SKEWD/a14000/s250 LEKEE/a13000 XCUTV FFFAT DOGGG/a11000/s210/h173"
+            }
+          },
+          "speed_restriction": 250,
+          "waypoints": "FLATI/a21000/ho ELLDO/a18000/s250"
+        }
+      ],
+      "LAWGR3": [
+        {
+          "airlines": {
+            "KDEN": [
+                {
+                  "airport": "KDSM",
+                  "icao": "SKW"
+                },
+                {
+                  "airport": "KDTW",
+                  "fleet": "short",
+                  "icao": "DAL"
+                },
+                {
+                  "airport": "KDTW",
+                  "fleet": "short",
+                  "icao": "UAL"
+                },
+                {
+                  "airport": "KCLE",
+                  "icao": "FFT"
+                },
+                {
+                  "airport": "KCLE",
+                  "fleet": "short",
+                  "icao": "UAL"
+                },
+                {
+                  "airport": "KALB",
+                  "icao": "FFT"
+                },
+                {
+                  "airport": "KLGA",
+                  "fleet": "short",
+                  "icao": "DAL"
+                },
+                {
+                  "airport": "KLGA",
+                  "icao": "FFT"
+                },
+                {
+                  "airport": "KJFK",
+                  "icao": "JBU"
+                },
+                {
+                  "airport": "KJFK",
+                  "fleet": "short",
+                  "icao": "AAL"
+                },
+                {
+                  "airport": "KJFK",
+                  "fleet": "short",
+                  "icao": "DAL"
+                },
+                {
+                  "airport": "KEWR",
+                  "fleet": "short",
+                  "icao": "UAL"
+                },
+                {
+                  "airport": "KBOS",
+                  "icao": "JBU"
+                },
+                {
+                  "airport": "KBOS",
+                  "fleet": "short",
+                  "icao": "UAL"
+                },
+                {
+                  "airport": "KDCA",
+                  "fleet": "short",
+                  "icao": "AAL"
+                },
+                {
+                  "airport": "KIAD",
+                  "fleet": "short",
+                  "icao": "UAL"
+                },
+                {
+                  "airport": "KBWI",
+                  "icao": "SWA"
+                },
+                {
+                  "airport": "KPHL",
+                  "icao": "FFT"
+                },
+                {
+                  "airport": "KPHL",
+                  "fleet": "short",
+                  "icao": "AAL"
+                }
+            ]
+          },
+          "cruise_altitude": 35000,
+          "initial_altitude": 21000,
+          "initial_controller": "DEN_17_CTR",
+          "initial_speed": 290,
+          "star": "LAWGR3",
+          "runway_waypoints": {
+            "KDEN": {
+                "7": "PPINT/a18000/s250 BURRP/a16000 JEPHF/a14000/s250 HAZLT HAITR/a11000/s210/h263",
+                "8": "PPINT/a18000/s250 BURRP/a16000 JEPHF/a14000/s250 HAZLT HAITR/a11000/s210/h263",
+                "16L": "PPINT/a18000/s250 TAPME/a13000/s230 GRRUB/a11000/s210/h265",
+                "16R": "PPINT/a18000/s250 TAPME/a13000/s230 GRRUB/a11000/s210/h265",
+                "17L": "PPINT/a18000/s250 TAPME/a13000/s230 GRRUB/a11000/s210/h265",
+                "17R": "PPINT/a18000/s250 TAPME/a13000/s230 GRRUB/a11000/s210/h265",
+                "25": "PPINT/a18000/s250 JIBBA/a13000 RODEY/a13000/s210/h172",
+                "26": "PPINT/a18000/s250 JIBBA/a13000 RODEY/a13000/s210/h172",
+                "34L": "PPINT/a18000/s250 BURRP/a16000 JEPHF/a14000/s250 HAZLT GRILA HIMOM/a11000/s210/h173",
+                "34R": "PPINT/a18000/s250 BURRP/a16000 JEPHF/a14000/s250 HAZLT GRILA HIMOM/a11000/s210/h173",
+                "35L": "PPINT/a18000/s250 BURRP/a16000 YUPEE/a14000/s250 FFFAT DOGGG/a11000/s210/h173",
+                "35R": "PPINT/a18000/s250 BURRP/a16000 YUPEE/a14000/s250 FFFAT DOGGG/a11000/s210/h173"
+            }
+          },
+          "speed_restriction": 250,
+          "waypoints": "LAWGR/a21000/ho PPINT/a18000/s250"
+        }
+      ],
+      "LONGZ2": [
+        {
+          "airlines": {
+            "KDEN": [
+              {
+                "airport": "KSLC",
+                "fleet": "short",
+                "icao": "DAL"
+              },
+              {
+                "airport": "PANC",
+                "icao" :"FDX"
+              },
+              {
+                "airport": "KLAS",
+                "icao": "FFT"
+              },
+              {
+                "airport": "KLAS",
+                "icao": "SWA"
+              },
+              {
+                "airport": "KLAS",
+                "fleet": "short",
+                "icao":"UAL"
+              },
+              {
+                "airport": "KSFO",
+                "icao": "FFT"
+              },
+              {
+                "airport": "KSFO",
+                "fleet": "short",
+                "icao": "UAL"
+              },
+              {
+                "airport": "KSJC",
+                "icao": "SWA"
+              },
+              {
+                "airport": "KOAK",
+                "icao": "FFT"
+              }
+            ]
+          },
+          "cruise_altitude": 35000,
+          "initial_altitude": 21000,
+          "initial_controller": "DEN_17_CTR",
+          "initial_speed": 290,
+          "star": "LONGZ2",
+          "runway_waypoints": {
+            "KDEN": {
+                "7": "FLNEL/a18000/s250 DORKE/a16000 BASHE/a13000/s210/h170",
+                "8": "FLNEL/a18000/s250 DORKE/a16000 BASHE/a13000/s210/h170",
+                "16L": "FLNEL/a18000/s250 BEOND/a13000/s210 SWAYN/a12000 KAILE/a11000/s210/h092",
+                "16R": "FLNEL/a18000/s250 BEOND/a13000/s210 SWAYN/a12000 KAILE/a11000/s210/h092", 
+                "17L": "FLNEL/a18000/s250 BEOND/a13000/s210 SWAYN/a12000 KAILE/a11000/s210/h092",
+                "17R": "FLNEL/a18000/s250 BEOND/a13000/s210 SWAYN/a12000 KAILE/a11000/s210/h092",
+                "25": "FLNEL/a18000/s250 HLMUT SKEWD/a14000/s250 LEKEE/a12000 XCUTV CAPTJ/a11000/s210/h083",
+                "26": "FLNEL/a18000/s250 HLMUT SKEWD/a14000/s250 LEKEE/a12000 XCUTV CAPTJ/a11000/s210/h083",
+                "34L": "FLNEL/a18000/s250 HLMUT ARCHY/a14000 BABAA/a12000/s250 HIMOM/a11000/s210/h173",
+                "34R": "FLNEL/a18000/s250 HLMUT ARCHY/a14000 BABAA/a12000/s250 HIMOM/a11000/s210/h173",
+                "35L": "FLNEL/a18000/s250 HLMUT ARCHY/a14000 BABAA/a12000/s250 HIMOM/a11000/s210/h173",
+                "35R": "FLNEL/a18000/s250 HLMUT SKEWD/a14000 LEKEE/a12000 XCUTV FFFAT DOGGG/a11000/s210/h173"
+            }
+          },
+          "speed_restriction": 250,
+          "waypoints": "LONGZ/a21000/ho FLNEL/a18000/s250"
+        }
+      ],
+      "NIIXX3": [
+        {
+          "airlines": {
+            "KDEN": [
+              {
+                "airport": "KDFW",
+                "fleet": "short",
+                "icao": "AAL"
+              },
+             {
+              "airport": "KTPA",
+              "icao": "SWA"
+             },
+             {
+              "airport": "KTPA",
+              "fleet": "short",
+              "icao": "UAL"
+             },
+             {
+              "airport": "KJAX",
+              "fleet": "short",
+              "icao": "UAL"
+             },
+             {
+              "airport": "KCLT",
+              "fleet": "short",
+              "icao": "AAL"
+             },
+             {
+              "airport": "KCLT",
+              "fleet": "short",
+              "icao": "UAL"
+             },
+             {
+              "airport": "KRDU",
+              "fleet": "short",
+              "icao": "UAL"
+             },
+             {
+              "airport": "KBNA",
+              "icao": "SWA"
+             },
+             {
+              "airport": "KBNA",
+              "fleet": "short",
+              "icao": "UAL"
+             },
+             {
+              "airport": "KCVG",
+              "fleet": "short",
+              "icao": "DAL"
+             },
+             {
+              "airport": "KIND",
+              "fleet": "short",
+              "icao": "UAL"
+             }
+            ]
+          },
+          "cruise_altitude": 35000,
+          "initial_altitude": 21000,
+          "initial_controller": "DEN_17_CTR",
+          "initial_speed": 290,
+          "star": "NIIXX3",
+          "runway_waypoints": {
+            "KDEN": {
+                "7": "HAGGR/a18000 JPAGE/a16000 ROOTZ/a14000/s250 RPIDS BBOOK/a11000/s210/h263",
+                "8": "HAGGR/a18000 JPAGE/a16000 ROOTZ/a14000/s250 RPIDS BBOOK/a11000/s210/h263",
+                "16L": "HAGGR/a18000 JPAGE/a16000 JAAAM/a14000/s250 HUDPI QWIKE/a11000/s210/h353",
+                "16R": "HAGGR/a18000 JPAGE/a16000 ROOTZ/a14000/s250 RPIDS RDDVL CLFFF/a11000/s210/h353",
+                "17L": "HAGGR/a18000 JPAGE/a16000 JAAAM/a14000/s250 HUDPI QWIKE/a11000/s210/h353",
+                "17R": "HAGGR/a18000 JPAGE/a16000 JAAAM/a14000/s250 HUDPI QWIKE/a11000/s210/h353",
+                "25": "HAGGR/a18000 GEILS/a14000/h317",
+                "26": "HAGGR/a18000 GEILS/a14000/h317",
+                "34L": "HAGGR/a18000 BSTON/a14000/s230 BOSSS/a12000/s210/h273",
+                "34R": "HAGGR/a18000 BSTON/a14000/s230 BOSSS/a12000/s210/h273",
+                "35L": "HAGGR/a18000 BSTON/a14000/s230 BOSSS/a12000/s210/h273",
+                "35R": "HAGGR/a18000 BSTON/a14000/s230 BOSSS/a12000/s210/h273"
+            }
+          },
+          "speed_restriction": 250,
+          "waypoints": "NIIXX/a21000/ho HAGGR/a18000/s250"
+        }
+      ],
+      "SSKII3": [
+        {
+          "airlines": {
+            "KDEN": [
+              {
+                "airport": "KLAX",
+                "fleet": "short",
+                "icao": "DAL"
+              },
+              {
+                "airport": "KLAX",
+                "icao": "JBU"
+              },
+              {
+                "airport": "KLAX",
+                "fleet": "short",
+                "icao": "UAL"
+              },
+              {
+                "airport": "KLAX",
+                "fleet": "short",
+                "icao": "AAL"
+              },
+              {
+                "airport": "KLGB",
+                "icao": "SWA"
+              },
+              {
+                "airport": "KSNA",
+                "icao": "SWA"
+              },
+              {
+                "airport": "PHNL",
+                "icao": "SWA"
+              },
+              {
+                "airport": "PHNL",
+                "fleet": "short",
+                "icao": "UAL"
+              },
+              {
+                "airport": "KSAN",
+                "fleet": "short",
+                "icao": "UAL"
+              },
+              {
+                "airport": "KSAN",
+                "icao": "SWA"
+              },
+              {
+                "airport": "KPHX",
+                "icao": "SWA"
+              },
+              {
+                "airport": "KPHX",
+                "fleet": "short",
+                "icao": "UAL"
+              },
+              {
+                "airport": "KPHX",
+                "fleet": "short",
+                "icao": "DAL"
+              }
+            ]
+          },
+          "cruise_altitude": 35000,
+          "initial_altitude": 21000,
+          "initial_controller": "DEN_17_CTR",
+          "initial_speed": 290,
+          "star": "SSKII3",
+          "runway_waypoints": {
+            "KDEN": {
+                "7": "BGDEE/a19000/s250 POWPW/a14000 BRNNO/a13000/s210/h352",
+                "8": "BGDEE/a19000/s250 POWPW/a14000 BRNNO/a13000/s210/h352",
+                "16L": "BGDEE/a19000/s250 TLRID/a16000 EPPIC/a14000/s240 RDDVL CLFFF/a11000/s210/h353",
+                "16R": "BGDEE/a19000/s250 TLRID/a16000 EPPIC/a14000/s240 RDDVL CLFFF/a11000/s210/h353",
+                "17L": "BGDEE/a19000/s250 TLRID/a16000 ZATUT/a14000/s240 LOOOP HUDPI QWIKE/a11000/s210/h353",
+                "17R": "BGDEE/a19000/s250 TLRID/a16000 ZATUT/a14000/s240 LOOOP HUDPI QWIKE/a11000/s210/h353",
+                "25": "BGDEE/a19000/s250 TLRID/a16000 ZATUT/a14000/s240 LOOOP JIBAT/a11000/s210/h082",
+                "26": "BGDEE/a19000/s250 TLRID/a16000 ZATUT/a14000/s240 LOOOP JIBAT/a11000/s210/h082",
+                "34L": "BGDEE/a19000/s250 CRAGG/a13000/s210 NARLE/a12000 TELLR/a11000/s210/h075",
+                "34R": "BGDEE/a19000/s250 CRAGG/a13000/s210 NARLE/a12000 TELLR/a11000/s210/h075",
+                "35L": "BGDEE/a19000/s250 CRAGG/a13000/s210 NARLE/a12000 TELLR/a11000/s210/h075",
+                "35R": "BGDEE/a19000/s250 CRAGG/a13000/s210 NARLE/a12000 TELLR/a11000/s210/h075"
+            }
+          },
+          "speed_restriction": 250,
+          "waypoints": "SSKII/a21000/ho BGDEE/a19000/s250"
+        }
+      ],
+      "TBARR3": [
+        {
+          "airlines": {
+            "KDEN": [
+              {
+                "airport": "KLAX",
+                "fleet": "short",
+                "icao": "DAL"
+              },
+              {
+                "airport": "KLAX",
+                "icao": "JBU"
+              },
+              {
+                "airport": "KLAX",
+                "fleet": "short",
+                "icao": "UAL"
+              },
+              {
+                "airport": "KLAX",
+                "fleet": "short",
+                "icao": "AAL"
+              },
+              {
+                "airport": "KLGB",
+                "icao": "SWA"
+              },
+              {
+                "airport": "KSNA",
+                "icao": "SWA"
+              },
+              {
+                "airport": "PHNL",
+                "icao": "SWA"
+              },
+              {
+                "airport": "PHNL",
+                "fleet": "short",
+                "icao": "UAL"
+              },
+              {
+                "airport": "KSAN",
+                "fleet": "short",
+                "icao": "UAL"
+              },
+              {
+                "airport": "KSAN",
+                "icao": "SWA"
+              },
+              {
+                "airport": "KPHX",
+                "icao": "SWA"
+              },
+              {
+                "airport": "KPHX",
+                "fleet": "short",
+                "icao": "UAL"
+              },
+              {
+                "airport": "KPHX",
+                "fleet": "short",
+                "icao": "DAL"
+              }
+            ]
+          },
+          "cruise_altitude": 35000,
+          "initial_altitude": 21000,
+          "initial_controller": "DEN_17_CTR",
+          "initial_speed": 290,
+          "star": "FLATI3",
+          "runway_waypoints": {
+            "KDEN": {
+              "7": "MNARK/a19000/s250 SUMTT/a14000/h033",
+              "8": "MNARK/a19000/s250 SUMTT/a14000/h033",
+              "16L": "MNARK/a19000/s250 EOLUS/a16000 EPPIC/a14000/s240 RDDVL CLFFF/a11000/s210/h353",
+              "16R": "MNARK/a19000/s250 EOLUS/a16000 EPPIC/a14000/s240 RDDVL CLFFF/a11000/s210/h353",
+              "17L": "MNARK/a19000/s250 EOLUS/a16000 ZATUT/a14000/s240 LOOOP HUDPI QWIKE/a11000/s210/h353",
+              "17R": "MNARK/a19000/s250 EOLUS/a16000 ZATUT/a14000/s240 LOOOP HUDPI QWIKE/a11000/s210/h353",
+              "25": "MNARK/a19000/s250 EOLUS/a16000 ZATUT/a14000/s240 LOOOP JIBAT/a11000/s210/h082",
+              "26": "MNARK/a19000/s250 EOLUS/a16000 ZATUT/a14000/s240 LOOOP JIBAT/a11000/s210/h082",
+              "34L": "MNARK/a19000/s250 BDIVN/a15000 KUSHH/a14000/s210 LDORA/a13000/s210/h064",
+              "34R": "MNARK/a19000/s250 BDIVN/a15000 KUSHH/a14000/s210 LDORA/a13000/s210/h064",
+              "35L": "MNARK/a19000/s250 BDIVN/a15000 KUSHH/a14000/s210 LDORA/a13000/s210/h064",
+              "35R": "MNARK/a19000/s250 BDIVN/a15000 KUSHH/a14000/s210 LDORA/a13000/s210/h064"
+            }
+          },
+          "speed_restriction": 250,
+          "waypoints": "TBARR/a21000/ho MNARK/a19000/s250"
+        }
+      ]
+    },
+    "control_positions": {
+      "DEN_17_CTR": {
+        "frequency": 127650,
+        "full_name": "Denver Center",
+        "scope_char": "C",
+        "sector_id": "D17",
+        "facility_id": "C",
+        "eram_facility": true
+      },
+      "DEN_I_APP": {
+        "frequency": 120350,
+        "full_name": "Denver Approach",
+        "scope_char": "I",
+        "sector_id": "1I"
+      },
+      "DEN_H_APP": {
+        "frequency": 119300,
+        "full_name": "Denver Approach",
+        "scope_char": "H",
+        "sector_id": "1H"
+      },
+      "DEN_G_APP": {
+        "frequency": 124950,
+        "full_name": "Denver Approach",
+        "scope_char": "G",
+        "sector_id": "1G"
+      },
+      "DEN_X_APP": {
+        "frequency": 126550,
+        "full_name": "Denver Approach",
+        "scope_char": "X",
+        "sector_id": "1X"
+      },
+      "DEN_W_APP": {
+        "frequency": 123850,
+        "full_name": "Denver Approach",
+        "scope_char": "W",
+        "sector_id": "1W"
+      },
+      "DEN_E_APP": {
+        "frequency": 120800,
+        "full_name": "Denver Approach",
+        "scope_char": "E",
+        "sector_id": "1E"
+      },
+      "DEN_O_APP": {
+        "frequency": 125750,
+        "full_name": "Denver Approach",
+        "scope_char": "O",
+        "sector_id": "1O"
+      },
+      "DEN_T_APP": {
+        "frequency": 133620,
+        "full_name": "Denver Approach",
+        "scope_char": "T",
+        "sector_id": "1T"
+      },
+      "DEN_L_DEP": {
+        "frequency": 126100,
+        "full_name": "Denver Departure",
+        "scope_char": "L",
+        "sector_id": "1L"
+      },
+      "DEN_N_DEP": {
+        "frequency": 127050,
+        "full_name": "Denver Departure",
+        "scope_char": "N",
+        "sector_id": "1N"
+      },
+      "DEN_R_DEP": {
+        "frequency": 128250,
+        "full_name": "Denver Departure",
+        "scope_char": "R",
+        "sector_id": "1R"
+      },
+      "DEN_S_DEP": {
+        "frequency": 128450,
+        "full_name": "Denver Departure",
+        "scope_char": "S",
+        "sector_id": "1S"
+      },
+      "DEN_E_TWR": {
+        "frequency": 132350,
+        "full_name": "Denver Tower",
+        "scope_char": "T",
+        "sector_id": "1ET"
+      },
+      "DEN_W_TWR": {
+        "frequency": 128750,
+        "full_name": "Denver Tower",
+        "scope_char": "T",
+        "sector_id": "1WT"
+      },
+      "DEN_N_TWR": {
+        "frequency": 135300,
+        "full_name": "Denver Tower",
+        "scope_char": "T",
+        "sector_id": "1NT"
+      },
+      "DEN_C_TWR": {
+        "frequency": 123400,
+        "full_name": "Denver Tower",
+        "scope_char": "T",
+        "sector_id": "1CT"
+      },
+      "DEN_S_TWR": {
+        "frequency": 133300,
+        "full_name": "Denver Tower",
+        "scope_char": "T",
+        "sector_id": "1ST"
+      }
+    },
+    "default_scenario": "South Calm",
+    "fixes": {
+      "_DEN_7": "N39.50.27.450,W104.43.36.001",
+      "_DEN_8": "N39.52.39.283,W104.39.44.066",
+      "_DEN_16L": "N39.53.49.330,W104.41.12.444",
+      "_DEN_16R": "N39.53.44.845,W104.41.45.790",
+      "_DEN_17L": "N39.51.53.779,W104.38.28.488",
+      "_DEN_17R": "N39.51.40.447,W104.39.36.581",
+      "_DEN_25": "N39.50.26.345,W104.41.02.124",
+      "_DEN_26": "N39.52.38.162,W104.37.10.014",
+      "_DEN_34L": "N39.51.06.724,W104.41.47.766",
+      "_DEN_34R": "N39.51.50.786,W104.41.13.802",
+      "_DEN_35L": "N39.49.41.914,W104.39.38.005",
+      "_DEN_35R": "N39.49.55.270,W104.38.30.043",
+      "KDEN": "N39.51.41.421,W104.40.23.005",
+      "DEN": "N39.51.41.421,W104.40.23.005"
+    },
+    "name": "KDEN",
+   "primary_airport": "KDEN",
+    "scenarios": {
+      "South Calm": {
+        "arrival_runways": [
+          {
+            "airport": "KDEN",
+            "runway": "16L"
+          },
+          {
+            "airport": "KDEN",
+            "runway": "16R"
+          },
+          {
+            "airport": "KDEN",
+            "runway": "17R"
+          }
+        ],
+        "arrivals": {
+          "AALLE3": {
+            "KDEN": 10
+          },
+          "CLASH4": {
+            "KDEN": 10
+          },
+          "FLATI3": {
+            "KDEN": 10
+          },
+          "LAWGR3": {
+            "KDEN": 10
+          },
+          "LONGZ2": {
+            "KDEN": 10
+          },
+          "NIIXX3": {
+            "KDEN": 10
+          },
+          "SSKII3": {
+            "KDEN": 10
+          },
+          "TBARR3": {
+            "KDEN": 10
+          }
+        },
+        "solo_controller": "DEN_I_APP",
+        "multi_controllers": {
+            "default" : {
+                "DEN_I_APP": {
+                    "primary": true,
+                    "arrivals": ["SSKII3", "TBARR3"]
+                },
+                "DEN_H_APP": {
+                    "backup": "DEN_I_APP",
+                    "arrivals": ["FLATI3", "LONGZ2"]
+                },
+                "DEN_G_APP": {
+                    "backup": "DEN_H_APP",
+                    "arrivals": ["AALLE3", "LAWGR3"]
+                },
+                "DEN_X_APP": {
+                    "backup": "DEN_G_APP",
+                    "arrivals": ["NIIXX3", "CLASH4"]
+                },
+                "DEN_W_APP": {
+                    "backup": "DEN_I_APP"
+                },
+                "DEN_E_APP": {
+                    "backup": "DEN_W_APP"
+                },
+                "DEN_O_APP": {
+                    "backup": "DEN_E_APP"
+                },
+                "DEN_T_APP": {
+                    "backup": "DEN_O_APP"
+                },
+                "DEN_L_DEP": {
+                    "backup": "DEN_I_APP"
+                },
+                "DEN_N_DEP": {
+                    "backup": "DEN_L_DEP",
+                    "departures": ["KDEN"]
+                },
+                "DEN_R_DEP": {
+                    "backup": "DEN_N_DEP"
+                },
+                "DEN_S_DEP": {
+                    "backup": "DEN_R_DEP"
+                }
+            }
+        },
+        "controllers": [
+          "DEN_E_TWR",
+          "DEN_W_TWR",
+          "DEN_N_TWR",
+          "DEN_S_TWR",
+          "DEN_17_CTR"
+        ],
+        "default_maps": [ "D01 AR BASE" ],
+        "departure_runways": [
+          {
+            "airport": "KDEN",
+            "category": "EAST",
+            "rate": 15,
+            "runway": "8"
+          },
+          {
+            "airport": "KDEN",
+            "category": "NORTH",
+            "rate": 15,
+            "runway": "8"
+          },
+          {
+            "airport": "KDEN",
+            "category": "SOUTH",
+            "rate": 15,
+            "runway": "17L"
+          },
+          {
+            "airport": "KDEN",
+            "category": "WEST",
+            "rate": 15,
+            "runway": "25"
+          }
+        ],
+        "wind": {
+          "direction": 140,
+          "speed": 1
+        }
+      },
+      "North Calm": {
+        "arrival_runways": [
+          {
+            "airport": "KDEN",
+            "runway": "34R"
+          },
+          {
+            "airport": "KDEN",
+            "runway": "35L"
+          },
+          {
+            "airport": "KDEN",
+            "runway": "35R"
+          }
+        ],
+        "arrivals": {
+          "AALLE3": {
+            "KDEN": 10
+          },
+          "CLASH4": {
+            "KDEN": 10
+          },
+          "FLATI3": {
+            "KDEN": 10
+          },
+          "LAWGR3": {
+            "KDEN": 10
+          },
+          "LONGZ2": {
+            "KDEN": 10
+          },
+          "NIIXX3": {
+            "KDEN": 10
+          },
+          "SSKII3": {
+            "KDEN": 10
+          },
+          "TBARR3": {
+            "KDEN": 10
+          }
+        },
+        "solo_controller": "DEN_I_APP",
+        "multi_controllers": {
+            "default" : {
+                "DEN_I_APP": {
+                    "primary": true,
+                    "arrivals": ["SSKII3", "TBARR3"]
+                },
+                "DEN_H_APP": {
+                    "backup": "DEN_I_APP",
+                    "arrivals": ["FLATI3", "LONGZ2"]
+                },
+                "DEN_G_APP": {
+                    "backup": "DEN_H_APP",
+                    "arrivals": ["AALLE3", "LAWGR3"]
+                },
+                "DEN_X_APP": {
+                    "backup": "DEN_G_APP",
+                    "arrivals": ["NIIXX3", "CLASH4"]
+                },
+                "DEN_W_APP": {
+                    "backup": "DEN_I_APP"
+                },
+                "DEN_E_APP": {
+                    "backup": "DEN_W_APP"
+                },
+                "DEN_O_APP": {
+                    "backup": "DEN_E_APP"
+                },
+                "DEN_T_APP": {
+                    "backup": "DEN_O_APP"
+                },
+                "DEN_L_DEP": {
+                    "backup": "DEN_I_APP"
+                },
+                "DEN_N_DEP": {
+                    "backup": "DEN_L_DEP",
+                    "departures": ["KDEN"]
+                },
+                "DEN_R_DEP": {
+                    "backup": "DEN_N_DEP"
+                },
+                "DEN_S_DEP": {
+                    "backup": "DEN_R_DEP"
+                }
+            }
+        },
+        "controllers": [
+          "DEN_E_TWR",
+          "DEN_W_TWR",
+          "DEN_N_TWR",
+          "DEN_S_TWR",
+          "DEN_17_CTR"
+        ],
+        "default_maps": [ "D01 AR BASE" ],
+        "departure_runways": [
+          {
+            "airport": "KDEN",
+            "category": "EAST",
+            "rate": 15,
+            "runway": "8"
+          },
+          {
+            "airport": "KDEN",
+            "category": "NORTH",
+            "rate": 15,
+            "runway": "34L"
+          },
+          {
+            "airport": "KDEN",
+            "category": "SOUTH",
+            "rate": 15,
+            "runway": "25"
+          },
+          {
+            "airport": "KDEN",
+            "category": "WEST",
+            "rate": 15,
+            "runway": "25"
+          }
+        ],
+        "wind": {
+          "direction": 300,
+          "speed": 1
+        }
+      },
+      "South and East": {
+        "arrival_runways": [
+          {
+            "airport": "KDEN",
+            "runway": "7"
+          },
+          {
+            "airport": "KDEN",
+            "runway": "16R"
+          },
+          {
+            "airport": "KDEN",
+            "runway": "17R"
+          },
+          {
+            "airport": "KDEN",
+            "runway": "16L"
+          }
+        ],
+        "arrivals": {
+          "AALLE3": {
+            "KDEN": 10
+          },
+          "CLASH4": {
+            "KDEN": 10
+          },
+          "FLATI3": {
+            "KDEN": 10
+          },
+          "LAWGR3": {
+            "KDEN": 10
+          },
+          "LONGZ2": {
+            "KDEN": 10
+          },
+          "NIIXX3": {
+            "KDEN": 10
+          },
+          "SSKII3": {
+            "KDEN": 10
+          },
+          "TBARR3": {
+            "KDEN": 10
+          }
+        },
+        "solo_controller": "DEN_I_APP",
+        "multi_controllers": {
+            "default" : {
+                "DEN_I_APP": {
+                    "primary": true,
+                    "arrivals": ["SSKII3", "TBARR3"]
+                },
+                "DEN_H_APP": {
+                    "backup": "DEN_I_APP",
+                    "arrivals": ["FLATI3", "LONGZ2"]
+                },
+                "DEN_G_APP": {
+                    "backup": "DEN_H_APP",
+                    "arrivals": ["AALLE3", "LAWGR3"]
+                },
+                "DEN_X_APP": {
+                    "backup": "DEN_G_APP",
+                    "arrivals": ["NIIXX3", "CLASH4"]
+                },
+                "DEN_W_APP": {
+                    "backup": "DEN_I_APP"
+                },
+                "DEN_E_APP": {
+                    "backup": "DEN_W_APP"
+                },
+                "DEN_O_APP": {
+                    "backup": "DEN_E_APP"
+                },
+                "DEN_T_APP": {
+                    "backup": "DEN_O_APP"
+                },
+                "DEN_L_DEP": {
+                    "backup": "DEN_I_APP"
+                },
+                "DEN_N_DEP": {
+                    "backup": "DEN_L_DEP",
+                    "departures": ["KDEN"]
+                },
+                "DEN_R_DEP": {
+                    "backup": "DEN_N_DEP"
+                },
+                "DEN_S_DEP": {
+                    "backup": "DEN_R_DEP"
+                }
+            }
+        },
+        "controllers": [
+          "DEN_E_TWR",
+          "DEN_W_TWR",
+          "DEN_N_TWR",
+          "DEN_S_TWR",
+          "DEN_17_CTR"
+        ],
+        "default_maps": [ "D01 AR BASE" ],
+        "departure_runways": [
+          {
+            "airport": "KDEN",
+            "category": "EAST",
+            "rate": 15,
+            "runway": "8"
+          },
+          {
+            "airport": "KDEN",
+            "category": "NORTH",
+            "rate": 15,
+            "runway": "8"
+          },
+          {
+            "airport": "KDEN",
+            "category": "SOUTH",
+            "rate": 15,
+            "runway": "17L"
+          },
+          {
+            "airport": "KDEN",
+            "category": "WEST",
+            "rate": 15,
+            "runway": "17L"
+          }
+        ],
+        "wind": {
+          "direction": 140,
+          "speed": 15
+        }
+      },
+      "South and West": {
+        "arrival_runways": [
+          {
+            "airport": "KDEN",
+            "runway": "16L"
+          },
+          {
+            "airport": "KDEN",
+            "runway": "16R"
+          },
+          {
+            "airport": "KDEN",
+            "runway": "17R"
+          }
+        ],
+        "arrivals": {
+          "AALLE3": {
+            "KDEN": 10
+          },
+          "CLASH4": {
+            "KDEN": 10
+          },
+          "FLATI3": {
+            "KDEN": 10
+          },
+          "LAWGR3": {
+            "KDEN": 10
+          },
+          "LONGZ2": {
+            "KDEN": 10
+          },
+          "NIIXX3": {
+            "KDEN": 10
+          },
+          "SSKII3": {
+            "KDEN": 10
+          },
+          "TBARR3": {
+            "KDEN": 10
+          }
+        },
+        "solo_controller": "DEN_I_APP",
+        "multi_controllers": {
+            "default" : {
+                "DEN_I_APP": {
+                    "primary": true,
+                    "arrivals": ["SSKII3", "TBARR3"]
+                },
+                "DEN_H_APP": {
+                    "backup": "DEN_I_APP",
+                    "arrivals": ["FLATI3", "LONGZ2"]
+                },
+                "DEN_G_APP": {
+                    "backup": "DEN_H_APP",
+                    "arrivals": ["AALLE3", "LAWGR3"]
+                },
+                "DEN_X_APP": {
+                    "backup": "DEN_G_APP",
+                    "arrivals": ["NIIXX3", "CLASH4"]
+                },
+                "DEN_W_APP": {
+                    "backup": "DEN_I_APP"
+                },
+                "DEN_E_APP": {
+                    "backup": "DEN_W_APP"
+                },
+                "DEN_O_APP": {
+                    "backup": "DEN_E_APP"
+                },
+                "DEN_T_APP": {
+                    "backup": "DEN_O_APP"
+                },
+                "DEN_L_DEP": {
+                    "backup": "DEN_I_APP"
+                },
+                "DEN_N_DEP": {
+                    "backup": "DEN_L_DEP",
+                    "departures": ["KDEN"]
+                },
+                "DEN_R_DEP": {
+                    "backup": "DEN_N_DEP"
+                },
+                "DEN_S_DEP": {
+                    "backup": "DEN_R_DEP"
+                }
+            }
+        },
+        "controllers": [
+          "DEN_E_TWR",
+          "DEN_W_TWR",
+          "DEN_N_TWR",
+          "DEN_S_TWR",
+          "DEN_17_CTR"
+        ],
+        "default_maps": [ "D01 AR BASE" ],
+        "departure_runways": [
+          {
+            "airport": "KDEN",
+            "category": "EAST",
+            "rate": 15,
+            "runway": "17L"
+          },
+          {
+            "airport": "KDEN",
+            "category": "NORTH",
+            "rate": 15,
+            "runway": "25"
+          },
+          {
+            "airport": "KDEN",
+            "category": "SOUTH",
+            "rate": 15,
+            "runway": "17L"
+          },
+          {
+            "airport": "KDEN",
+            "category": "WEST",
+            "rate": 15,
+            "runway": "25"
+          }
+        ],
+        "wind": {
+          "direction": 210,
+          "speed": 15
+        }
+      },
+      "North and East": {
+        "arrival_runways": [
+          {
+            "airport": "KDEN",
+            "runway": "34R"
+          },
+          {
+            "airport": "KDEN",
+            "runway": "35L"
+          },
+          {
+            "airport": "KDEN",
+            "runway": "35R"
+          }
+        ],
+        "arrivals": {
+          "AALLE3": {
+            "KDEN": 10
+          },
+          "CLASH4": {
+            "KDEN": 10
+          },
+          "FLATI3": {
+            "KDEN": 10
+          },
+          "LAWGR3": {
+            "KDEN": 10
+          },
+          "LONGZ2": {
+            "KDEN": 10
+          },
+          "NIIXX3": {
+            "KDEN": 10
+          },
+          "SSKII3": {
+            "KDEN": 10
+          },
+          "TBARR3": {
+            "KDEN": 10
+          }
+        },
+        "solo_controller": "DEN_I_APP",
+        "multi_controllers": {
+            "default" : {
+                "DEN_I_APP": {
+                    "primary": true,
+                    "arrivals": ["SSKII3", "TBARR3"]
+                },
+                "DEN_H_APP": {
+                    "backup": "DEN_I_APP",
+                    "arrivals": ["FLATI3", "LONGZ2"]
+                },
+                "DEN_G_APP": {
+                    "backup": "DEN_H_APP",
+                    "arrivals": ["AALLE3", "LAWGR3"]
+                },
+                "DEN_X_APP": {
+                    "backup": "DEN_G_APP",
+                    "arrivals": ["NIIXX3", "CLASH4"]
+                },
+                "DEN_W_APP": {
+                    "backup": "DEN_I_APP"
+                },
+                "DEN_E_APP": {
+                    "backup": "DEN_W_APP"
+                },
+                "DEN_O_APP": {
+                    "backup": "DEN_E_APP"
+                },
+                "DEN_T_APP": {
+                    "backup": "DEN_O_APP"
+                },
+                "DEN_L_DEP": {
+                    "backup": "DEN_I_APP"
+                },
+                "DEN_N_DEP": {
+                    "backup": "DEN_L_DEP",
+                    "departures": ["KDEN"]
+                },
+                "DEN_R_DEP": {
+                    "backup": "DEN_N_DEP"
+                },
+                "DEN_S_DEP": {
+                    "backup": "DEN_R_DEP"
+                }
+            }
+        },
+        "controllers": [
+          "DEN_E_TWR",
+          "DEN_W_TWR",
+          "DEN_N_TWR",
+          "DEN_S_TWR",
+          "DEN_17_CTR"
+        ],
+        "default_maps": [ "D01 AR BASE" ],
+        "departure_runways": [
+          {
+            "airport": "KDEN",
+            "category": "EAST",
+            "rate": 15,
+            "runway": "8"
+          },
+          {
+            "airport": "KDEN",
+            "category": "NORTH",
+            "rate": 15,
+            "runway": "34L"
+          },
+          {
+            "airport": "KDEN",
+            "category": "SOUTH",
+            "rate": 15,
+            "runway": "8"
+          },
+          {
+            "airport": "KDEN",
+            "category": "WEST",
+            "rate": 15,
+            "runway": "34L"
+          }
+        ],
+        "wind": {
+          "direction": 80,
+          "speed": 12
+        }
+      },
+      "North and West": {
+        "arrival_runways": [
+          {
+            "airport": "KDEN",
+            "runway": "34R"
+          },
+          {
+            "airport": "KDEN",
+            "runway": "35L"
+          },
+          {
+            "airport": "KDEN",
+            "runway": "35R"
+          }
+        ],
+        "arrivals": {
+          "AALLE3": {
+            "KDEN": 10
+          },
+          "CLASH4": {
+            "KDEN": 10
+          },
+          "FLATI3": {
+            "KDEN": 10
+          },
+          "LAWGR3": {
+            "KDEN": 10
+          },
+          "LONGZ2": {
+            "KDEN": 10
+          },
+          "NIIXX3": {
+            "KDEN": 10
+          },
+          "SSKII3": {
+            "KDEN": 10
+          },
+          "TBARR3": {
+            "KDEN": 10
+          }
+        },
+        "solo_controller": "DEN_I_APP",
+        "multi_controllers": {
+            "default" : {
+                "DEN_I_APP": {
+                    "primary": true,
+                    "arrivals": ["SSKII3", "TBARR3"]
+                },
+                "DEN_H_APP": {
+                    "backup": "DEN_I_APP",
+                    "arrivals": ["FLATI3", "LONGZ2"]
+                },
+                "DEN_G_APP": {
+                    "backup": "DEN_H_APP",
+                    "arrivals": ["AALLE3", "LAWGR3"]
+                },
+                "DEN_X_APP": {
+                    "backup": "DEN_G_APP",
+                    "arrivals": ["NIIXX3", "CLASH4"]
+                },
+                "DEN_W_APP": {
+                    "backup": "DEN_I_APP"
+                },
+                "DEN_E_APP": {
+                    "backup": "DEN_W_APP"
+                },
+                "DEN_O_APP": {
+                    "backup": "DEN_E_APP"
+                },
+                "DEN_T_APP": {
+                    "backup": "DEN_O_APP"
+                },
+                "DEN_L_DEP": {
+                    "backup": "DEN_I_APP"
+                },
+                "DEN_N_DEP": {
+                    "backup": "DEN_L_DEP",
+                    "departures": ["KDEN"]
+                },
+                "DEN_R_DEP": {
+                    "backup": "DEN_N_DEP"
+                },
+                "DEN_S_DEP": {
+                    "backup": "DEN_R_DEP"
+                }
+            }
+        },
+        "controllers": [
+          "DEN_E_TWR",
+          "DEN_W_TWR",
+          "DEN_N_TWR",
+          "DEN_S_TWR",
+          "DEN_17_CTR"
+        ],
+        "default_maps": [ "D01 AR BASE" ],
+        "departure_runways": [
+          {
+            "airport": "KDEN",
+            "category": "EAST",
+            "rate": 15,
+            "runway": "34L"
+          },
+          {
+            "airport": "KDEN",
+            "category": "NORTH",
+            "rate": 15,
+            "runway": "34L"
+          },
+          {
+            "airport": "KDEN",
+            "category": "SOUTH",
+            "rate": 15,
+            "runway": "25"
+          },
+          {
+            "airport": "KDEN",
+            "category": "WEST",
+            "rate": 15,
+            "runway": "25"
+          }
+        ],
+        "wind": {
+          "direction": 140,
+          "speed": 1
+        }
+      },
+      "South All": {
+        "arrival_runways": [
+          {
+            "airport": "KDEN",
+            "runway": "17L"
+          },
+          {
+            "airport": "KDEN",
+            "runway": "16R"
+          },
+          {
+            "airport": "KDEN",
+            "runway": "17R"
+          }
+        ],
+        "arrivals": {
+          "AALLE3": {
+            "KDEN": 10
+          },
+          "CLASH4": {
+            "KDEN": 10
+          },
+          "FLATI3": {
+            "KDEN": 10
+          },
+          "LAWGR3": {
+            "KDEN": 10
+          },
+          "LONGZ2": {
+            "KDEN": 10
+          },
+          "NIIXX3": {
+            "KDEN": 10
+          },
+          "SSKII3": {
+            "KDEN": 10
+          },
+          "TBARR3": {
+            "KDEN": 10
+          }
+        },
+        "solo_controller": "DEN_I_APP",
+        "multi_controllers": {
+            "default" : {
+                "DEN_I_APP": {
+                    "primary": true,
+                    "arrivals": ["SSKII3", "TBARR3"]
+                },
+                "DEN_H_APP": {
+                    "backup": "DEN_I_APP",
+                    "arrivals": ["FLATI3", "LONGZ2"]
+                },
+                "DEN_G_APP": {
+                    "backup": "DEN_H_APP",
+                    "arrivals": ["AALLE3", "LAWGR3"]
+                },
+                "DEN_X_APP": {
+                    "backup": "DEN_G_APP",
+                    "arrivals": ["NIIXX3", "CLASH4"]
+                },
+                "DEN_W_APP": {
+                    "backup": "DEN_I_APP"
+                },
+                "DEN_E_APP": {
+                    "backup": "DEN_W_APP"
+                },
+                "DEN_O_APP": {
+                    "backup": "DEN_E_APP"
+                },
+                "DEN_T_APP": {
+                    "backup": "DEN_O_APP"
+                },
+                "DEN_L_DEP": {
+                    "backup": "DEN_I_APP"
+                },
+                "DEN_N_DEP": {
+                    "backup": "DEN_L_DEP",
+                    "departures": ["KDEN"]
+                },
+                "DEN_R_DEP": {
+                    "backup": "DEN_N_DEP"
+                },
+                "DEN_S_DEP": {
+                    "backup": "DEN_R_DEP"
+                }
+            }
+        },
+        "controllers": [
+          "DEN_E_TWR",
+          "DEN_W_TWR",
+          "DEN_N_TWR",
+          "DEN_S_TWR",
+          "DEN_17_CTR"
+        ],
+        "default_maps": [ "D01 AR BASE" ],
+        "departure_runways": [
+          {
+            "airport": "KDEN",
+            "category": "EAST",
+            "rate": 15,
+            "runway": "17L"
+          },
+          {
+            "airport": "KDEN",
+            "category": "NORTH",
+            "rate": 15,
+            "runway": "16L"
+          },
+          {
+            "airport": "KDEN",
+            "category": "SOUTH",
+            "rate": 15,
+            "runway": "17L"
+          },
+          {
+            "airport": "KDEN",
+            "category": "WEST",
+            "rate": 15,
+            "runway": "16L"
+          }
+        ],
+        "wind": {
+          "direction": 140,
+          "speed": 35
+        }
+      },
+      "North All": {
+        "arrival_runways": [
+          {
+            "airport": "KDEN",
+            "runway": "34R"
+          },
+          {
+            "airport": "KDEN",
+            "runway": "35L"
+          },
+          {
+            "airport": "KDEN",
+            "runway": "35R"
+          }
+        ],
+        "arrivals": {
+          "AALLE3": {
+            "KDEN": 10
+          },
+          "CLASH4": {
+            "KDEN": 10
+          },
+          "FLATI3": {
+            "KDEN": 10
+          },
+          "LAWGR3": {
+            "KDEN": 10
+          },
+          "LONGZ2": {
+            "KDEN": 10
+          },
+          "NIIXX3": {
+            "KDEN": 10
+          },
+          "SSKII3": {
+            "KDEN": 10
+          },
+          "TBARR3": {
+            "KDEN": 10
+          }
+        },
+        "solo_controller": "DEN_I_APP",
+        "multi_controllers": {
+            "default" : {
+                "DEN_I_APP": {
+                    "primary": true,
+                    "arrivals": ["SSKII3", "TBARR3"]
+                },
+                "DEN_H_APP": {
+                    "backup": "DEN_I_APP",
+                    "arrivals": ["FLATI3", "LONGZ2"]
+                },
+                "DEN_G_APP": {
+                    "backup": "DEN_H_APP",
+                    "arrivals": ["AALLE3", "LAWGR3"]
+                },
+                "DEN_X_APP": {
+                    "backup": "DEN_G_APP",
+                    "arrivals": ["NIIXX3", "CLASH4"]
+                },
+                "DEN_W_APP": {
+                    "backup": "DEN_I_APP"
+                },
+                "DEN_E_APP": {
+                    "backup": "DEN_W_APP"
+                },
+                "DEN_O_APP": {
+                    "backup": "DEN_E_APP"
+                },
+                "DEN_T_APP": {
+                    "backup": "DEN_O_APP"
+                },
+                "DEN_L_DEP": {
+                    "backup": "DEN_I_APP"
+                },
+                "DEN_N_DEP": {
+                    "backup": "DEN_L_DEP",
+                    "departures": ["KDEN"]
+                },
+                "DEN_R_DEP": {
+                    "backup": "DEN_N_DEP"
+                },
+                "DEN_S_DEP": {
+                    "backup": "DEN_R_DEP"
+                }
+            }
+        },
+        "controllers": [
+          "DEN_E_TWR",
+          "DEN_W_TWR",
+          "DEN_N_TWR",
+          "DEN_S_TWR",
+          "DEN_17_CTR"
+        ],
+        "default_maps": [ "D01 AR BASE" ],
+        "departure_runways": [
+          {
+            "airport": "KDEN",
+            "category": "EAST",
+            "rate": 15,
+            "runway": "34R"
+          },
+          {
+            "airport": "KDEN",
+            "category": "NORTH",
+            "rate": 15,
+            "runway": "34R"
+          },
+          {
+            "airport": "KDEN",
+            "category": "SOUTH",
+            "rate": 15,
+            "runway": "34L"
+          },
+          {
+            "airport": "KDEN",
+            "category": "WEST",
+            "rate": 15,
+            "runway": "34L"
+          }
+        ],
+        "wind": {
+          "direction": 20,
+          "speed": 31
+        }
+      },
+      "West All": {
+        "arrival_runways": [
+          {
+            "airport": "KDEN",
+            "runway": "25"
+          },
+          {
+            "airport": "KDEN",
+            "runway": "26"
+          }
+        ],
+        "arrivals": {
+          "AALLE3": {
+            "KDEN": 10
+          },
+          "CLASH4": {
+            "KDEN": 10
+          },
+          "FLATI3": {
+            "KDEN": 10
+          },
+          "LAWGR3": {
+            "KDEN": 10
+          },
+          "LONGZ2": {
+            "KDEN": 10
+          },
+          "NIIXX3": {
+            "KDEN": 10
+          },
+          "SSKII3": {
+            "KDEN": 10
+          },
+          "TBARR3": {
+            "KDEN": 10
+          }
+        },
+        "solo_controller": "DEN_I_APP",
+        "multi_controllers": {
+            "default" : {
+                "DEN_I_APP": {
+                    "primary": true,
+                    "arrivals": ["SSKII3", "TBARR3"]
+                },
+                "DEN_H_APP": {
+                    "backup": "DEN_I_APP",
+                    "arrivals": ["FLATI3", "LONGZ2"]
+                },
+                "DEN_G_APP": {
+                    "backup": "DEN_H_APP",
+                    "arrivals": ["AALLE3", "LAWGR3"]
+                },
+                "DEN_X_APP": {
+                    "backup": "DEN_G_APP",
+                    "arrivals": ["NIIXX3", "CLASH4"]
+                },
+                "DEN_W_APP": {
+                    "backup": "DEN_I_APP"
+                },
+                "DEN_E_APP": {
+                    "backup": "DEN_W_APP"
+                },
+                "DEN_O_APP": {
+                    "backup": "DEN_E_APP"
+                },
+                "DEN_T_APP": {
+                    "backup": "DEN_O_APP"
+                },
+                "DEN_L_DEP": {
+                    "backup": "DEN_I_APP"
+                },
+                "DEN_N_DEP": {
+                    "backup": "DEN_L_DEP",
+                    "departures": ["KDEN"]
+                },
+                "DEN_R_DEP": {
+                    "backup": "DEN_N_DEP"
+                },
+                "DEN_S_DEP": {
+                    "backup": "DEN_R_DEP"
+                }
+            }
+        },
+        "controllers": [
+          "DEN_E_TWR",
+          "DEN_W_TWR",
+          "DEN_N_TWR",
+          "DEN_S_TWR",
+          "DEN_17_CTR"
+        ],
+        "default_maps": [ "D01 AR BASE" ],
+        "departure_runways": [
+          {
+            "airport": "KDEN",
+            "category": "EAST",
+            "rate": 15,
+            "runway": "25"
+          },
+          {
+            "airport": "KDEN",
+            "category": "NORTH",
+            "rate": 15,
+            "runway": "25"
+          },
+          {
+            "airport": "KDEN",
+            "category": "SOUTH",
+            "rate": 15,
+            "runway": "25"
+          },
+          {
+            "airport": "KDEN",
+            "category": "WEST",
+            "rate": 15,
+            "runway": "25"
+          }
+        ],
+        "wind": {
+          "direction": 270,
+          "speed": 33
+        }
+      },
+      "East All": {
+        "arrival_runways": [
+          {
+            "airport": "KDEN",
+            "runway": "7"
+          },
+          {
+            "airport": "KDEN",
+            "runway": "8"
+          }
+        ],
+        "arrivals": {
+          "AALLE3": {
+            "KDEN": 10
+          },
+          "CLASH4": {
+            "KDEN": 10
+          },
+          "FLATI3": {
+            "KDEN": 10
+          },
+          "LAWGR3": {
+            "KDEN": 10
+          },
+          "LONGZ2": {
+            "KDEN": 10
+          },
+          "NIIXX3": {
+            "KDEN": 10
+          },
+          "SSKII3": {
+            "KDEN": 10
+          },
+          "TBARR3": {
+            "KDEN": 10
+          }
+        },
+        "solo_controller": "DEN_I_APP",
+        "multi_controllers": {
+            "default" : {
+                "DEN_I_APP": {
+                    "primary": true,
+                    "arrivals": ["SSKII3", "TBARR3"]
+                },
+                "DEN_H_APP": {
+                    "backup": "DEN_I_APP",
+                    "arrivals": ["FLATI3", "LONGZ2"]
+                },
+                "DEN_G_APP": {
+                    "backup": "DEN_H_APP",
+                    "arrivals": ["AALLE3", "LAWGR3"]
+                },
+                "DEN_X_APP": {
+                    "backup": "DEN_G_APP",
+                    "arrivals": ["NIIXX3", "CLASH4"]
+                },
+                "DEN_W_APP": {
+                    "backup": "DEN_I_APP"
+                },
+                "DEN_E_APP": {
+                    "backup": "DEN_W_APP"
+                },
+                "DEN_O_APP": {
+                    "backup": "DEN_E_APP"
+                },
+                "DEN_T_APP": {
+                    "backup": "DEN_O_APP"
+                },
+                "DEN_L_DEP": {
+                    "backup": "DEN_I_APP"
+                },
+                "DEN_N_DEP": {
+                    "backup": "DEN_L_DEP",
+                    "departures": ["KDEN"]
+                },
+                "DEN_R_DEP": {
+                    "backup": "DEN_N_DEP"
+                },
+                "DEN_S_DEP": {
+                    "backup": "DEN_R_DEP"
+                }
+            }
+        },
+        "controllers": [
+          "DEN_E_TWR",
+          "DEN_W_TWR",
+          "DEN_N_TWR",
+          "DEN_S_TWR",
+          "DEN_17_CTR"
+        ],
+        "default_maps": [ "D01 AR BASE" ],
+        "departure_runways": [
+          {
+            "airport": "KDEN",
+            "category": "EAST",
+            "rate": 15,
+            "runway": "8"
+          },
+          {
+            "airport": "KDEN",
+            "category": "NORTH",
+            "rate": 15,
+            "runway": "8"
+          },
+          {
+            "airport": "KDEN",
+            "category": "SOUTH",
+            "rate": 15,
+            "runway": "8"
+          },
+          {
+            "airport": "KDEN",
+            "category": "WEST",
+            "rate": 15,
+            "runway": "8"
+          }
+        ],
+        "wind": {
+          "direction": 140,
+          "speed": 1
+        }
+      }
+    },
+    "stars_config": {
+    "center": "KDEN",
+    "inhibit_ca_volumes": [
+      {
+        "name": "D01 NO CA",
+        "type": "polygon",
+        "floor": 5000,
+        "ceiling": 13000,
+        "vertices": [
+          "N039.18.01.727,W104.33.48.707",
+          "N039.18.14.375,W104.45.11.370",
+          "N040.24.47.562,W104.45.01.098",
+          "N040.24.22.019,W104.31.03.253"
+        ]
+      }
+    ],
+    "radar_sites": {
+      "DEN": {
+        "char": "D",
+        "elevation": 136,
+        "position": "KDEN",
+        "primary_range": 60,
+        "secondary_range": 120,
+        "silence_angle": 30,
+        "slope_angle": 0.175
+      }
+    },
+    "scratchpads": {
+      "HBU": "BAY",
+      "TEHRU": "BAY",
+      "CHUWY": "YOK",
+      "WERNR": "CON",
+      "CONNR": "CON",
+      "VOAXA": "COO",
+      "DDRTH": "YAM",
+      "EEONS": "EEO",
+      "WYNDM": "EEO",
+      "EMMYS": "EMM",
+      "ZIRKL": "EMM",
+      "GAETR": "EPK",
+      "DUUZE": "EPK",
+      "EXTAN": "EXT",
+      "SHAYK": "EXT",
+      "JOBBA": "BRY",
+      "SAABR": "BRY",
+      "JOPLN": "SHO",
+      "VRONI": "SHO",
+      "SLEEK": "STA",
+      "DAAYE": "SOL",
+      "RAITT": "SOL",
+      "SUDDZ": "SCA",
+      "XXWNG": "RIK",
+      "CHNGY": "ZIM"
+    },
+    "stars_maps": [
+      {
+        "group": 0,
+        "label": "AR BASE",
+        "name": "D01 AR BASE"
+      },
+      {
+        "group": 0,
+        "label": "DR BASE",
+        "name": "D01 DR BASE"
+      },
+      {
+        "group": 1,
+        "label": "D01 MVA",
+        "name": "D01 MVA"
+      },
+      {
+        "group": 0,
+        "label": "EOVM",
+        "name": "D01 EOVM"
+      },
+      {
+        "group": 0,
+        "label": "AIRWAYS",
+        "name": "D01 AIRWAYS"
+     },
+     {
+      "group": 0,
+      "label": "VFR",
+      "name": "D01 VFR"
+      },
+      {
+        "group": 0,
+        "label": "NORTH D",
+        "name": "D01 North Dump"
+      },
+      {
+        "group": 0,
+        "label": "SOUTH D",
+        "name": "D01 South Dump"
+      },
+      {
+        "group": 0,
+        "label": "EAST D",
+        "name": "D01 East Dump"
+     },
+     {
+      "group": 0,
+      "label": "WEST D",
+      "name": "D01 West Dump"
+      },
+      {
+        "group": 0,
+        "label": "AR LE",
+        "name": "D01 AR LE"
+      },
+      {
+          "group": 0,
+          "label": "AR LEW",
+          "name": "D01 AR LEW"
+      },
+      {
+          "group": 0,
+          "label": "AR LN",
+          "name": "D01 AR LN"
+      },
+      {
+          "group": 0,
+          "label": "AR LNE",
+          "name": "D01 AR LNE"
+      },
+      {
+          "group": 0,
+          "label": "AR LNS",
+          "name": "D01 AR LNS"
+      },
+      {
+          "group": 0,
+          "label": "AR LNW",
+          "name": "D01 AR LNW"
+      },
+      {
+          "group": 0,
+          "label": "AR LS",
+          "name": "D01 AR LS"
+      },
+      {
+          "group": 0,
+          "label": "AR LSE",
+          "name": "D01 AR LSE"
+      },
+      {
+          "group": 0,
+          "label": "AR LSW",
+          "name": "D01 AR LSW"
+      },
+      {
+          "group": 0,
+          "label": "AR LW",
+          "name": "D01 AR LW"
+      },
+      {
+          "group": 0,
+          "label": "BRAVO",
+          "name": "D01 BRAVO"
+      },
+      {
+        "group": 0,
+        "label": "DR LE",
+        "name": "D01 DR LE"
+      },
+      {
+          "group": 0,
+          "label": "DR LEW",
+          "name": "D01 DR LEW"
+      },
+      {
+          "group": 0,
+          "label": "DR LN",
+          "name": "D01 DR LN"
+      },
+      {
+          "group": 0,
+          "label": "DR LNE",
+          "name": "D01 DR LNE"
+      },
+      {
+          "group": 0,
+          "label": "DR LNS",
+          "name": "D01 DR LNS"
+      },
+      {
+          "group": 0,
+          "label": "DR LNW",
+          "name": "D01 DR LNW"
+      },
+      {
+          "group": 0,
+          "label": "DR LS",
+          "name": "D01 DR LS"
+      },
+      {
+          "group": 0,
+          "label": "DR LSE",
+          "name": "D01 DR LSE"
+      },
+      {
+          "group": 0,
+          "label": "DR LSW",
+          "name": "D01 DR LSW"
+      },
+      {
+          "group": 0,
+          "label": "DR LW",
+          "name": "D01 DR LW"
+      },
+      {
+        "group": 0,
+        "label": "ESID LE",
+        "name": "D01 ESID LE"
+      },
+      {
+          "group": 0,
+          "label": "ESID LN",
+          "name": "D01 ESID LN"
+      },
+      {
+          "group": 0,
+          "label": "ESID LS",
+          "name": "D01 ESID LS"
+      },
+      {
+          "group": 0,
+          "label": "FIXES",
+          "name": "D01 Fixes"
+      },
+      {
+          "group": 0,
+          "label": "FR LE",
+          "name": "D01 FR LE"
+      },
+      {
+          "group": 0,
+          "label": "FR LN",
+          "name": "D01 FR LN"
+      },
+      {
+          "group": 0,
+          "label": "FR LS6L",
+          "name": "D01 FR LS6L"
+      },
+      {
+          "group": 0,
+          "label": "FR LS6R",
+          "name": "D01 FR LS6R"
+      },
+      {
+          "group": 0,
+          "label": "FR LW",
+          "name": "D01 FR LW"
+      },
+      {
+          "group": 0,
+          "label": "I6R34L",
+          "name": "D01 I16R34L"
+      },
+      {
+          "group": 0,
+          "label": "I17L35R",
+          "name": "D01 I17L35R"
+      },
+      {
+          "group": 0,
+          "label": "I17R35L",
+          "name": "D01 I17R35L"
+      },
+      {
+          "group": 0,
+          "label": "I34R",
+          "name": "D01 I34R"
+      },
+      {
+          "group": 0,
+          "label": "JET RTE",
+          "name": "D01 JET RTE"
+      },
+      {
+          "group": 0,
+          "label": "LN STAR",
+          "name": "D01 LN STARs"
+      },
+      {
+          "group": 0,
+          "label": "LNS STAR",
+          "name": "D01 LNS STARS"
+      },
+      {
+          "group": 0,
+          "label": "LS STAR",
+          "name": "D01 LS STAR"
+      },
+      {
+          "group": 1,
+          "label": "D01 MVA",
+          "name": "D01 MVA"
+      },
+      {
+          "group": 0,
+          "label": "NORTH DUMP",
+          "name": "D01 North Dump"
+      },
+      {
+          "group": 0,
+          "label": "NSID LEW",
+          "name": "D01 NSID LE-W"
+      },
+      {
+          "group": 0,
+          "label": "NSID LN",
+          "name": "D01 NSID LN"
+      },
+      {
+          "group": 0,
+          "label": "SAT SID",
+          "name": "D01 SAT SID"
+      },
+      {
+          "group": 0,
+          "label": "SAT STAR",
+          "name": "D01 SAT STAR"
+      },
+      {
+          "group": 0,
+          "label": "SOUTH DUMP",
+          "name": "D01 South Dump"
+      },
+      {
+          "group": 0,
+          "label": "SR LE",
+          "name": "D01 SR LE"
+      },
+      {
+          "group": 0,
+          "label": "SR LEW",
+          "name": "D01 SR LEW"
+      },
+      {
+          "group": 0,
+          "label": "SR LN",
+          "name": "D01 SR LN="
+      },
+      {
+          "group": 0,
+          "label": "SR LNE",
+          "name": "D01 SR LNE"
+      },
+      {
+          "group": 0,
+          "label": "SR LNS",
+          "name": "D01 SR LNS"
+      },
+      {
+          "group": 0,
+          "label": "SR LNW",
+          "name": "D01 SR LNW"
+      },
+      {
+          "group": 0,
+          "label": "SR LS",
+          "name": "D01 SR LS"
+      },
+      {
+          "group": 0,
+          "label": "SR LSE",
+          "name": "D01 SR LSE"
+      },
+      {
+          "group": 0,
+          "label": "SR LSW",
+          "name": "D01 SR LSW"
+      },
+      {
+          "group": 0,
+          "label": "SR LW",
+          "name": "D01 SR LW"
+      },
+      {
+          "group": 0,
+          "label": "SSID LEW",
+          "name": "D01 SSID LE-W"
+      },
+      {
+          "group": 0,
+          "label": "SSID LS",
+          "name": "D01 SSID LS"
+      },
+      {
+          "group": 0,
+          "label": "VFR",
+          "name": "D01 VFR"
+      },
+      {
+          "group": 0,
+          "label": "WEST DUMP",
+          "name": "D01 West Dump"
+      },
+      {
+          "group": 0,
+          "label": "WSID LNW",
+          "name": "D01 WSID LN-W"
+      },
+      {
+          "group": 0,
+          "label": "WSID LS",
+          "name": "D01 WSID LS"
+      },
+      {
+          "group": 0,
+          "label": "ZDV",
+          "name": "D01 ZDV"
+      }
+    ],
+    "video_map_file": "videomaps/ZDV-videomaps.json.zst"
+    }
+  }


### PR DESCRIPTION
D01
 - added RNAV Z approaches for runways 7, 16R, 17R, 26, 34R, 35R
 - added correct departure gates for each SID
 - fixed scratchpads to match SOP/LOAs

COS
 - fixed departure headings to match SOP
 - fixed cruise altitudes to match LOAs
 - added additional airlines to departure routes