### PR TITLE
Add option to hide messages pane

### DIFF
--- a/pkg/panes/messages.go
+++ b/pkg/panes/messages.go
@@ -58,7 +58,7 @@ func init() {
 
 func NewMessagesPane() *MessagesPane {
 	return &MessagesPane{
-		FontIdentifier: renderer.FontIdentifier{Name: "Inconsolata Condensed Regular", Size: 15},
+		FontIdentifier: renderer.FontIdentifier{Name: "Inconsolata Condensed Regular", Size: 16},
 
 		HideMessagePane: false,
 	}

--- a/pkg/panes/messages.go
+++ b/pkg/panes/messages.go
@@ -40,6 +40,8 @@ type MessagesPane struct {
 	ContactTransmissionsAlert  bool
 	ReadbackTransmissionsAlert bool
 	HideMessagePane            bool
+	prevContactAlerts          bool
+	prevReadbackAlerts         bool
 
 	font            *renderer.Font
 	scrollbar       *ScrollBar
@@ -58,7 +60,7 @@ func init() {
 
 func NewMessagesPane() *MessagesPane {
 	return &MessagesPane{
-		FontIdentifier: renderer.FontIdentifier{Name: "Inconsolata Condensed Regular", Size: 16},
+		FontIdentifier: renderer.FontIdentifier{Name: "Inconsolata Condensed Regular", Size: 15},
 
 		HideMessagePane: false,
 	}
@@ -110,11 +112,22 @@ func (mp *MessagesPane) Upgrade(prev, current int) {
 
 func (mp *MessagesPane) DrawUI(p platform.Platform, config *platform.Config) {
 
-	imgui.Checkbox("Hide Messages Pane", &mp.HideMessagePane)
+	wasHidden := mp.HideMessagePane
+
+	imgui.Checkbox("Hide Message Pane", &mp.HideMessagePane)
+
+	// When hiding, save current states and uncheck
+	if mp.HideMessagePane && !wasHidden {
+		mp.prevContactAlerts = mp.ContactTransmissionsAlert
+		mp.prevReadbackAlerts = mp.ReadbackTransmissionsAlert
+		mp.ContactTransmissionsAlert = false
+		mp.ReadbackTransmissionsAlert = false
+	}
 
 	if mp.HideMessagePane {
 		imgui.BeginDisabled()
 	}
+
 	if newFont, changed := renderer.DrawFontPicker(&mp.FontIdentifier, "Font"); changed {
 		mp.font = newFont
 	}
@@ -129,6 +142,9 @@ func (mp *MessagesPane) DrawUI(p platform.Platform, config *platform.Config) {
 		}
 		imgui.EndCombo()
 	}
+
+	// Disable sound options when pane is hidden
+
 	imgui.Checkbox("Play audio alert after pilot initial contact transmissions", &mp.ContactTransmissionsAlert)
 	imgui.Checkbox("Play audio alert after pilot readback transmissions", &mp.ReadbackTransmissionsAlert)
 	if mp.HideMessagePane {
@@ -193,6 +209,7 @@ func (msg *Message) Color() renderer.RGB {
 }
 
 func (mp *MessagesPane) processEvents(ctx *Context) {
+
 	consolidateRadioTransmissions := func(events []sim.Event) []sim.Event {
 		canConsolidate := func(a, b sim.Event) bool {
 			return a.Type == sim.RadioTransmissionEvent && b.Type == sim.RadioTransmissionEvent &&

--- a/pkg/panes/messages.go
+++ b/pkg/panes/messages.go
@@ -39,6 +39,7 @@ type MessagesPane struct {
 	AudioAlertSelection        string
 	ContactTransmissionsAlert  bool
 	ReadbackTransmissionsAlert bool
+	IsVisible                  bool
 
 	font            *renderer.Font
 	scrollbar       *ScrollBar
@@ -57,13 +58,15 @@ func init() {
 
 func NewMessagesPane() *MessagesPane {
 	return &MessagesPane{
-		FontIdentifier: renderer.FontIdentifier{Name: "Inconsolata Condensed Regular", Size: 16},
+		FontIdentifier: renderer.FontIdentifier{Name: "Inconsolata Condensed Regular", Size: 15},
+
+		IsVisible: true,
 	}
 }
 
 func (mp *MessagesPane) DisplayName() string { return "Messages" }
 
-func (mp *MessagesPane) Hide() bool { return false }
+func (mp *MessagesPane) Hide() bool { return !mp.IsVisible }
 
 func (mp *MessagesPane) Activate(r renderer.Renderer, p platform.Platform, eventStream *sim.EventStream, lg *log.Logger) {
 	if mp.font = renderer.GetFont(mp.FontIdentifier); mp.font == nil {
@@ -106,6 +109,9 @@ func (mp *MessagesPane) Upgrade(prev, current int) {
 }
 
 func (mp *MessagesPane) DrawUI(p platform.Platform, config *platform.Config) {
+
+	imgui.Checkbox("Show Messages Pane", &mp.IsVisible)
+
 	if newFont, changed := renderer.DrawFontPicker(&mp.FontIdentifier, "Font"); changed {
 		mp.font = newFont
 	}

--- a/pkg/panes/messages.go
+++ b/pkg/panes/messages.go
@@ -39,7 +39,7 @@ type MessagesPane struct {
 	AudioAlertSelection        string
 	ContactTransmissionsAlert  bool
 	ReadbackTransmissionsAlert bool
-	IsVisible                  bool
+	HideMessagePane            bool
 
 	font            *renderer.Font
 	scrollbar       *ScrollBar
@@ -60,13 +60,13 @@ func NewMessagesPane() *MessagesPane {
 	return &MessagesPane{
 		FontIdentifier: renderer.FontIdentifier{Name: "Inconsolata Condensed Regular", Size: 15},
 
-		IsVisible: true,
+		HideMessagePane: false,
 	}
 }
 
 func (mp *MessagesPane) DisplayName() string { return "Messages" }
 
-func (mp *MessagesPane) Hide() bool { return !mp.IsVisible }
+func (mp *MessagesPane) Hide() bool { return mp.HideMessagePane }
 
 func (mp *MessagesPane) Activate(r renderer.Renderer, p platform.Platform, eventStream *sim.EventStream, lg *log.Logger) {
 	if mp.font = renderer.GetFont(mp.FontIdentifier); mp.font == nil {
@@ -110,8 +110,11 @@ func (mp *MessagesPane) Upgrade(prev, current int) {
 
 func (mp *MessagesPane) DrawUI(p platform.Platform, config *platform.Config) {
 
-	imgui.Checkbox("Show Messages Pane", &mp.IsVisible)
+	imgui.Checkbox("Hide Messages Pane", &mp.HideMessagePane)
 
+	if mp.HideMessagePane {
+		imgui.BeginDisabled()
+	}
 	if newFont, changed := renderer.DrawFontPicker(&mp.FontIdentifier, "Font"); changed {
 		mp.font = newFont
 	}
@@ -128,6 +131,9 @@ func (mp *MessagesPane) DrawUI(p platform.Platform, config *platform.Config) {
 	}
 	imgui.Checkbox("Play audio alert after pilot initial contact transmissions", &mp.ContactTransmissionsAlert)
 	imgui.Checkbox("Play audio alert after pilot readback transmissions", &mp.ReadbackTransmissionsAlert)
+	if mp.HideMessagePane {
+		imgui.EndDisabled()
+	}
 }
 
 func (mp *MessagesPane) Draw(ctx *Context, cb *renderer.CommandBuffer) {

--- a/pkg/panes/messages.go
+++ b/pkg/panes/messages.go
@@ -60,7 +60,7 @@ func init() {
 
 func NewMessagesPane() *MessagesPane {
 	return &MessagesPane{
-		FontIdentifier: renderer.FontIdentifier{Name: "Inconsolata Condensed Regular", Size: 15},
+		FontIdentifier: renderer.FontIdentifier{Name: "Inconsolata Condensed Regular", Size: 16},
 
 		HideMessagePane: false,
 	}

--- a/pkg/panes/stars/commands.go
+++ b/pkg/panes/stars/commands.go
@@ -96,7 +96,11 @@ func (c CommandMode) PreviewString() string {
 	case CommandModeMin:
 		return "MIN"
 	case CommandModeTargetGen:
-		return "TG"
+		if !TargetGenLock {
+			return "TG"
+		} else {
+			return "TG LOCK"
+		}
 	case CommandModeReleaseDeparture:
 		return "RD"
 	case CommandModeRestrictionArea:
@@ -160,6 +164,8 @@ type CommandStatus struct {
 	err    error
 }
 
+var TargetGenLock bool
+
 func (sp *STARSPane) processKeyboardInput(ctx *panes.Context, tracks []sim.Track) {
 	if !ctx.HaveFocus || ctx.Keyboard == nil {
 		return
@@ -210,9 +216,11 @@ func (sp *STARSPane) processKeyboardInput(ctx *panes.Context, tracks []sim.Track
 			if status := sp.executeSTARSCommand(ctx, sp.previewAreaInput, tracks); status.err != nil {
 				sp.displayError(status.err, ctx, "")
 			} else {
-				if status.clear {
+				if status.clear && !TargetGenLock {
 					sp.setCommandMode(ctx, CommandModeNone)
 					sp.maybeAutoHomeCursor(ctx)
+				} else {
+					sp.setCommandMode(ctx, CommandModeTargetGen)
 				}
 				sp.previewAreaOutput = status.output
 			}
@@ -222,6 +230,7 @@ func (sp *STARSPane) processKeyboardInput(ctx *panes.Context, tracks []sim.Track
 				sp.setCommandMode(ctx, sp.activeSpinner.EscapeMode())
 			} else {
 				sp.setCommandMode(ctx, CommandModeNone)
+				TargetGenLock = false // unlock target generation
 			}
 
 		case imgui.KeyF1:
@@ -308,7 +317,12 @@ func (sp *STARSPane) processKeyboardInput(ctx *panes.Context, tracks []sim.Track
 			sp.setCommandMode(ctx, CommandModePref)
 
 		case imgui.KeyTab:
-			sp.setCommandMode(ctx, CommandModeTargetGen)
+			if imgui.IsKeyDown(imgui.KeyLeftShift) { // Check if LeftShift is pressed
+				TargetGenLock = true
+				sp.setCommandMode(ctx, CommandModeTargetGen)
+			} else {
+				sp.setCommandMode(ctx, CommandModeTargetGen)
+			}
 		}
 	}
 }
@@ -2313,11 +2327,14 @@ func (sp *STARSPane) executeSTARSCommand(ctx *panes.Context, cmd string, tracks 
 		if trk != nil {
 			sp.runAircraftCommands(ctx, trk.ADSBCallsign, cmds)
 			status.clear = true
+
 		} else {
 			status.err = ErrSTARSIllegalACID
 		}
+
 		return
 	}
+
 	status.err = ErrSTARSCommandFormat
 	return
 }

--- a/pkg/panes/stars/stars.go
+++ b/pkg/panes/stars/stars.go
@@ -774,6 +774,40 @@ func (sp *STARSPane) Draw(ctx *panes.Context, cb *renderer.CommandBuffer) {
 		sp.lastHistoryTrackUpdate = time.Time{}
 		sp.discardTracks = false
 	}
+
+	sp.drawPauseOverlay(ctx, cb)
+}
+
+func (sp *STARSPane) drawPauseOverlay(ctx *panes.Context, cb *renderer.CommandBuffer) {
+	if !ctx.Client.State.Paused {
+		return
+	}
+
+	text := "SIMULATION PAUSED"
+	font := sp.systemFontB[5] // Largest font
+	center := [2]float32{ctx.PaneExtent.Width() / 2, ctx.PaneExtent.Height() / 2}
+
+	quad := renderer.GetColoredTrianglesDrawBuilder()
+	defer renderer.ReturnColoredTrianglesDrawBuilder(quad)
+	quad.AddQuad(
+		[2]float32{center[0] - 150, center[1] - 30}, // Left-top
+		[2]float32{center[0] + 150, center[1] - 30}, // Right-top
+		[2]float32{center[0] + 150, center[1] + 30}, // Right-bottom
+		[2]float32{center[0] - 150, center[1] + 30}, // Left-bottom
+		renderer.RGB{R: 1, G: 0, B: 0})              // Solid red
+
+	td := renderer.GetTextDrawBuilder()
+	defer renderer.ReturnTextDrawBuilder(td)
+	td.AddTextCentered(text, center, renderer.TextStyle{
+		Font:  font,
+		Color: renderer.RGB{R: 1, G: 1, B: 1},
+	})
+
+	// draws
+	transforms := GetScopeTransformations(ctx.PaneExtent, 0, 0, [2]float32{}, 0, 0)
+	transforms.LoadWindowViewingMatrices(cb)
+	quad.GenerateCommands(cb)
+	td.GenerateCommands(cb)
 }
 
 func (sp *STARSPane) drawWX(ctx *panes.Context, transforms ScopeTransformations, cb *renderer.CommandBuffer) {

--- a/pkg/panes/stars/stars.go
+++ b/pkg/panes/stars/stars.go
@@ -784,26 +784,37 @@ func (sp *STARSPane) drawPauseOverlay(ctx *panes.Context, cb *renderer.CommandBu
 	}
 
 	text := "SIMULATION PAUSED"
-	font := sp.systemFontB[5] // Largest font
-	center := [2]float32{ctx.PaneExtent.Width() / 2, ctx.PaneExtent.Height() / 2}
+	font := sp.systemFontA[3] // Largest font
 
+	// Get pane width
+	width := ctx.PaneExtent.Width()
+	height := ctx.PaneExtent.Height()
+
+	// Fixed position from top
+	topOffset := height - 140
+	textY := topOffset + 30      // Text will be 30px below top (in middle of background quad)
+	quadTop := topOffset + 45    // Background extends 15px above text
+	quadBottom := topOffset + 15 // Background extends 15px below text
+
+	// Draw background quad (fixed width of 360px centered horizontally)
 	quad := renderer.GetColoredTrianglesDrawBuilder()
 	defer renderer.ReturnColoredTrianglesDrawBuilder(quad)
 	quad.AddQuad(
-		[2]float32{center[0] - 150, center[1] - 30}, // Left-top
-		[2]float32{center[0] + 150, center[1] - 30}, // Right-top
-		[2]float32{center[0] + 150, center[1] + 30}, // Right-bottom
-		[2]float32{center[0] - 150, center[1] + 30}, // Left-bottom
-		renderer.RGB{R: 1, G: 0, B: 0})              // Solid red
+		[2]float32{width/2 - 180, quadTop},    // Left-top
+		[2]float32{width/2 + 180, quadTop},    // Right-top
+		[2]float32{width/2 + 180, quadBottom}, // Right-bottom
+		[2]float32{width/2 - 180, quadBottom}, // Left-bottom
+		renderer.RGB{R: 1, G: 0, B: 0})        // Solid red
 
+	// Draw text
 	td := renderer.GetTextDrawBuilder()
 	defer renderer.ReturnTextDrawBuilder(td)
-	td.AddTextCentered(text, center, renderer.TextStyle{
+	td.AddTextCentered(text, [2]float32{width / 2, textY}, renderer.TextStyle{
 		Font:  font,
 		Color: renderer.RGB{R: 1, G: 1, B: 1},
 	})
 
-	// draws
+	// Apply transformations and draw
 	transforms := GetScopeTransformations(ctx.PaneExtent, 0, 0, [2]float32{}, 0, 0)
 	transforms.LoadWindowViewingMatrices(cb)
 	quad.GenerateCommands(cb)


### PR DESCRIPTION
Add option to hide messages pane

I ran into a bug where hiding the pane stops the transmission audio as expected, but when I show the pane again, it plays all the transmissions that were missed while it was hidden. Right now, the only way I’ve found to avoid this is to automatically uncheck the radio transmission option when the pane is hidden.

![image](https://github.com/user-attachments/assets/ff2fc91a-82a1-408c-bd7e-6bfa199c22e2)
