### PR TITLE
fix: correct phraseology for departure initial contacts

### DIFF
--- a/pkg/sim/nav.go
+++ b/pkg/sim/nav.go
@@ -648,9 +648,9 @@ func (nav *Nav) DepartureMessage() *speech.RadioTransmission {
 	target := util.Select(nav.Altitude.Assigned != nil, nav.Altitude.Assigned, nav.Altitude.Cleared)
 	if target != nil && *target-nav.FlightState.Altitude > 100 {
 		// one of the two should be set, but just in case...
-		return speech.MakeReadbackTransmission("at {alt} climbing {alt}", nav.FlightState.Altitude, *target)
+		return speech.MakeContactTransmission("at {alt} climbing {alt}", nav.FlightState.Altitude, *target)
 	} else {
-		return speech.MakeReadbackTransmission("at {alt}", nav.FlightState.Altitude)
+		return speech.MakeContactTransmission("at {alt}", nav.FlightState.Altitude)
 	}
 }
 


### PR DESCRIPTION
Quick fix that corrects the phraseology for departure initial contact messages by using `MakeContactTransmission` rather than `MakeReadbackTransmission`