### PR TITLE
fix: maintain control of a/c that doesn't contact tower

### DIFF
--- a/pkg/sim/control.go
+++ b/pkg/sim/control.go
@@ -1268,8 +1268,11 @@ func (s *Sim) ContactTower(tcp string, callsign av.ADSBCallsign) error {
 
 	return s.dispatchControlledAircraftCommand(tcp, callsign,
 		func(tcp string, ac *Aircraft) *speech.RadioTransmission {
-			ac.STARSFlightPlan.ControllingController = "_TOWER"
-			return setTransmissionController(tcp, ac.ContactTower(s.lg))
+			result := ac.ContactTower(s.lg)
+			if result.Type != speech.RadioTransmissionUnexpected {
+				ac.STARSFlightPlan.ControllingController = "_TOWER"
+			}
+			return setTransmissionController(tcp, result)
 		})
 
 }


### PR DESCRIPTION
Fixes #664

Not sure if the call to `setTransmissionController` needs to be changed but this seems to work