### PR TITLE
Stop window from creating out of bounds, disable GLFW_AUTO_ICONIFY

### DIFF
--- a/platform.go
+++ b/platform.go
@@ -104,8 +104,8 @@ func NewGLFWPlatform(io imgui.IO, windowSize [2]int, windowPosition [2]int, mult
 	glfw.WindowHint(glfw.ContextVersionMajor, 2)
 	glfw.WindowHint(glfw.ContextVersionMinor, 1)
 
+	vm := glfw.GetPrimaryMonitor().GetVideoMode()
 	if windowSize[0] == 0 || windowSize[1] == 0 {
-		vm := glfw.GetPrimaryMonitor().GetVideoMode()
 		if runtime.GOOS == "windows" {
 			windowSize[0] = vm.Width - 200
 			windowSize[1] = vm.Height - 300
@@ -115,6 +115,11 @@ func NewGLFWPlatform(io imgui.IO, windowSize [2]int, windowPosition [2]int, mult
 		}
 	}
 
+	// If window position is out of bounds, create the window at (100, 100)
+	if windowPosition[0] < 0 || windowPosition[1] < 0 || windowPosition[0] > vm.Width || windowPosition[1] > vm.Height {
+		globalConfig.InitialWindowPosition = [2]int{100, 100}
+		windowPosition = [2]int{100, 100}
+	}
 	// Start with an invisible window so that we can position it first
 	glfw.WindowHint(glfw.Visible, 0)
 	// Disable GLFW_AUTO_ICONIFY to stop the window from automatically minimizing in fullscreen

--- a/platform.go
+++ b/platform.go
@@ -117,6 +117,8 @@ func NewGLFWPlatform(io imgui.IO, windowSize [2]int, windowPosition [2]int, mult
 
 	// Start with an invisible window so that we can position it first
 	glfw.WindowHint(glfw.Visible, 0)
+	// Disable GLFW_AUTO_ICONIFY to stop the window from automatically minimizing in fullscreen
+	glfw.WindowHint(glfw.AutoIconify, 0)
 	// Maybe enable multisampling
 	if multisample {
 		glfw.WindowHint(glfw.Samples, 4)


### PR DESCRIPTION
Addresses #231 (and also fixes the window minimizing automatically while in fullscreen)

- adds a check to prevent negative or out of bounds `InitialWindowPosition` values (for example, if you close vice while it's minimized on Windows, the `InitialWindowPosition` would be `[-32000, -32000]`)
- disables `GLFW_AUTO_ICONIFY` to stop it from automatically minimizing