### PR TITLE
fix assigned alt

### DIFF
--- a/pkg/aviation/aviation.go
+++ b/pkg/aviation/aviation.go
@@ -769,13 +769,16 @@ func (ar *Arrival) PostDeserialize(loc Locator, nmPerLongitude float32, magnetic
 	if ar.AssignedAltitude == 0 {
 		// check the route to see altitude restrictions
 		wps := []Waypoint(ar.Waypoints)
+		altitudeRestriction := false 
 		for _, wp := range wps {
 			if wp.AltitudeRestriction != nil {
+				altitudeRestriction = true
 				break
 			}
+		}
+		if !altitudeRestriction {
 			// If there are no altitude restrictions or an assigned altitude,
 			e.ErrorString("must specify \"assigned_altitude\" or have altitude restrictions in the route")
-			break
 		}
 	}
 

--- a/pkg/aviation/aviation.go
+++ b/pkg/aviation/aviation.go
@@ -773,7 +773,7 @@ func (ar *Arrival) PostDeserialize(loc Locator, nmPerLongitude float32, magnetic
 			if wp.AltitudeRestriction != nil {
 				break
 			}
-			// If there are no altitude restrictions or an assigned altitude, 
+			// If there are no altitude restrictions or an assigned altitude,
 			e.ErrorString("must specify \"assigned_altitude\" or have altitude restrictions in the route")
 			break
 		}

--- a/pkg/aviation/aviation.go
+++ b/pkg/aviation/aviation.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"maps"
-	gomath "math"
 	"slices"
 	"strconv"
 	"strings"
@@ -769,22 +768,15 @@ func (ar *Arrival) PostDeserialize(loc Locator, nmPerLongitude float32, magnetic
 	}
 	if ar.AssignedAltitude == 0 {
 		// check the route to see altitude restrictions
-		var lowestAlt int
 		wps := []Waypoint(ar.Waypoints)
-		lowest := gomath.MaxInt
 		for _, wp := range wps {
 			if wp.AltitudeRestriction != nil {
-				if wp.AltitudeRestriction.TargetAltitude(ar.InitialAltitude) > float32(lowest) {
-					lowestAlt = int(wp.AltitudeRestriction.TargetAltitude(ar.InitialAltitude))
-				}
+				break
 			}
-		}
-		if lowestAlt == gomath.MaxInt {
+			// If there are no altitude restrictions or an assigned altitude, 
 			e.ErrorString("must specify \"assigned_altitude\" or have altitude restrictions in the route")
-		} else {
-			ar.AssignedAltitude = float32(lowestAlt)
+			break
 		}
-
 	}
 
 	for i := range ar.Waypoints {


### PR DESCRIPTION
If `assigned_altitude` was never set in an inbound route, the assigned altitude in the arrival struct would be zero, despite if crossing restrictions were in the route. This PR addresses that issue. 