### PR TITLE
Fixed issue with new a/c command syntax.

### DIFF
--- a/pkg/panes/stars/commands.go
+++ b/pkg/panes/stars/commands.go
@@ -1956,7 +1956,12 @@ func (sp *STARSPane) executeSTARSCommand(cmd string, ctx *panes.Context) (status
 		} else if cmd == ";" {
 			sp.lockTargetGenMode = true
 			sp.previewAreaInput = ""
-		} else if callsign, cmds, ok := strings.Cut(cmd, " "); ok {
+		} 
+		callsign, cmds, ok := strings.Cut(cmd, " ")
+		if !ok {
+			callsign = sp.targetGenLastCallsign
+			cmds = cmd
+		}
 			ac := ctx.ControlClient.AircraftFromPartialCallsign(callsign)
 			if ac == nil && sp.targetGenLastCallsign != "" {
 				// If a valid callsign wasn't given, try the last callsign used.
@@ -1971,15 +1976,12 @@ func (sp *STARSPane) executeSTARSCommand(cmd string, ctx *panes.Context) (status
 				} else {
 					status.clear = true
 				}
+				
 			} else {
 				status.err = ErrSTARSIllegalACID
 			}
-		} else {
-			status.err = ErrSTARSCommandFormat
-		}
-		return
-	}
-
+			return 
+		} 
 	status.err = ErrSTARSCommandFormat
 	return
 }

--- a/pkg/panes/stars/commands.go
+++ b/pkg/panes/stars/commands.go
@@ -1956,32 +1956,32 @@ func (sp *STARSPane) executeSTARSCommand(cmd string, ctx *panes.Context) (status
 		} else if cmd == ";" {
 			sp.lockTargetGenMode = true
 			sp.previewAreaInput = ""
-		} 
+		}
 		callsign, cmds, ok := strings.Cut(cmd, " ")
 		if !ok {
 			callsign = sp.targetGenLastCallsign
 			cmds = cmd
 		}
-			ac := ctx.ControlClient.AircraftFromPartialCallsign(callsign)
-			if ac == nil && sp.targetGenLastCallsign != "" {
-				// If a valid callsign wasn't given, try the last callsign used.
-				ac = ctx.ControlClient.Aircraft[sp.targetGenLastCallsign]
-			}
-			if ac != nil {
-				sp.runAircraftCommands(ctx, ac, cmds)
-				sp.targetGenLastCallsign = ac.Callsign
-				if sp.lockTargetGenMode {
-					// Clear the input but stay in TGT GEN mode.
-					sp.previewAreaInput = ""
-				} else {
-					status.clear = true
-				}
-				
+		ac := ctx.ControlClient.AircraftFromPartialCallsign(callsign)
+		if ac == nil && sp.targetGenLastCallsign != "" {
+			// If a valid callsign wasn't given, try the last callsign used.
+			ac = ctx.ControlClient.Aircraft[sp.targetGenLastCallsign]
+		}
+		if ac != nil {
+			sp.runAircraftCommands(ctx, ac, cmds)
+			sp.targetGenLastCallsign = ac.Callsign
+			if sp.lockTargetGenMode {
+				// Clear the input but stay in TGT GEN mode.
+				sp.previewAreaInput = ""
 			} else {
-				status.err = ErrSTARSIllegalACID
+				status.clear = true
 			}
-			return 
-		} 
+
+		} else {
+			status.err = ErrSTARSIllegalACID
+		}
+		return
+	}
 	status.err = ErrSTARSCommandFormat
 	return
 }


### PR DESCRIPTION
Closes `STARSPane targetGenLastCallsign` not working #397