### PR TITLE
Fix Error Loading Single Player Scenarios

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -630,6 +630,7 @@ func (c *NewSimConfiguration) Start() error {
 		}
 	} else {
 		// Create sim configuration for new sim
+		c.IsLocal = (c.newSimType == NewSimCreateLocal)
 		if err := c.mgr.CreateNewSim(c.NewSimConfiguration, c.selectedServer, c.lg); err != nil {
 			c.lg.Errorf("CreateNewSim failed: %v", err)
 			return err


### PR DESCRIPTION
`IsLocal` was never set, so Go defaulted it to false. 

A check if the sim was local was added to `NewSimConfiguration.Start()`