### PR TITLE
Use sim time instead of wall clock time for deferred nav headings

### DIFF
--- a/nav/approach.go
+++ b/nav/approach.go
@@ -451,7 +451,7 @@ func (nav *Nav) prepareForChartedVisual() av.CommandIntent {
 	return av.MakeUnableIntent("unable. We are not on course to intercept the approach")
 }
 
-func (nav *Nav) ClearedApproach(airport string, id string, straightIn bool) (av.CommandIntent, bool) {
+func (nav *Nav) ClearedApproach(airport string, id string, straightIn bool, simTime time.Time) (av.CommandIntent, bool) {
 	ap := nav.Approach.Assigned
 	if ap == nil {
 		return av.MakeUnableIntent("unable. We haven't been told to expect an approach"), false
@@ -481,9 +481,8 @@ func (nav *Nav) ClearedApproach(airport string, id string, straightIn bool) (av.
 	// Follow LNAV instructions more quickly given an approach clearance;
 	// assume that at this point they are expecting them and ready to dial things in.
 	if dh := nav.DeferredNavHeading; dh != nil {
-		now := time.Now()
-		if dh.Time.Sub(now) > 6*time.Second {
-			dh.Time = now.Add(time.Duration((3 + 3*nav.Rand.Float32()) * float32(time.Second)))
+		if dh.Time.Sub(simTime) > 6*time.Second {
+			dh.Time = simTime.Add(time.Duration((3 + 3*nav.Rand.Float32()) * float32(time.Second)))
 		}
 	}
 

--- a/nav/lateral.go
+++ b/nav/lateral.go
@@ -81,7 +81,7 @@ func (nav *Nav) updatePositionAndGS(wxs wx.Sample) {
 	nav.FlightState.GS = math.Length2f(math.Add2f(flightVector, windVector)) * 3600
 }
 
-func (nav *Nav) DepartOnCourse(alt float32, exit string) {
+func (nav *Nav) DepartOnCourse(alt float32, exit string, simTime time.Time) {
 	if _, ok := nav.AssignedHeading(); !ok {
 		// Don't do anything if they are not on a heading; let them fly the
 		// regular route and don't (potentially) skip waypoints and go
@@ -101,7 +101,7 @@ func (nav *Nav) DepartOnCourse(alt float32, exit string) {
 	}
 	nav.Altitude = NavAltitude{Assigned: &alt}
 	nav.Speed = NavSpeed{}
-	nav.EnqueueOnCourse()
+	nav.EnqueueOnCourse(simTime)
 }
 
 func (nav *Nav) Check(lg *log.Logger) {
@@ -159,7 +159,7 @@ func (nav *Nav) TargetHeading(callsign string, wxs wx.Sample, simTime time.Time)
 	}
 
 	// Is it time to start following a heading or direct to a fix recently issued by the controller?
-	if dh := nav.DeferredNavHeading; dh != nil && time.Now().After(dh.Time) {
+	if dh := nav.DeferredNavHeading; dh != nil && simTime.After(dh.Time) {
 		nav.Heading = NavHeading{Assigned: dh.Heading, Turn: dh.Turn, Hold: dh.Hold} // these may be nil
 		if len(dh.Waypoints) > 0 {
 			nav.Waypoints = dh.Waypoints
@@ -393,7 +393,7 @@ func (nav *Nav) updateWaypoints(callsign string, wxs wx.Sample, fp *av.FlightPla
 
 		if wp.ClearApproach {
 			if fp != nil {
-				_, _ = nav.ClearedApproach(fp.ArrivalAirport, nav.Approach.AssignedId, false)
+				_, _ = nav.ClearedApproach(fp.ArrivalAirport, nav.Approach.AssignedId, false, simTime)
 			}
 		}
 

--- a/sim/aircraft.go
+++ b/sim/aircraft.go
@@ -257,13 +257,13 @@ func (ac *Aircraft) ExpediteClimb() av.CommandIntent {
 	return ac.Nav.ExpediteClimb()
 }
 
-func (ac *Aircraft) AssignHeading(heading int, turn nav.TurnMethod) av.CommandIntent {
-	return ac.Nav.AssignHeading(float32(heading), turn)
+func (ac *Aircraft) AssignHeading(heading int, turn nav.TurnMethod, simTime time.Time) av.CommandIntent {
+	return ac.Nav.AssignHeading(float32(heading), turn, simTime)
 }
 
-func (ac *Aircraft) TurnLeft(deg int) av.CommandIntent {
+func (ac *Aircraft) TurnLeft(deg int, simTime time.Time) av.CommandIntent {
 	hdg := math.NormalizeHeading(ac.Nav.FlightState.Heading - float32(deg))
-	ac.Nav.AssignHeading(hdg, nav.TurnLeft)
+	ac.Nav.AssignHeading(hdg, nav.TurnLeft, simTime)
 	return av.HeadingIntent{
 		Type:    av.HeadingTurnLeft,
 		Heading: hdg,
@@ -271,9 +271,9 @@ func (ac *Aircraft) TurnLeft(deg int) av.CommandIntent {
 	}
 }
 
-func (ac *Aircraft) TurnRight(deg int) av.CommandIntent {
+func (ac *Aircraft) TurnRight(deg int, simTime time.Time) av.CommandIntent {
 	hdg := math.NormalizeHeading(ac.Nav.FlightState.Heading + float32(deg))
-	ac.Nav.AssignHeading(hdg, nav.TurnRight)
+	ac.Nav.AssignHeading(hdg, nav.TurnRight, simTime)
 	return av.HeadingIntent{
 		Type:    av.HeadingTurnRight,
 		Heading: hdg,
@@ -281,12 +281,12 @@ func (ac *Aircraft) TurnRight(deg int) av.CommandIntent {
 	}
 }
 
-func (ac *Aircraft) FlyPresentHeading() av.CommandIntent {
-	return ac.Nav.FlyPresentHeading()
+func (ac *Aircraft) FlyPresentHeading(simTime time.Time) av.CommandIntent {
+	return ac.Nav.FlyPresentHeading(simTime)
 }
 
-func (ac *Aircraft) DirectFix(fix string) av.CommandIntent {
-	return ac.Nav.DirectFix(strings.ToUpper(fix))
+func (ac *Aircraft) DirectFix(fix string, simTime time.Time) av.CommandIntent {
+	return ac.Nav.DirectFix(strings.ToUpper(fix), simTime)
 }
 
 func (ac *Aircraft) HoldAtFix(fix string, hold *av.Hold) av.CommandIntent {
@@ -317,24 +317,24 @@ func (ac *Aircraft) AtFixIntercept(fix string, lg *log.Logger) av.CommandIntent 
 	return ac.Nav.AtFixIntercept(fix, ac.FlightPlan.ArrivalAirport, lg)
 }
 
-func (ac *Aircraft) ClearedApproach(id string, lg *log.Logger) (av.CommandIntent, bool) {
-	return ac.Nav.ClearedApproach(ac.FlightPlan.ArrivalAirport, id, false)
+func (ac *Aircraft) ClearedApproach(id string, simTime time.Time, lg *log.Logger) (av.CommandIntent, bool) {
+	return ac.Nav.ClearedApproach(ac.FlightPlan.ArrivalAirport, id, false, simTime)
 }
 
-func (ac *Aircraft) ClearedStraightInApproach(id string, lg *log.Logger) (av.CommandIntent, bool) {
-	return ac.Nav.ClearedApproach(ac.FlightPlan.ArrivalAirport, id, true)
+func (ac *Aircraft) ClearedStraightInApproach(id string, simTime time.Time, lg *log.Logger) (av.CommandIntent, bool) {
+	return ac.Nav.ClearedApproach(ac.FlightPlan.ArrivalAirport, id, true, simTime)
 }
 
 func (ac *Aircraft) CancelApproachClearance() av.CommandIntent {
 	return ac.Nav.CancelApproachClearance()
 }
 
-func (ac *Aircraft) ClimbViaSID() av.CommandIntent {
-	return ac.Nav.ClimbViaSID()
+func (ac *Aircraft) ClimbViaSID(simTime time.Time) av.CommandIntent {
+	return ac.Nav.ClimbViaSID(simTime)
 }
 
-func (ac *Aircraft) DescendViaSTAR() av.CommandIntent {
-	return ac.Nav.DescendViaSTAR()
+func (ac *Aircraft) DescendViaSTAR(simTime time.Time) av.CommandIntent {
+	return ac.Nav.DescendViaSTAR(simTime)
 }
 
 func (ac *Aircraft) ResumeOwnNavigation() av.CommandIntent {
@@ -524,11 +524,11 @@ func (ac *Aircraft) ContactMessage(reportingPoints []av.ReportingPoint) *av.Radi
 	return ac.Nav.ContactMessage(reportingPoints, ac.STAR, reportHeading, ac.IsDeparture())
 }
 
-func (ac *Aircraft) DepartOnCourse(lg *log.Logger) {
+func (ac *Aircraft) DepartOnCourse(simTime time.Time, lg *log.Logger) {
 	if ac.FlightPlan.Exit == "" {
 		lg.Warn("unset \"exit\" for departure", slog.String("adsb_callsign", string(ac.ADSBCallsign)))
 	}
-	ac.Nav.DepartOnCourse(float32(ac.FlightPlan.Altitude), ac.FlightPlan.Exit)
+	ac.Nav.DepartOnCourse(float32(ac.FlightPlan.Altitude), ac.FlightPlan.Exit, simTime)
 }
 
 func (ac *Aircraft) Check(lg *log.Logger) {

--- a/sim/control.go
+++ b/sim/control.go
@@ -1316,13 +1316,13 @@ func (s *Sim) AssignHeading(hdg *HeadingArgs) (av.CommandIntent, error) {
 	return s.dispatchControlledAircraftCommand(hdg.TCW, hdg.ADSBCallsign,
 		func(tcw TCW, ac *Aircraft) av.CommandIntent {
 			if hdg.Present {
-				return ac.FlyPresentHeading()
+				return ac.FlyPresentHeading(s.State.SimTime)
 			} else if hdg.LeftDegrees != 0 {
-				return ac.TurnLeft(hdg.LeftDegrees)
+				return ac.TurnLeft(hdg.LeftDegrees, s.State.SimTime)
 			} else if hdg.RightDegrees != 0 {
-				return ac.TurnRight(hdg.RightDegrees)
+				return ac.TurnRight(hdg.RightDegrees, s.State.SimTime)
 			} else {
-				return ac.AssignHeading(hdg.Heading, hdg.Turn)
+				return ac.AssignHeading(hdg.Heading, hdg.Turn, s.State.SimTime)
 			}
 		})
 }
@@ -1433,7 +1433,7 @@ func (s *Sim) DirectFix(tcw TCW, callsign av.ADSBCallsign, fix string) (av.Comma
 
 	return s.dispatchControlledAircraftCommand(tcw, callsign,
 		func(tcw TCW, ac *Aircraft) av.CommandIntent {
-			return ac.DirectFix(fix)
+			return ac.DirectFix(fix, s.State.SimTime)
 		})
 }
 
@@ -1524,9 +1524,9 @@ func (s *Sim) ClearedApproach(tcw TCW, callsign av.ADSBCallsign, approach string
 			var intent av.CommandIntent
 			var ok bool
 			if straightIn {
-				intent, ok = ac.ClearedStraightInApproach(approach, s.lg)
+				intent, ok = ac.ClearedStraightInApproach(approach, s.State.SimTime, s.lg)
 			} else {
-				intent, ok = ac.ClearedApproach(approach, s.lg)
+				intent, ok = ac.ClearedApproach(approach, s.State.SimTime, s.lg)
 			}
 
 			if ok {
@@ -1562,7 +1562,7 @@ func (s *Sim) ClimbViaSID(tcw TCW, callsign av.ADSBCallsign) (av.CommandIntent, 
 
 	return s.dispatchControlledAircraftCommand(tcw, callsign,
 		func(tcw TCW, ac *Aircraft) av.CommandIntent {
-			return ac.ClimbViaSID()
+			return ac.ClimbViaSID(s.State.SimTime)
 		})
 }
 
@@ -1572,7 +1572,7 @@ func (s *Sim) DescendViaSTAR(tcw TCW, callsign av.ADSBCallsign) (av.CommandInten
 
 	return s.dispatchControlledAircraftCommand(tcw, callsign,
 		func(tcw TCW, ac *Aircraft) av.CommandIntent {
-			return ac.DescendViaSTAR()
+			return ac.DescendViaSTAR(s.State.SimTime)
 		})
 }
 
@@ -2349,7 +2349,7 @@ func (s *Sim) processFutureEvents() {
 						ac.NASFlightPlan.InterimAlt = 0
 						ac.NASFlightPlan.InterimType = 0
 					}
-					ac.DepartOnCourse(s.lg)
+					ac.DepartOnCourse(s.State.SimTime, s.lg)
 				}
 				return false
 			}


### PR DESCRIPTION
I noticed strange behavior (delays, overshoot, etc.) when fast-forwarding the sim or returning to a session after my laptop went to sleep. I found the comment on DeferredNavHeading noting that it should use sim time rather than wall clock time, and Claude helped me plumb simTime through everywhere it's needed.

All tests pass, and from playing around with the sim (proceed direct, cleared approach, etc), it seems the weirdness when fast-forwarding is now resolved. 

Let me know if I should test anything else or if you need changes to this. I love vice, so I am looking to contribute more in the future as well.

```
?   	github.com/mmp/vice/autowhisper	[no test files]
?   	github.com/mmp/vice/autowhisper/internal/whisper	[no test files]
?   	github.com/mmp/vice/autowhisper/internal/whisperlow	[no test files]
ok  	github.com/mmp/vice/aviation	0.203s
?   	github.com/mmp/vice/client	[no test files]
?   	github.com/mmp/vice/cmd/bundleresources	[no test files]
?   	github.com/mmp/vice/cmd/crc2vice	[no test files]
?   	github.com/mmp/vice/cmd/crc2vice-eram	[no test files]
?   	github.com/mmp/vice/cmd/dat2vice	[no test files]
?   	github.com/mmp/vice/cmd/sttreview	[no test files]
?   	github.com/mmp/vice/cmd/sttsim	[no test files]
?   	github.com/mmp/vice/cmd/stttest	[no test files]
?   	github.com/mmp/vice/cmd/updatesay	[no test files]
?   	github.com/mmp/vice/cmd/vice	[no test files]
?   	github.com/mmp/vice/cmd/wxgridviz	[no test files]
?   	github.com/mmp/vice/cmd/wxingest	[no test files]
?   	github.com/mmp/vice/cmd/wxpackage	[no test files]
?   	github.com/mmp/vice/cmd/wxscrape	[no test files]
?   	github.com/mmp/vice/eram	[no test files]
?   	github.com/mmp/vice/log	[no test files]
ok  	github.com/mmp/vice/math	0.289s
?   	github.com/mmp/vice/nav	[no test files]
?   	github.com/mmp/vice/panes	[no test files]
?   	github.com/mmp/vice/platform	[no test files]
?   	github.com/mmp/vice/radar	[no test files]
ok  	github.com/mmp/vice/rand	0.409s
?   	github.com/mmp/vice/renderer	[no test files]
?   	github.com/mmp/vice/server	[no test files]
ok  	github.com/mmp/vice/sim	0.556s
?   	github.com/mmp/vice/stars	[no test files]
ok  	github.com/mmp/vice/stt	1.928s
ok  	github.com/mmp/vice/util	0.833s
?   	github.com/mmp/vice/windows	[no test files]
ok  	github.com/mmp/vice/wx	0.988s
```