### PR TITLE
Fix go version for windows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mmp/vice
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/MichaelTJones/pcg v0.0.0-20180122055547-df440c6ed7ed


### PR DESCRIPTION
The `go build` and `go run` commands refuse to work on windows due to the project requesting version `1.23`. This PR simply modifies that to be `1.23.0`. 