### PR TITLE
scenario: add another nil check for `a.VerticiesStr.B`

### DIFF
--- a/aviation/airspace.go
+++ b/aviation/airspace.go
@@ -138,7 +138,7 @@ func (a *AirspaceVolume) PostDeserialize(loc Locator, e *util.ErrorLogger) {
 			var vstrs []string
 			if a.VerticesStr.A != nil { // single string provided
 				vstrs = strings.Fields(*a.VerticesStr.A)
-			} else {
+			} else if a.VerticesStr.B != nil {
 				vstrs = *a.VerticesStr.B
 			}
 			if len(vstrs) == 0 {


### PR DESCRIPTION
When verticies aren't defined *vice* ends up panicking instead of returning the ErrorString.