### PR TITLE
Ability to Type While Aircraft is Speaking

### DIFF
--- a/pkg/panes/stars/commands.go
+++ b/pkg/panes/stars/commands.go
@@ -186,10 +186,7 @@ func (sp *STARSPane) processKeyboardInput(ctx *panes.Context, tracks []sim.Track
 	}
 
 	if sp.commandMode == CommandModeTargetGen || sp.commandMode == CommandModeTargetGenLock {
-		if ctx.Client.RadioIsActive() {
-			// Discard entered TGT GEN text if we're awaiting a readback
-			input = ""
-		} else if input != "" {
+		if input != "" {
 			// As long as text is being entered, hold radio transmissions
 			// for the coming few seconds.
 			ctx.Client.HoldRadioTransmissions()


### PR DESCRIPTION
Exactly as described, I added the ability for users to type commands while an aircraft is speaking. 

(Many people, including myself, found it difficult to issue commands to aircraft in a busy environment when typing was locked)