### PR TITLE
add error for FC on owned tracks

### DIFF
--- a/pkg/sim/sim.go
+++ b/pkg/sim/sim.go
@@ -2261,7 +2261,7 @@ func (s *Sim) HandoffControl(token, callsign string) error {
 					radioTransmissions = append(radioTransmissions, av.RadioTransmission{
 						Controller: ac.ControllingController,
 						Message:    "Unable, we are already on " + octrl.Frequency.String(),
-						Type:       av.RadioTransmissionUnexpected,
+						Type:       av.RadioTransmissionReadback,
 					})
 					return radioTransmissions
 				}

--- a/pkg/sim/sim.go
+++ b/pkg/sim/sim.go
@@ -2257,6 +2257,14 @@ func (s *Sim) HandoffControl(token, callsign string) error {
 		func(ctrl *av.Controller, ac *av.Aircraft) []av.RadioTransmission {
 			var radioTransmissions []av.RadioTransmission
 			if octrl := s.State.Controllers[ac.TrackingController]; octrl != nil {
+				if octrl.Frequency == ctrl.Frequency {
+					radioTransmissions = append(radioTransmissions, av.RadioTransmission{
+						Controller: ac.ControllingController,
+						Message:    "Unable, we are already on " + octrl.Frequency.String(),
+						Type:       av.RadioTransmissionUnexpected,
+					})
+					return radioTransmissions
+				}
 				name := util.Select(octrl.FullName != "", octrl.FullName, octrl.Callsign)
 				bye := rand.Sample("good day", "seeya")
 				contact := rand.Sample("contact ", "over to ", "")

--- a/ui.go
+++ b/ui.go
@@ -1018,7 +1018,7 @@ func showAboutDialog() {
 		`Additional credits:
 - Software Development: Artem Dorofeev,
   Dennis Graiani, Michael Trokel, Samuel
-  Valencia, and Yi Zhang.
+  Valencia, Xavier Caldwell, and Yi Zhang.
 - Facility engineering: Connor Allen, Adam
   Bolek, Brody Carty, Lucas Chan, Aaron
   Flett, Mike K, Josh Lambert, Jonah


### PR DESCRIPTION
Fixes #230 

Add an error message when attempting to use the "FC" command on an owned track. This checks if the new frequency is the same as the current frequency and, if so, the pilot will respond with "Unable, we are already on [frequency]"