### PR TITLE
aviation: Improved display of STAR routes

### DIFF
--- a/pkg/aviation/route.go
+++ b/pkg/aviation/route.go
@@ -822,12 +822,15 @@ func MakeSTAR() *STAR {
 	}
 }
 
+const routePrintFormat = "%-13s: %s\n"
+
 func (s STAR) Print(name string) {
 	for tr, wps := range s.Transitions {
-		fmt.Printf("%-12s: %s\n", name+"."+tr, wps.Encode())
+		fmt.Printf(routePrintFormat, name+"."+tr, wps.Encode())
 	}
+
 	for rwy, wps := range s.RunwayWaypoints {
-		fmt.Printf("%-12s: %s\n", name+".RWY"+rwy, wps.Encode())
+		fmt.Printf(routePrintFormat, name+".RWY"+rwy, wps.Encode())
 	}
 }
 

--- a/pkg/aviation/route.go
+++ b/pkg/aviation/route.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"maps"
 	"slices"
 	"strconv"
 	"strings"
@@ -825,12 +826,12 @@ func MakeSTAR() *STAR {
 const routePrintFormat = "%-13s: %s\n"
 
 func (s STAR) Print(name string) {
-	for tr, wps := range s.Transitions {
-		fmt.Printf(routePrintFormat, name+"."+tr, wps.Encode())
+	for _, tr := range slices.Sorted(maps.Keys(s.Transitions)) {
+		fmt.Printf(routePrintFormat, name+"."+tr, s.Transitions[tr].Encode())
 	}
 
-	for rwy, wps := range s.RunwayWaypoints {
-		fmt.Printf(routePrintFormat, name+".RWY"+rwy, wps.Encode())
+	for _, rwy := range slices.Sorted(maps.Keys(s.RunwayWaypoints)) {
+		fmt.Printf(routePrintFormat, name+".RWY"+rwy, s.RunwayWaypoints[rwy].Encode())
 	}
 }
 


### PR DESCRIPTION
* Fixed potential gap
  The maximum length of a STAR Computer Code is 13. Ex. BLUMS5.RWY30R

* Display routes in ordered
  Routes are displayed in ascending order of transition name (or runway number) by transition type (en-route, runway, in that order).