### PR TITLE
Update Avelo in openscope airlines json

### DIFF
--- a/resources/openscope-airlines.json
+++ b/resources/openscope-airlines.json
@@ -44444,20 +44444,18 @@
   },
   {
     "icao": "vxp",
-    "name": "Alevo",
+    "name": "Avelo",
     "callsign": {
-      "name": "Alevo",
+      "name": "Avelo",
       "callsignFormats": [
-        "####",
-        "###",
-        "##"
+        "###"
       ]
     },
     "fleets": {
       "default": [
         [
-          "B38M",
-          8
+          "B738",
+          10
         ],
         [
           "B737",


### PR DESCRIPTION
Fixed callsign from Alevo --> Avelo
Fixed Callsign numbers to just include ### instead of ##, ###, ####. 
Fixed fleet to include 10 B738 rather than 8 B38M. 

Source: https://www.flightradar24.com/data/airlines/xp-vxp/fleet

Fixes #342 