### PR TITLE
fix: climb virtual controlled a/c to cruise

### DIFF
--- a/pkg/sim/control.go
+++ b/pkg/sim/control.go
@@ -647,6 +647,21 @@ func (s *Sim) handoffTrack(fp *STARSFlightPlan, toTCP string) {
 	s.Handoffs[fp.ACID] = Handoff{
 		AutoAcceptTime: s.State.SimTime.Add(time.Duration(acceptDelay) * time.Second),
 	}
+	callsign := func() av.ADSBCallsign {
+		// ugly way to do this but using s.CallsignForACID here causes vice to crash
+		for _, aircraft := range s.Aircraft {
+			if aircraft.STARSFlightPlan.ACID == fp.ACID {
+				return aircraft.ADSBCallsign
+			}
+		}
+		return av.ADSBCallsign("")
+	}()
+	if fp.TypeOfFlight == av.FlightTypeDeparture && !s.isActiveHumanController(fp.TrackingController) && !s.isActiveHumanController(toTCP) {
+		if callsign != "" {
+			// aircraft is a departure that will likely never talk to a human, send it on course (mainly so it climbs up to cruise)
+			s.enqueueDepartOnCourse(callsign)
+		}
+	}
 }
 
 func (s *Sim) ContactTrackingController(tcp string, acid ACID) error {


### PR DESCRIPTION
Previously, aircraft that were entirely controlled by virtual controllers would not climb to cruise due to `DepartOnCourse` never being called for them. This fixes that by calling it for any departure handed off from one virtual controller to another, since these aircraft will likely never talk to a human controller