### PR TITLE
Add visual approach requests (controller-initiated and pilot-spontaneous) #583

### DIFF
--- a/aviation/intent.go
+++ b/aviation/intent.go
@@ -783,17 +783,20 @@ func (m MixUpIntent) Render(rt *RadioTransmission, r *rand.Rand) {
 ///////////////////////////////////////////////////////////////////////////
 // FieldInSight Intent
 
-// FieldInSightIntent represents a pilot's response to "do you have the field in sight?"
+// FieldInSightIntent represents a pilot's response to an AP (airport advisory) command.
+// The pilot may report "field in sight", "looking", or an IMC response.
 type FieldInSightIntent struct {
-	HasField bool   // true if VMC and field in sight
-	Runway   string // runway for the visual approach (if HasField)
+	HasField bool // true if pilot can see the airport
+	Looking  bool // true if pilot says "looking" (can't see yet but not IMC)
 }
 
 func (f FieldInSightIntent) Render(rt *RadioTransmission, r *rand.Rand) {
 	if f.HasField {
-		rt.Add("affirmative, [field in sight|we have the field in sight|we have the airport], runway {rwy}", f.Runway)
+		rt.Add("[field in sight|we have the field in sight|we have the airport in sight]")
+	} else if f.Looking {
+		rt.Add("[looking|looking for it]")
 	} else {
-		rt.Add("negative, [we're in the clouds|we're IMC|we don't have the field]")
+		rt.Add("[we're in the clouds|we're IMC|we don't have the field]")
 	}
 }
 

--- a/aviation/intent.go
+++ b/aviation/intent.go
@@ -781,7 +781,21 @@ func (m MixUpIntent) Render(rt *RadioTransmission, r *rand.Rand) {
 }
 
 ///////////////////////////////////////////////////////////////////////////
-// RenderIntents
+// FieldInSight Intent
+
+// FieldInSightIntent represents a pilot's response to "do you have the field in sight?"
+type FieldInSightIntent struct {
+	HasField bool   // true if VMC and field in sight
+	Runway   string // runway for the visual approach (if HasField)
+}
+
+func (f FieldInSightIntent) Render(rt *RadioTransmission, r *rand.Rand) {
+	if f.HasField {
+		rt.Add("affirmative, [field in sight|we have the field in sight|we have the airport], runway {rwy}", f.Runway)
+	} else {
+		rt.Add("negative, [we're in the clouds|we're IMC|we don't have the field]")
+	}
+}
 
 // RenderIntents converts a slice of CommandIntents into a single coherent RadioTransmission.
 // It handles merging related intents (e.g., altitude + expedite), PTACs, etc., for more

--- a/aviation/intent.go
+++ b/aviation/intent.go
@@ -7,6 +7,7 @@ package aviation
 import (
 	"reflect"
 	"slices"
+	"strings"
 
 	"github.com/mmp/vice/math"
 	"github.com/mmp/vice/rand"
@@ -531,7 +532,11 @@ type ApproachIntent struct {
 func (a ApproachIntent) Render(rt *RadioTransmission, r *rand.Rand) {
 	switch a.Type {
 	case ApproachExpect:
-		rt.Add("[we'll expect the|expecting the|we'll plan for the] {appr} approach", a.ApproachName)
+		suffix := " approach"
+		if strings.Contains(strings.ToLower(a.ApproachName), "approach") {
+			suffix = ""
+		}
+		rt.Add("[we'll expect the|expecting the|we'll plan for the] {appr}"+suffix, a.ApproachName)
 		if a.LAHSORunway != "" {
 			rt.Add("[and we'll hold short of|hold short of] runway {rwy}", a.LAHSORunway)
 		}
@@ -561,10 +566,17 @@ func (c ClearedApproachIntent) Render(rt *RadioTransmission, r *rand.Rand) {
 		prefix = "cancel [the|] hold, "
 	}
 
+	// Visual approaches include "approach" in the name (e.g. "visual approach runway 22L"),
+	// so skip the trailing [approach|] to avoid "approach approach".
+	suffix := " [approach|]"
+	if strings.Contains(strings.ToLower(c.Approach), "approach") {
+		suffix = ""
+	}
+
 	if c.StraightIn {
-		rt.Add(prefix+"cleared straight in {appr} [approach|]", c.Approach)
+		rt.Add(prefix+"cleared straight in {appr}"+suffix, c.Approach)
 	} else {
-		rt.Add(prefix+"cleared {appr} [approach|]", c.Approach)
+		rt.Add(prefix+"cleared {appr}"+suffix, c.Approach)
 	}
 }
 

--- a/cmd/vice/ui.go
+++ b/cmd/vice/ui.go
@@ -480,6 +480,8 @@ var secondaryAcCommands = [][3]string{
 	{"*CAC*", `"Cancel approach clearance".`, "*CAC*"},
 	{"*CSI_appr", `"Cleared straight-in _appr_ approach.`, "*CSII6*"},
 	{"*I*", `"Intercept the localizer."`, "*I*"},
+	{"*CV_rwy*", `"Cleared visual approach runway _rwy_."`, "*CV13L*"},
+	{"*FS*", `"Do you have the field in sight?"`, "*FS*"},
 	{"*ID*", `"Ident."`, "*ID*"},
 	{"*CVS*", `"Climb via the SID"`, "*CVS*"},
 	{"*DVS*", `"Descend via the STAR"`, "*CVS*"},

--- a/cmd/vice/ui.go
+++ b/cmd/vice/ui.go
@@ -480,7 +480,7 @@ var secondaryAcCommands = [][3]string{
 	{"*CAC*", `"Cancel approach clearance".`, "*CAC*"},
 	{"*CSI_appr", `"Cleared straight-in _appr_ approach.`, "*CSII6*"},
 	{"*I*", `"Intercept the localizer."`, "*I*"},
-	{"*CV_rwy*", `"Cleared visual approach runway _rwy_." Requires field in sight, visual request, or traffic in sight.`, "*CV13L*"},
+	{"*CVA_rwy*", `"Cleared visual approach runway _rwy_." Requires field in sight, visual request, or traffic in sight.`, "*CVA13L*"},
 	{"*AP/_oclock_/_miles_*", `"Airport, _oclock_ o'clock, _miles_ miles." Pilot responds with field in sight or looking.`, "*AP/12/5*"},
 	{"*ID*", `"Ident."`, "*ID*"},
 	{"*CVS*", `"Climb via the SID"`, "*CVS*"},

--- a/cmd/vice/ui.go
+++ b/cmd/vice/ui.go
@@ -480,7 +480,7 @@ var secondaryAcCommands = [][3]string{
 	{"*CAC*", `"Cancel approach clearance".`, "*CAC*"},
 	{"*CSI_appr", `"Cleared straight-in _appr_ approach.`, "*CSII6*"},
 	{"*I*", `"Intercept the localizer."`, "*I*"},
-	{"*CV_rwy*", `"Cleared visual approach runway _rwy_."`, "*CV13L*"},
+	{"*CV_rwy*", `"Cleared visual approach runway _rwy_." Requires field in sight, visual request, or traffic in sight.`, "*CV13L*"},
 	{"*AP/_oclock_/_miles_*", `"Airport, _oclock_ o'clock, _miles_ miles." Pilot responds with field in sight or looking.`, "*AP/12/5*"},
 	{"*ID*", `"Ident."`, "*ID*"},
 	{"*CVS*", `"Climb via the SID"`, "*CVS*"},

--- a/cmd/vice/ui.go
+++ b/cmd/vice/ui.go
@@ -481,7 +481,7 @@ var secondaryAcCommands = [][3]string{
 	{"*CSI_appr", `"Cleared straight-in _appr_ approach.`, "*CSII6*"},
 	{"*I*", `"Intercept the localizer."`, "*I*"},
 	{"*CV_rwy*", `"Cleared visual approach runway _rwy_."`, "*CV13L*"},
-	{"*FS*", `"Do you have the field in sight?"`, "*FS*"},
+	{"*AP/_oclock_/_miles_*", `"Airport, _oclock_ o'clock, _miles_ miles." Pilot responds with field in sight or looking.`, "*AP/12/5*"},
 	{"*ID*", `"Ident."`, "*ID*"},
 	{"*CVS*", `"Climb via the SID"`, "*CVS*"},
 	{"*DVS*", `"Descend via the STAR"`, "*CVS*"},

--- a/math/latlong.go
+++ b/math/latlong.go
@@ -25,6 +25,7 @@ func NMPerLongitudeAt(p Point2LL) float32 {
 
 const NauticalMilesToFeet = 6076.12
 const FeetToNauticalMiles = 1 / NauticalMilesToFeet
+const StatuteMilesToNauticalMiles = float32(1 / 1.15078)
 
 // Point2LL represents a 2D point on the Earth in latitude-longitude.
 // Important: 0 (x) is longitude, 1 (y) is latitude

--- a/math/latlong.go
+++ b/math/latlong.go
@@ -25,7 +25,7 @@ func NMPerLongitudeAt(p Point2LL) float32 {
 
 const NauticalMilesToFeet = 6076.12
 const FeetToNauticalMiles = 1 / NauticalMilesToFeet
-const StatuteMilesToNauticalMiles = float32(1 / 1.15078)
+const StatuteMilesToNauticalMiles = 1 / 1.15078
 
 // Point2LL represents a 2D point on the Earth in latitude-longitude.
 // Important: 0 (x) is longitude, 1 (y) is latitude

--- a/nav/approach.go
+++ b/nav/approach.go
@@ -625,7 +625,7 @@ func (nav *Nav) ClearedDirectVisual(runway string, simTime time.Time) (av.Comman
 	nav.Speed = NavSpeed{}
 
 	return av.ClearedApproachIntent{
-		Approach:   "visual runway " + runway,
+		Approach:   "Visual Approach Runway " + runway,
 		CancelHold: cancelHold,
 	}, true
 }

--- a/nav/approach.go
+++ b/nav/approach.go
@@ -581,7 +581,7 @@ func (nav *Nav) buildDirectVisualWaypoints(runway string) []av.Waypoint {
 		Location: final3nm,
 	}
 	finalWp.SetOnApproach(true)
-	finalWp.SetAltitudeRestriction(av.AltitudeRestriction{Range: [2]float32{final3nmAlt, 0}})
+	finalWp.SetAltitudeRestriction(av.AltitudeRestriction{Range: [2]float32{final3nmAlt, final3nmAlt}})
 
 	thresholdWp := av.Waypoint{
 		Fix:      "_" + runway + "_THRESHOLD",

--- a/nav/approach.go
+++ b/nav/approach.go
@@ -453,7 +453,7 @@ func (nav *Nav) prepareForChartedVisual() av.CommandIntent {
 	}
 
 	// Update the route and go direct to the intercept/first point.
-	nav.Waypoints = wi
+	nav.Waypoints = append(wi, nav.FlightState.ArrivalAirport)
 	nav.Heading = NavHeading{}
 	nav.DeferredNavHeading = nil
 	return nil

--- a/nav/approach.go
+++ b/nav/approach.go
@@ -441,15 +441,22 @@ func (nav *Nav) prepareForChartedVisual() av.CommandIntent {
 		}
 	}
 
-	if wi != nil {
-		// Update the route and go direct to the intercept point.
-		nav.Waypoints = append(wi, nav.FlightState.ArrivalAirport)
-		nav.Heading = NavHeading{}
-		nav.DeferredNavHeading = nil
-		return nil
+	if wi == nil {
+		// No geometric intercept found. For a visual approach the pilot
+		// has the field in sight, so fly a 3nm final to the runway
+		// threshold rather than through the charted waypoints.
+		wi = nav.buildDirectVisualWaypoints(nav.Approach.Assigned.Runway)
 	}
 
-	return av.MakeUnableIntent("unable. We are not on course to intercept the approach")
+	if wi == nil {
+		return av.MakeUnableIntent("unable. We are not on course to intercept the approach")
+	}
+
+	// Update the route and go direct to the intercept/first point.
+	nav.Waypoints = wi
+	nav.Heading = NavHeading{}
+	nav.DeferredNavHeading = nil
+	return nil
 }
 
 func (nav *Nav) ClearedApproach(airport string, id string, straightIn bool, simTime time.Time) (av.CommandIntent, bool) {
@@ -498,6 +505,132 @@ func (nav *Nav) ClearedApproach(airport string, id string, straightIn bool, simT
 	return av.ClearedApproachIntent{
 		Approach:   ap.FullName,
 		StraightIn: straightIn,
+		CancelHold: cancelHold,
+	}, true
+}
+
+// buildDirectVisualWaypoints returns a route for a visual approach to
+// the given runway. When the aircraft is roughly aligned with the
+// extended centerline (within ~1.5nm cross-track), it produces a
+// 2-waypoint path: 3nm final then threshold. When offset further, it
+// inserts a base-turn waypoint at the aircraft's lateral offset so the
+// pilot flies a realistic base-to-final turn. Returns nil if the
+// runway is not found or if the first waypoint is behind the aircraft
+// (meaning it should go around instead).
+func (nav *Nav) buildDirectVisualWaypoints(runway string) []av.Waypoint {
+	rwy, ok := av.LookupRunway(nav.FlightState.ArrivalAirport.Fix, runway)
+	if !ok {
+		return nil
+	}
+
+	nmPerLong := nav.FlightState.NmPerLongitude
+	magVar := nav.FlightState.MagneticVariation
+
+	alt := rwy.Elevation + rwy.ThresholdCrossingHeight
+	threshold := math.Offset2LL(rwy.Threshold, rwy.Heading, rwy.DisplacedThresholdDistance,
+		nmPerLong, magVar)
+
+	reciprocal := math.NormalizeHeading(rwy.Heading + 180)
+	final3nm := math.Offset2LL(threshold, reciprocal, 3, nmPerLong, magVar)
+
+	// Work in nm-space to compute cross-track offset from extended centerline.
+	thresholdNM := math.LL2NM(threshold, nmPerLong)
+	outboundNM := math.LL2NM(final3nm, nmPerLong)
+	acNM := math.LL2NM(nav.FlightState.Position, nmPerLong)
+
+	// Signed distance: negative = left of outbound direction, positive = right.
+	crossTrack := math.SignedPointLineDistance(acNM, thresholdNM, outboundNM)
+
+	// Glideslope intercept altitude at 3nm (~3° slope ≈ 955ft AGL, rounded to 900).
+	final3nmAlt := float32(rwy.Elevation) + 900
+
+	var wps []av.Waypoint
+
+	if math.Abs(crossTrack) > 1.5 {
+		// Aircraft is offset from the centerline. Insert a base-turn
+		// waypoint so the pilot flies a realistic turn onto final.
+		// Place it along the centerline at 4.5nm from threshold, then
+		// offset perpendicular by the cross-track distance.
+		centerlineDir := math.Normalize2f(math.Sub2f(outboundNM, thresholdNM))
+		baseOnCenterlineNM := math.Add2f(thresholdNM, math.Scale2f(centerlineDir, 4.5))
+
+		// Perpendicular-left direction (90° CCW rotation).
+		perpLeft := [2]float32{-centerlineDir[1], centerlineDir[0]}
+		// Negate crossTrack because SignedPointLineDistance returns
+		// positive for points to the right of the outbound direction
+		// in nm-space, but perpLeft points left.
+		baseNM := math.Add2f(baseOnCenterlineNM, math.Scale2f(perpLeft, -crossTrack))
+		baseLoc := math.NM2LL(baseNM, nmPerLong)
+
+		// Go-around check: if the first waypoint is behind the aircraft,
+		// it can't set up a stable approach.
+		bearingToBase := math.Heading2LL(nav.FlightState.Position, baseLoc, nmPerLong, magVar)
+		if math.HeadingDifference(bearingToBase, nav.FlightState.Heading) > 90 {
+			return nil
+		}
+
+		wps = append(wps, av.Waypoint{
+			Fix:        "_" + runway + "_BASE",
+			Location:   baseLoc,
+			OnApproach: true,
+		})
+	} else {
+		// Roughly aligned. Go-around check on the 3nm final point.
+		bearingTo3nm := math.Heading2LL(nav.FlightState.Position, final3nm, nmPerLong, magVar)
+		if math.HeadingDifference(bearingTo3nm, nav.FlightState.Heading) > 90 {
+			return nil
+		}
+	}
+
+	wps = append(wps,
+		av.Waypoint{
+			Fix:                 "_" + runway + "_3NM_FINAL",
+			Location:            final3nm,
+			OnApproach:          true,
+			AltitudeRestriction: &av.AltitudeRestriction{Range: [2]float32{final3nmAlt, 0}},
+		},
+		av.Waypoint{
+			Fix:                 "_" + runway + "_THRESHOLD",
+			Location:            threshold,
+			AltitudeRestriction: &av.AltitudeRestriction{Range: [2]float32{float32(alt), float32(alt)}},
+			Land:                true,
+			FlyOver:             true,
+			OnApproach:          true,
+		},
+	)
+
+	return wps
+}
+
+// ClearedDirectVisual sets up the aircraft to fly a visual approach to
+// the runway threshold. The aircraft flies a 3nm final aligned with the
+// runway heading to the threshold. Returns (intent, true) on success.
+// Returns (nil, false) if the approach can't be set up (runway unknown
+// or aircraft too close for a stable approach) — the caller should
+// trigger a go-around.
+func (nav *Nav) ClearedDirectVisual(runway string, simTime time.Time) (av.CommandIntent, bool) {
+	wi := nav.buildDirectVisualWaypoints(runway)
+	if wi == nil {
+		return nil, false
+	}
+
+	// Cancel hold before clearing nav state.
+	cancelHold := nav.Heading.Hold != nil
+	if nav.Heading.Hold != nil {
+		nav.Heading.Hold.Cancel = true
+	}
+
+	nav.Waypoints = wi
+	nav.Heading = NavHeading{}
+	nav.DeferredNavHeading = nil
+
+	// Mark as cleared and allow descent.
+	nav.Approach.Cleared = true
+	nav.Altitude = NavAltitude{}
+	nav.Speed = NavSpeed{}
+
+	return av.ClearedApproachIntent{
+		Approach:   "visual runway " + runway,
 		CancelHold: cancelHold,
 	}, true
 }

--- a/nav/approach.go
+++ b/nav/approach.go
@@ -442,17 +442,10 @@ func (nav *Nav) prepareForChartedVisual() av.CommandIntent {
 	}
 
 	if wi == nil {
-		// No geometric intercept found. For a visual approach the pilot
-		// has the field in sight, so fly a 3nm final to the runway
-		// threshold rather than through the charted waypoints.
-		wi = nav.buildDirectVisualWaypoints(nav.Approach.Assigned.Runway)
-	}
-
-	if wi == nil {
 		return av.MakeUnableIntent("unable. We are not on course to intercept the approach")
 	}
 
-	// Update the route and go direct to the intercept/first point.
+	// Update the route and go direct to the intercept point.
 	nav.Waypoints = append(wi, nav.FlightState.ArrivalAirport)
 	nav.Heading = NavHeading{}
 	nav.DeferredNavHeading = nil

--- a/nav/approach.go
+++ b/nav/approach.go
@@ -569,11 +569,12 @@ func (nav *Nav) buildDirectVisualWaypoints(runway string) []av.Waypoint {
 			return nil
 		}
 
-		wps = append(wps, av.Waypoint{
-			Fix:        "_" + runway + "_BASE",
-			Location:   baseLoc,
-			OnApproach: true,
-		})
+		base := av.Waypoint{
+			Fix:      "_" + runway + "_BASE",
+			Location: baseLoc,
+		}
+		base.SetOnApproach(true)
+		wps = append(wps, base)
 	} else {
 		// Roughly aligned. Go-around check on the 3nm final point.
 		bearingTo3nm := math.Heading2LL(nav.FlightState.Position, final3nm, nmPerLong, magVar)
@@ -582,22 +583,23 @@ func (nav *Nav) buildDirectVisualWaypoints(runway string) []av.Waypoint {
 		}
 	}
 
-	wps = append(wps,
-		av.Waypoint{
-			Fix:                 "_" + runway + "_3NM_FINAL",
-			Location:            final3nm,
-			OnApproach:          true,
-			AltitudeRestriction: &av.AltitudeRestriction{Range: [2]float32{final3nmAlt, 0}},
-		},
-		av.Waypoint{
-			Fix:                 "_" + runway + "_THRESHOLD",
-			Location:            threshold,
-			AltitudeRestriction: &av.AltitudeRestriction{Range: [2]float32{float32(alt), float32(alt)}},
-			Land:                true,
-			FlyOver:             true,
-			OnApproach:          true,
-		},
-	)
+	finalWp := av.Waypoint{
+		Fix:      "_" + runway + "_3NM_FINAL",
+		Location: final3nm,
+	}
+	finalWp.SetOnApproach(true)
+	finalWp.SetAltitudeRestriction(av.AltitudeRestriction{Range: [2]float32{final3nmAlt, 0}})
+
+	thresholdWp := av.Waypoint{
+		Fix:      "_" + runway + "_THRESHOLD",
+		Location: threshold,
+	}
+	thresholdWp.SetOnApproach(true)
+	thresholdWp.SetLand(true)
+	thresholdWp.SetFlyOver(true)
+	thresholdWp.SetAltitudeRestriction(av.AltitudeRestriction{Range: [2]float32{float32(alt), float32(alt)}})
+
+	wps = append(wps, finalWp, thresholdWp)
 
 	return wps
 }

--- a/nav/approach.go
+++ b/nav/approach.go
@@ -619,6 +619,20 @@ func (nav *Nav) ClearedDirectVisual(runway string, simTime time.Time) (av.Comman
 	nav.Heading = NavHeading{}
 	nav.DeferredNavHeading = nil
 
+	// Synthesize an Approach so downstream consumers (go-around,
+	// spacing checks, landing bookkeeping, departure scheduling) have
+	// the runway data they need.
+	rwy, _ := av.LookupRunway(nav.FlightState.ArrivalAirport.Fix, runway)
+	opp, _ := av.LookupOppositeRunway(nav.FlightState.ArrivalAirport.Fix, runway)
+	nav.Approach.Assigned = &av.Approach{
+		Id:                "V" + runway,
+		FullName:          "Visual Approach Runway " + runway,
+		Runway:            runway,
+		Threshold:         rwy.Threshold,
+		OppositeThreshold: opp.Threshold,
+	}
+	nav.Approach.AssignedId = "V" + runway
+
 	// Mark as cleared and allow descent.
 	nav.Approach.Cleared = true
 	nav.Altitude = NavAltitude{}

--- a/sim/aircraft.go
+++ b/sim/aircraft.go
@@ -130,16 +130,25 @@ type Aircraft struct {
 	TrafficInSightTime  time.Time // When traffic was reported in sight
 	TrafficLookingUntil time.Time // If non-zero, aircraft may report traffic in sight before this time
 
+	// FieldInSight is set when the pilot has confirmed the airport is in sight
+	// (either via AP command response or spontaneous report).
+	FieldInSight bool
+	// FieldLookingUntil is non-zero when the pilot said "looking" in response
+	// to an AP command and may report "field in sight" before this time.
+	FieldLookingUntil time.Time
+
 	// RequestedVisual is set when the pilot has spontaneously requested
 	// the visual approach (field in sight). Prevents repeated requests.
 	RequestedVisual bool
 	// WantsVisual is decided once per aircraft: whether this pilot
-	// prefers to request the visual when eligible (many crews prefer the
-	// ILS even in VMC).
+	// spontaneously reports field in sight when eligible.
 	WantsVisual VisualPreference
-	// VisualRequestTime is when the pilot will key the mic to request the
-	// visual, set once the field comes into sight (adds a short random
-	// delay to simulate identification and reaction time).
+	// WantsVisualRequest is decided independently: whether this pilot
+	// spontaneously requests the visual approach (implies field in sight).
+	WantsVisualRequest VisualPreference
+	// VisualRequestTime is when the pilot will key the mic to report the
+	// field in sight, set once the field first comes into view (adds a short
+	// random delay to simulate identification and reaction time).
 	VisualRequestTime time.Time
 }
 

--- a/sim/aircraft.go
+++ b/sim/aircraft.go
@@ -31,7 +31,6 @@ const (
 	AddressingFormTypeTrailing3
 )
 
-
 type Aircraft struct {
 	// This is ADS-B callsign of the aircraft. Just because different the
 	// callsign in the flight plan can be different across multiple STARS

--- a/sim/aircraft.go
+++ b/sim/aircraft.go
@@ -167,6 +167,15 @@ func (ac *Aircraft) GetSTTFixes() []string {
 		return len(fix) >= 3 && len(fix) <= 5 && fix[0] != '_'
 	}
 
+	// Include arrival and departure airports so STT can match airport
+	// names (e.g. "Kennedy 12 o'clock 12 miles" for AP command).
+	if ac.FlightPlan.ArrivalAirport != "" {
+		fixes = append(fixes, ac.FlightPlan.ArrivalAirport)
+	}
+	if ac.FlightPlan.DepartureAirport != "" {
+		fixes = append(fixes, ac.FlightPlan.DepartureAirport)
+	}
+
 	for _, wp := range ac.Nav.AssignedWaypoints() {
 		if math.NMDistance2LL(p, wp.Location) > 75 && len(fixes) > 0 {
 			break

--- a/sim/aircraft.go
+++ b/sim/aircraft.go
@@ -31,6 +31,16 @@ const (
 	AddressingFormTypeTrailing3
 )
 
+// VisualPreference indicates whether a pilot prefers to request a
+// visual approach when eligible.
+type VisualPreference int
+
+const (
+	VisualPreferenceUndecided VisualPreference = iota
+	VisualPreferenceNo
+	VisualPreferenceYes
+)
+
 type Aircraft struct {
 	// This is ADS-B callsign of the aircraft. Just because different the
 	// callsign in the flight plan can be different across multiple STARS
@@ -123,6 +133,14 @@ type Aircraft struct {
 	// RequestedVisual is set when the pilot has spontaneously requested
 	// the visual approach (field in sight). Prevents repeated requests.
 	RequestedVisual bool
+	// WantsVisual is decided once per aircraft: whether this pilot
+	// prefers to request the visual when eligible (many crews prefer the
+	// ILS even in VMC).
+	WantsVisual VisualPreference
+	// VisualRequestTime is when the pilot will key the mic to request the
+	// visual, set once the field comes into sight (adds a short random
+	// delay to simulate identification and reaction time).
+	VisualRequestTime time.Time
 }
 
 func (ac *Aircraft) GetRadarTrack(now time.Time) av.RadarTrack {

--- a/sim/aircraft.go
+++ b/sim/aircraft.go
@@ -31,15 +31,6 @@ const (
 	AddressingFormTypeTrailing3
 )
 
-// VisualPreference indicates whether a pilot prefers to request a
-// visual approach when eligible.
-type VisualPreference int
-
-const (
-	VisualPreferenceUndecided VisualPreference = iota
-	VisualPreferenceNo
-	VisualPreferenceYes
-)
 
 type Aircraft struct {
 	// This is ADS-B callsign of the aircraft. Just because different the
@@ -140,12 +131,12 @@ type Aircraft struct {
 	// RequestedVisual is set when the pilot has spontaneously requested
 	// the visual approach (field in sight). Prevents repeated requests.
 	RequestedVisual bool
-	// WantsVisual is decided once per aircraft: whether this pilot
+	// WantsVisual is decided at aircraft creation: whether this pilot
 	// spontaneously reports field in sight when eligible.
-	WantsVisual VisualPreference
-	// WantsVisualRequest is decided independently: whether this pilot
-	// spontaneously requests the visual approach (implies field in sight).
-	WantsVisualRequest VisualPreference
+	WantsVisual bool
+	// WantsVisualRequest is decided at aircraft creation: whether this
+	// pilot spontaneously requests the visual approach (implies field in sight).
+	WantsVisualRequest bool
 	// VisualRequestTime is when the pilot will key the mic to report the
 	// field in sight, set once the field first comes into view (adds a short
 	// random delay to simulate identification and reaction time).

--- a/sim/aircraft.go
+++ b/sim/aircraft.go
@@ -119,6 +119,10 @@ type Aircraft struct {
 	TrafficInSight      bool      // True if aircraft has reported traffic in sight
 	TrafficInSightTime  time.Time // When traffic was reported in sight
 	TrafficLookingUntil time.Time // If non-zero, aircraft may report traffic in sight before this time
+
+	// RequestedVisual is set when the pilot has spontaneously requested
+	// the visual approach (field in sight). Prevents repeated requests.
+	RequestedVisual bool
 }
 
 func (ac *Aircraft) GetRadarTrack(now time.Time) av.RadarTrack {
@@ -336,6 +340,10 @@ func (ac *Aircraft) AtFixIntercept(fix string, lg *log.Logger) av.CommandIntent 
 
 func (ac *Aircraft) ClearedApproach(id string, simTime time.Time, lg *log.Logger) (av.CommandIntent, bool) {
 	return ac.Nav.ClearedApproach(ac.FlightPlan.ArrivalAirport, id, false, simTime)
+}
+
+func (ac *Aircraft) ClearedDirectVisual(runway string, simTime time.Time) (av.CommandIntent, bool) {
+	return ac.Nav.ClearedDirectVisual(runway, simTime)
 }
 
 func (ac *Aircraft) ClearedStraightInApproach(id string, simTime time.Time, lg *log.Logger) (av.CommandIntent, bool) {

--- a/sim/control.go
+++ b/sim/control.go
@@ -2015,14 +2015,19 @@ const (
 	visualDelayMax      = 8             // seconds; max delay after field in sight
 )
 
-// effectiveVisualRange returns the maximum distance at which a pilot can
-// identify the field, based on METAR visibility capped at visualMaxDistance.
+// effectiveVisualRange returns the maximum distance (in nautical miles) at
+// which a pilot can identify the field, based on METAR visibility capped
+// at visualMaxDistance.
 func effectiveVisualRange(metar wx.METAR) float32 {
 	vis, err := metar.Visibility()
-	if err != nil || vis > visualMaxDistance {
+	if err != nil {
 		return visualMaxDistance
 	}
-	return vis
+	visNM := vis * math.StatuteMilesToNauticalMiles
+	if visNM > visualMaxDistance {
+		return visualMaxDistance
+	}
+	return visNM
 }
 
 // checkSpontaneousVisualRequest checks if an arrival aircraft should

--- a/sim/control.go
+++ b/sim/control.go
@@ -2010,7 +2010,7 @@ const (
 	visualMaxDistance   = float32(15)   // nm; absolute cap on field-in-sight range
 	visualMaxBearingOff = float32(120)  // degrees off nose; forward visibility arc
 	visualFieldProb     = float32(0.10) // fraction of pilots who spontaneously report field in sight
-	visualRequestProb   = float32(0.01) // fraction of pilots who spontaneously request the visual
+	visualRequestProb   = float32(0.10) // fraction of field-in-sight pilots who also request the visual
 	visualDelayMin      = 2             // seconds; min delay after field in sight
 	visualDelayMax      = 8             // seconds; max delay after field in sight
 )
@@ -2045,7 +2045,7 @@ func (s *Sim) checkSpontaneousVisualRequest(ac *Aircraft) {
 		return
 	}
 
-	// One-time independent coin flips.
+	// One-time coin flip: ~10% of pilots spontaneously report field in sight.
 	if ac.WantsVisual == VisualPreferenceUndecided {
 		if s.Rand.Float32() < visualFieldProb {
 			ac.WantsVisual = VisualPreferenceYes
@@ -2053,17 +2053,17 @@ func (s *Sim) checkSpontaneousVisualRequest(ac *Aircraft) {
 			ac.WantsVisual = VisualPreferenceNo
 		}
 	}
+	if ac.WantsVisual == VisualPreferenceNo {
+		return
+	}
+
+	// Of those, ~1% also request the visual approach.
 	if ac.WantsVisualRequest == VisualPreferenceUndecided {
 		if s.Rand.Float32() < visualRequestProb {
 			ac.WantsVisualRequest = VisualPreferenceYes
 		} else {
 			ac.WantsVisualRequest = VisualPreferenceNo
 		}
-	}
-
-	// If this pilot won't do either, bail out.
-	if ac.WantsVisual == VisualPreferenceNo && ac.WantsVisualRequest == VisualPreferenceNo {
-		return
 	}
 
 	elig := s.checkVisualEligibility(ac)

--- a/sim/control.go
+++ b/sim/control.go
@@ -1685,7 +1685,7 @@ func (s *Sim) ClearedVisualApproach(tcw TCW, callsign av.ADSBCallsign, runway st
 			intent, ok := ac.ClearedDirectVisual(runway, s.State.SimTime)
 			if !ok {
 				s.goAround(ac)
-				return nil
+				return av.MakeUnableIntent("unable, going around")
 			}
 			ac.ApproachTCP = TCP(ac.ControllerFrequency)
 			return intent
@@ -3253,7 +3253,7 @@ func (s *Sim) runOneControlCommand(tcw TCW, callsign av.ADSBCallsign, command st
 			runway := command[3:]
 			return av.ApproachIntent{
 				Type:         av.ApproachExpect,
-				ApproachName: "Visual Runway " + runway,
+				ApproachName: "Visual Approach Runway " + runway,
 			}, nil
 		} else if len(command) > 1 {
 			// Parse: "EI22L/LAHSO26" -> approach="I22L", lahsoRunway="26"

--- a/sim/e2e_test.go
+++ b/sim/e2e_test.go
@@ -15,13 +15,13 @@ import (
 
 type e2eCase struct {
 	name          string
-	transcript    string                // what the controller said
+	transcript    string                  // what the controller said
 	sttAircraft   map[string]stt.Aircraft // STT context (callsign matching, approaches)
-	simSetup      func(s *sim.Sim)      // optional Sim tweaks (e.g., set FieldInSight)
-	wantCommand   string                // expected "CALLSIGN CMD" from STT
-	wantError     bool                  // should command dispatch fail?
-	wantReadback  string                // substring expected in readback (or "")
-	notInReadback string                // substring that must NOT appear
+	simSetup      func(s *sim.Sim)        // optional Sim tweaks (e.g., set FieldInSight)
+	wantCommand   string                  // expected "CALLSIGN CMD" from STT
+	wantError     bool                    // should command dispatch fail?
+	wantReadback  string                  // substring expected in readback (or "")
+	notInReadback string                  // substring that must NOT appear
 }
 
 func TestE2E_STTToSim(t *testing.T) {
@@ -49,7 +49,7 @@ func TestE2E_STTToSim(t *testing.T) {
 					CandidateApproaches: map[string]string{
 						"I L S runway two two left":  "I22L",
 						"I L S runway two two right": "I22R",
-						"Visual runway two two left":  "V22L",
+						"Visual runway two two left": "V22L",
 					},
 					AssignedApproach: "ILS Runway 22L",
 					State:            "arrival",
@@ -68,7 +68,7 @@ func TestE2E_STTToSim(t *testing.T) {
 					Callsign:     "AAL1232",
 					AircraftType: "A321",
 					CandidateApproaches: map[string]string{
-						"I L S runway three one right": "I31R",
+						"I L S runway three one right":  "I31R",
 						"Visual runway three one right": "V31R",
 					},
 					AssignedApproach: "ILS Runway 31R",
@@ -100,7 +100,7 @@ func TestE2E_STTToSim(t *testing.T) {
 					Callsign:     "SWA247",
 					AircraftType: "B738",
 					CandidateApproaches: map[string]string{
-						"I L S runway two six": "I26",
+						"I L S runway two six":  "I26",
 						"Visual runway two six": "V26",
 					},
 					AssignedApproach: "ILS Runway 26",
@@ -142,7 +142,7 @@ func TestE2E_STTToSim(t *testing.T) {
 					Callsign:     "DAL43",
 					AircraftType: "A321",
 					CandidateApproaches: map[string]string{
-						"I L S runway two two left": "I22L",
+						"I L S runway two two left":  "I22L",
 						"Visual runway two two left": "V22L",
 					},
 					AssignedApproach: "ILS Runway 22L",

--- a/sim/e2e_test.go
+++ b/sim/e2e_test.go
@@ -1,0 +1,242 @@
+package sim_test
+
+import (
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	av "github.com/mmp/vice/aviation"
+	"github.com/mmp/vice/log"
+	"github.com/mmp/vice/sim"
+	"github.com/mmp/vice/stt"
+	"github.com/mmp/vice/wx"
+)
+
+type e2eCase struct {
+	name          string
+	transcript    string                // what the controller said
+	sttAircraft   map[string]stt.Aircraft // STT context (callsign matching, approaches)
+	simSetup      func(s *sim.Sim)      // optional Sim tweaks (e.g., set FieldInSight)
+	wantCommand   string                // expected "CALLSIGN CMD" from STT
+	wantError     bool                  // should command dispatch fail?
+	wantReadback  string                // substring expected in readback (or "")
+	notInReadback string                // substring that must NOT appear
+}
+
+func TestE2E_STTToSim(t *testing.T) {
+	lg := &log.Logger{Logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	transcriber := stt.NewTranscriber(lg)
+
+	// Initialize av.DB so callsign rendering doesn't crash.
+	if av.DB == nil {
+		av.DB = &av.StaticDatabase{
+			Airports:            map[string]av.FAAAirport{},
+			Callsigns:           map[string]string{"DAL": "delta", "AAL": "american", "SWA": "southwest", "SCX": "sun country"},
+			AircraftPerformance: map[string]av.AircraftPerformance{},
+		}
+	}
+	t.Cleanup(func() { av.DB = nil })
+
+	tests := []e2eCase{
+		{
+			name:       "expect visual approach → generic visual, not charted",
+			transcript: "Delta forty three expect visual approach runway two two left",
+			sttAircraft: map[string]stt.Aircraft{
+				"Delta 43": {
+					Callsign:     "DAL43",
+					AircraftType: "A321",
+					CandidateApproaches: map[string]string{
+						"I L S runway two two left":  "I22L",
+						"I L S runway two two right": "I22R",
+						"Visual runway two two left":  "V22L",
+					},
+					AssignedApproach: "ILS Runway 22L",
+					State:            "arrival",
+					Altitude:         6000,
+				},
+			},
+			wantCommand:   "DAL43 EVA22L",
+			wantReadback:  "visual",
+			notInReadback: "Belmont",
+		},
+		{
+			name:       "vectors visual approach → EVA command",
+			transcript: "American twelve thirty two vectors visual approach runway three one right",
+			sttAircraft: map[string]stt.Aircraft{
+				"American 1232": {
+					Callsign:     "AAL1232",
+					AircraftType: "A321",
+					CandidateApproaches: map[string]string{
+						"I L S runway three one right": "I31R",
+						"Visual runway three one right": "V31R",
+					},
+					AssignedApproach: "ILS Runway 31R",
+					State:            "arrival",
+					Altitude:         5000,
+				},
+			},
+			wantCommand: "AAL1232 EVA31R",
+		},
+		{
+			name:       "kennedy at your 11 o'clock 8 miles → AP command",
+			transcript: "Delta forty three kennedy at your eleven o'clock eight miles",
+			sttAircraft: map[string]stt.Aircraft{
+				"Delta 43": {
+					Callsign:     "DAL43",
+					AircraftType: "A321",
+					Fixes:        map[string]string{"Kennedy": "KJFK"},
+					State:        "arrival",
+					Altitude:     5000,
+				},
+			},
+			wantCommand: "DAL43 AP/11/8",
+		},
+		{
+			name:       "cleared visual approach → CVA command",
+			transcript: "Southwest two forty seven cleared visual runway two six",
+			sttAircraft: map[string]stt.Aircraft{
+				"Southwest two 47": {
+					Callsign:     "SWA247",
+					AircraftType: "B738",
+					CandidateApproaches: map[string]string{
+						"I L S runway two six": "I26",
+						"Visual runway two six": "V26",
+					},
+					AssignedApproach: "ILS Runway 26",
+					State:            "arrival",
+					Altitude:         4000,
+				},
+			},
+			wantCommand: "SWA247 CVA26",
+			simSetup: func(s *sim.Sim) {
+				// CVA requires field in sight or visual request
+				for _, ac := range s.Aircraft {
+					ac.FieldInSight = true
+				}
+			},
+		},
+		{
+			name:       "expect a visual approach — filler word 'a'",
+			transcript: "Sun Country five zero five expect a visual approach runway one two right",
+			sttAircraft: map[string]stt.Aircraft{
+				"Sun Country five zero five": {
+					Callsign:     "SCX505",
+					AircraftType: "B738",
+					CandidateApproaches: map[string]string{
+						"I L S runway one two right":  "I12R",
+						"Visual runway one two right": "VR1",
+					},
+					AssignedApproach: "ILS Runway 12R",
+					State:            "arrival",
+					Altitude:         4000,
+				},
+			},
+			wantCommand: "SCX505 EVA12R",
+		},
+		{
+			name:       "EVA readback doesn't say 'approach approach'",
+			transcript: "Delta forty three expect visual approach runway two two left",
+			sttAircraft: map[string]stt.Aircraft{
+				"Delta 43": {
+					Callsign:     "DAL43",
+					AircraftType: "A321",
+					CandidateApproaches: map[string]string{
+						"I L S runway two two left": "I22L",
+						"Visual runway two two left": "V22L",
+					},
+					AssignedApproach: "ILS Runway 22L",
+					State:            "arrival",
+					Altitude:         6000,
+				},
+			},
+			wantCommand:   "DAL43 EVA22L",
+			notInReadback: "approach approach",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Step 1: STT decode
+			result, err := transcriber.DecodeTranscript(tt.sttAircraft, tt.transcript, "")
+			if err != nil {
+				t.Fatalf("DecodeTranscript error: %v", err)
+			}
+			if result != tt.wantCommand {
+				t.Fatalf("STT command = %q, want %q", result, tt.wantCommand)
+			}
+
+			// Step 2: Parse callsign + commands from STT result
+			callsign, commands := splitCallsignAndCommands(result)
+			if callsign == "" || commands == "" {
+				t.Fatalf("failed to parse callsign/commands from %q", result)
+			}
+
+			// Step 3: Set up sim and aircraft
+			s := sim.NewTestSim(lg)
+			runway := guessRunway(commands)
+			ac := sim.MakeTestAircraft(av.ADSBCallsign(callsign), runway)
+			s.Aircraft[av.ADSBCallsign(callsign)] = ac
+
+			// Add airport with matching approaches
+			s.State.METAR["KJFK"] = wx.METAR{Raw: "KJFK 10SM BKN050"}
+			s.State.Airports["KJFK"] = &av.Airport{
+				Location: [2]float32{0, 0},
+				Approaches: map[string]*av.Approach{
+					"I" + runway: {Type: av.ILSApproach, Runway: runway},
+					"V" + runway: {Type: av.ChartedVisualApproach, Runway: runway},
+				},
+			}
+
+			if tt.simSetup != nil {
+				tt.simSetup(s)
+			}
+
+			// Step 4: Execute command
+			res := s.RunAircraftControlCommands(sim.E2ETCW(), av.ADSBCallsign(callsign), commands)
+
+			if tt.wantError && res.Error == nil {
+				t.Error("expected error from command dispatch, got nil")
+			}
+			if !tt.wantError && res.Error != nil {
+				t.Errorf("unexpected dispatch error: %v (remaining: %s)", res.Error, res.RemainingInput)
+			}
+
+			// Step 5: Check readback
+			readback := strings.ToLower(res.ReadbackSpokenText)
+			if tt.wantReadback != "" {
+				want := strings.ToLower(tt.wantReadback)
+				if !strings.Contains(readback, want) {
+					t.Errorf("readback %q does not contain %q", res.ReadbackSpokenText, tt.wantReadback)
+				}
+			}
+			if tt.notInReadback != "" {
+				bad := strings.ToLower(tt.notInReadback)
+				if strings.Contains(readback, bad) {
+					t.Errorf("readback %q should not contain %q", res.ReadbackSpokenText, tt.notInReadback)
+				}
+			}
+		})
+	}
+}
+
+// splitCallsignAndCommands splits "DAL43 EVA22L" into ("DAL43", "EVA22L").
+func splitCallsignAndCommands(sttResult string) (string, string) {
+	idx := strings.IndexByte(sttResult, ' ')
+	if idx < 0 {
+		return sttResult, ""
+	}
+	return sttResult[:idx], sttResult[idx+1:]
+}
+
+// guessRunway extracts a runway identifier from a command string for test setup.
+// E.g., "EVA22L" → "22L", "CVA26" → "26", "AP/11/8" → "22L" (fallback).
+func guessRunway(commands string) string {
+	cmd := strings.Fields(commands)[0]
+	for _, prefix := range []string{"EVA", "CVA"} {
+		if strings.HasPrefix(cmd, prefix) && len(cmd) > len(prefix) {
+			return cmd[len(prefix):]
+		}
+	}
+	return "22L" // fallback for non-approach commands
+}

--- a/sim/e2e_test.go
+++ b/sim/e2e_test.go
@@ -175,6 +175,16 @@ func TestE2E_STTToSim(t *testing.T) {
 			// Step 3: Set up sim and aircraft
 			s := sim.NewTestSim(lg)
 			runway := guessRunway(commands)
+
+			// CVA/EVA runway validation and visual-path setup use av.DB runway data.
+			av.DB.Airports["KJFK"] = av.FAAAirport{
+				Id:        "KJFK",
+				Elevation: 13,
+				Runways: []av.Runway{
+					{Id: runway, Heading: 180, Threshold: [2]float32{0, 0}, Elevation: 13},
+				},
+			}
+
 			ac := sim.MakeTestAircraft(av.ADSBCallsign(callsign), runway)
 			s.Aircraft[av.ADSBCallsign(callsign)] = ac
 

--- a/sim/export_test.go
+++ b/sim/export_test.go
@@ -45,13 +45,13 @@ func MakeTestAircraft(callsign av.ADSBCallsign, runway string) *Aircraft {
 		},
 		Nav: nav.Nav{
 			FlightState: nav.FlightState{
-				Position:               [2]float32{0, 5.0 / 60}, // 5nm north
-				Heading:                180,
-				Altitude:               3000,
-				NmPerLongitude:         52,
-				MagneticVariation:      0,
-				ArrivalAirport:         av.Waypoint{Fix: "KJFK"},
-				ArrivalAirportLocation: [2]float32{0, 0},
+				Position:                [2]float32{0, 5.0 / 60}, // 5nm north
+				Heading:                 180,
+				Altitude:                3000,
+				NmPerLongitude:          52,
+				MagneticVariation:       0,
+				ArrivalAirport:          av.Waypoint{Fix: "KJFK"},
+				ArrivalAirportLocation:  [2]float32{0, 0},
 				ArrivalAirportElevation: 13,
 			},
 			Approach: nav.NavApproach{

--- a/sim/export_test.go
+++ b/sim/export_test.go
@@ -1,0 +1,69 @@
+package sim
+
+import (
+	"time"
+
+	av "github.com/mmp/vice/aviation"
+	"github.com/mmp/vice/log"
+	"github.com/mmp/vice/nav"
+	vrand "github.com/mmp/vice/rand"
+	"github.com/mmp/vice/wx"
+)
+
+// NewTestSim creates a minimal Sim suitable for command dispatch tests.
+// Exported only to _test packages via Go's export_test.go convention.
+func NewTestSim(lg *log.Logger) *Sim {
+	tcw := TCW("TEST")
+	freq := ControlPosition("125.0")
+
+	return &Sim{
+		lg:          lg,
+		Rand:        vrand.Make(),
+		eventStream: NewEventStream(lg),
+		State: &CommonState{
+			DynamicState: DynamicState{
+				METAR:                map[string]wx.METAR{},
+				SimTime:              time.Now(),
+				CurrentConsolidation: map[TCW]*TCPConsolidation{tcw: {PrimaryTCP: TCP(freq)}},
+			},
+			Airports: map[string]*av.Airport{},
+		},
+		Aircraft:        map[av.ADSBCallsign]*Aircraft{},
+		PendingContacts: make(map[TCP][]PendingContact),
+		PrivilegedTCWs:  map[TCW]bool{tcw: true},
+	}
+}
+
+// MakeTestAircraft creates a minimal arrival aircraft suitable for e2e tests.
+func MakeTestAircraft(callsign av.ADSBCallsign, runway string) *Aircraft {
+	return &Aircraft{
+		ADSBCallsign:        callsign,
+		TypeOfFlight:        av.FlightTypeArrival,
+		ControllerFrequency: ControlPosition("125.0"),
+		FlightPlan: av.FlightPlan{
+			ArrivalAirport: "KJFK",
+		},
+		Nav: nav.Nav{
+			FlightState: nav.FlightState{
+				Position:               [2]float32{0, 5.0 / 60}, // 5nm north
+				Heading:                180,
+				Altitude:               3000,
+				NmPerLongitude:         52,
+				MagneticVariation:      0,
+				ArrivalAirport:         av.Waypoint{Fix: "KJFK"},
+				ArrivalAirportLocation: [2]float32{0, 0},
+				ArrivalAirportElevation: 13,
+			},
+			Approach: nav.NavApproach{
+				AssignedId: "I" + runway,
+				Assigned: &av.Approach{
+					Type:   av.ILSApproach,
+					Runway: runway,
+				},
+			},
+		},
+	}
+}
+
+// E2ETCW returns the TCW used by NewTestSim.
+func E2ETCW() TCW { return TCW("TEST") }

--- a/sim/sim.go
+++ b/sim/sim.go
@@ -1531,6 +1531,9 @@ func (s *Sim) updateState() {
 
 			// Check for delayed "traffic in sight" call
 			s.checkDelayedTrafficInSight(ac)
+
+			// Check for spontaneous "field in sight, requesting visual" call
+			s.checkSpontaneousVisualRequest(ac)
 		}
 
 		s.possiblyRequestFlightFollowing()

--- a/sim/sim.go
+++ b/sim/sim.go
@@ -1532,7 +1532,10 @@ func (s *Sim) updateState() {
 			// Check for delayed "traffic in sight" call
 			s.checkDelayedTrafficInSight(ac)
 
-			// Check for spontaneous "field in sight, requesting visual" call
+			// Check for delayed "field in sight" call (after AP "looking" response)
+			s.checkDelayedFieldInSight(ac)
+
+			// Check for spontaneous "field in sight" call
 			s.checkSpontaneousVisualRequest(ac)
 		}
 

--- a/sim/spawn_arrivals.go
+++ b/sim/spawn_arrivals.go
@@ -148,6 +148,11 @@ func (s *Sim) createArrivalNoLock(group string, arrivalAirport string) (*Aircraf
 
 	s.maybeSetGoAround(ac, s.State.LaunchConfig.GoAroundRate)
 
+	// Decide at creation whether this pilot will spontaneously report
+	// field in sight (~10%) and/or request the visual (~10% of those).
+	ac.WantsVisual = s.Rand.Float32() < visualFieldProb
+	ac.WantsVisualRequest = ac.WantsVisual && s.Rand.Float32() < visualRequestProb
+
 	if err := s.assignSquawk(ac, &nasFp); err != nil {
 		return nil, err
 	}

--- a/sim/visual_approach_test.go
+++ b/sim/visual_approach_test.go
@@ -440,10 +440,10 @@ func TestVisualApproachWaypoints(t *testing.T) {
 			if last.Fix != "_36_THRESHOLD" {
 				t.Errorf("last waypoint = %q, want _36_THRESHOLD", last.Fix)
 			}
-			if !last.Land {
+			if !last.Land() {
 				t.Error("threshold waypoint should have Land=true")
 			}
-			if !last.FlyOver {
+			if !last.FlyOver() {
 				t.Error("threshold waypoint should have FlyOver=true")
 			}
 
@@ -454,9 +454,9 @@ func TestVisualApproachWaypoints(t *testing.T) {
 					final3nm = wp
 				}
 			}
-			if final3nm.AltitudeRestriction == nil {
+			if alt := final3nm.AltitudeRestriction(); alt == nil {
 				t.Error("3nm final should have an altitude restriction")
-			} else if final3nm.AltitudeRestriction.Range[0] == 0 {
+			} else if alt.Range[0] == 0 {
 				t.Error("3nm final altitude lower bound should be non-zero")
 			}
 		})

--- a/sim/visual_approach_test.go
+++ b/sim/visual_approach_test.go
@@ -47,13 +47,13 @@ func NewVisualScenario(t *testing.T, airportLoc math.Point2LL, runway string, ac
 		},
 		Nav: nav.Nav{
 			FlightState: nav.FlightState{
-				Position:          acPos,
-				Heading:           heading,
-				Altitude:          3000,
-				NmPerLongitude:    52,
-				MagneticVariation: 0,
-				ArrivalAirport:    av.Waypoint{Fix: "KJFK"},
-				ArrivalAirportLocation: airportLoc,
+				Position:                acPos,
+				Heading:                 heading,
+				Altitude:                3000,
+				NmPerLongitude:          52,
+				MagneticVariation:       0,
+				ArrivalAirport:          av.Waypoint{Fix: "KJFK"},
+				ArrivalAirportLocation:  airportLoc,
 				ArrivalAirportElevation: 13,
 			},
 			Approach: nav.NavApproach{
@@ -1163,7 +1163,7 @@ func TestScenarioAboveCeilingIMC(t *testing.T) {
 
 	vs := NewVisualScenario(t, airportLoc, "13L", math.Point2LL{0, 5.0 / 60}, 180)
 	vs.SetMETAR("KJFK 10SM BKN030") // 3000ft ceiling, VMC surface
-	vs.SetAltitude(4000)             // above ceiling
+	vs.SetAltitude(4000)            // above ceiling
 
 	intent := vs.AirportAdvisory(12, 5)
 	vs.ExpectIMC(intent) // Aircraft in clouds → IMC response

--- a/sim/visual_approach_test.go
+++ b/sim/visual_approach_test.go
@@ -1,0 +1,500 @@
+package sim
+
+import (
+	"testing"
+	"time"
+
+	av "github.com/mmp/vice/aviation"
+	"github.com/mmp/vice/math"
+	"github.com/mmp/vice/nav"
+	vrand "github.com/mmp/vice/rand"
+	"github.com/mmp/vice/wx"
+)
+
+// makeVisualTestAircraft creates an arrival aircraft with an ILS approach
+// assigned, on frequency, positioned at the given location heading in the
+// given direction. Suitable for canRequestVisualApproach and
+// checkSpontaneousVisualRequest tests.
+func makeVisualTestAircraft(pos math.Point2LL, heading float32) *Aircraft {
+	return &Aircraft{
+		ADSBCallsign:        "AAL123",
+		TypeOfFlight:        av.FlightTypeArrival,
+		ControllerFrequency: "125.0",
+		FlightPlan: av.FlightPlan{
+			ArrivalAirport: "KJFK",
+		},
+		Nav: nav.Nav{
+			FlightState: nav.FlightState{
+				Position:          pos,
+				Heading:           heading,
+				NmPerLongitude:    52, // ~40°N
+				MagneticVariation: 0,
+			},
+			Approach: nav.NavApproach{
+				AssignedId: "I13L",
+				Assigned: &av.Approach{
+					Type:   av.ILSApproach,
+					Runway: "13L",
+				},
+			},
+		},
+	}
+}
+
+// makeVisualTestSim creates a minimal Sim with a KJFK airport at the given
+// location, a VMC METAR, and a charted visual approach for the given runway.
+func makeVisualTestSim(airportLoc math.Point2LL, runway string) *Sim {
+	return &Sim{
+		Rand: vrand.Make(),
+		State: &CommonState{
+			DynamicState: DynamicState{
+				METAR: map[string]wx.METAR{
+					"KJFK": {Raw: "KJFK 10SM BKN050"},
+				},
+			},
+			Airports: map[string]*av.Airport{
+				"KJFK": {
+					Location: airportLoc,
+					Approaches: map[string]*av.Approach{
+						"V13L": {Type: av.ChartedVisualApproach, Runway: runway},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestCheckVisualEligibility(t *testing.T) {
+	airportLoc := math.Point2LL{0, 0}
+
+	tests := []struct {
+		name      string
+		sim       *Sim
+		ac        *Aircraft
+		wantField bool
+	}{
+		{
+			name:      "VMC, close, facing airport, charted visual exists",
+			sim:       makeVisualTestSim(airportLoc, "13L"),
+			ac:        makeVisualTestAircraft(math.Point2LL{0, 5.0 / 60}, 180), // 5nm north, heading south
+			wantField: true,
+		},
+		{
+			name:      "Too far from airport (20nm)",
+			sim:       makeVisualTestSim(airportLoc, "13L"),
+			ac:        makeVisualTestAircraft(math.Point2LL{0, 20.0 / 60}, 180),
+			wantField: false,
+		},
+		{
+			name:      "Facing away from airport",
+			sim:       makeVisualTestSim(airportLoc, "13L"),
+			ac:        makeVisualTestAircraft(math.Point2LL{0, 5.0 / 60}, 0), // heading north, away
+			wantField: false,
+		},
+		{
+			name: "IMC conditions",
+			sim: func() *Sim {
+				s := makeVisualTestSim(airportLoc, "13L")
+				s.State.METAR["KJFK"] = wx.METAR{Raw: "KJFK 1SM OVC003"} // 1SM vis, 300ft ceiling
+				return s
+			}(),
+			ac:        makeVisualTestAircraft(math.Point2LL{0, 5.0 / 60}, 180),
+			wantField: false,
+		},
+		{
+			name: "No charted visual for assigned runway, still field in sight",
+			sim: func() *Sim {
+				s := makeVisualTestSim(airportLoc, "31R") // visual exists for 31R, not 13L
+				return s
+			}(),
+			ac:        makeVisualTestAircraft(math.Point2LL{0, 5.0 / 60}, 180),
+			wantField: true,
+		},
+		{
+			name: "No METAR available",
+			sim: func() *Sim {
+				s := makeVisualTestSim(airportLoc, "13L")
+				delete(s.State.METAR, "KJFK")
+				return s
+			}(),
+			ac:        makeVisualTestAircraft(math.Point2LL{0, 5.0 / 60}, 180),
+			wantField: false,
+		},
+		{
+			name:      "Nil assigned approach",
+			sim:       makeVisualTestSim(airportLoc, "13L"),
+			ac: func() *Aircraft {
+				ac := makeVisualTestAircraft(math.Point2LL{0, 5.0 / 60}, 180)
+				ac.Nav.Approach.Assigned = nil
+				return ac
+			}(),
+			wantField: false,
+		},
+		{
+			name: "Unknown arrival airport",
+			sim: func() *Sim {
+				s := makeVisualTestSim(airportLoc, "13L")
+				delete(s.State.Airports, "KJFK")
+				return s
+			}(),
+			ac:        makeVisualTestAircraft(math.Point2LL{0, 5.0 / 60}, 180),
+			wantField: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			elig := tt.sim.checkVisualEligibility(tt.ac)
+			if elig.FieldInSight != tt.wantField {
+				t.Errorf("FieldInSight = %v, want %v", elig.FieldInSight, tt.wantField)
+			}
+		})
+	}
+}
+
+func TestCanRequestVisualApproach(t *testing.T) {
+	tests := []struct {
+		name string
+		ac   *Aircraft
+		want bool
+	}{
+		{
+			name: "Eligible arrival with ILS assigned",
+			ac: func() *Aircraft {
+				return makeVisualTestAircraft(math.Point2LL{}, 180)
+			}(),
+			want: true,
+		},
+		{
+			name: "Departure aircraft",
+			ac: func() *Aircraft {
+				ac := makeVisualTestAircraft(math.Point2LL{}, 180)
+				ac.TypeOfFlight = av.FlightTypeDeparture
+				return ac
+			}(),
+			want: false,
+		},
+		{
+			name: "Already requested visual",
+			ac: func() *Aircraft {
+				ac := makeVisualTestAircraft(math.Point2LL{}, 180)
+				ac.RequestedVisual = true
+				return ac
+			}(),
+			want: false,
+		},
+		{
+			name: "Not on frequency",
+			ac: func() *Aircraft {
+				ac := makeVisualTestAircraft(math.Point2LL{}, 180)
+				ac.ControllerFrequency = ""
+				return ac
+			}(),
+			want: false,
+		},
+		{
+			name: "No approach assigned",
+			ac: func() *Aircraft {
+				ac := makeVisualTestAircraft(math.Point2LL{}, 180)
+				ac.Nav.Approach.AssignedId = ""
+				ac.Nav.Approach.Assigned = nil
+				return ac
+			}(),
+			want: false,
+		},
+		{
+			name: "Approach already cleared",
+			ac: func() *Aircraft {
+				ac := makeVisualTestAircraft(math.Point2LL{}, 180)
+				ac.Nav.Approach.Cleared = true
+				return ac
+			}(),
+			want: false,
+		},
+		{
+			name: "Already on a visual approach",
+			ac: func() *Aircraft {
+				ac := makeVisualTestAircraft(math.Point2LL{}, 180)
+				ac.Nav.Approach.Assigned = &av.Approach{
+					Type:   av.ChartedVisualApproach,
+					Runway: "13L",
+				}
+				return ac
+			}(),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.ac.canRequestVisualApproach(); got != tt.want {
+				t.Errorf("canRequestVisualApproach() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVisualRequestBearingFilter(t *testing.T) {
+	// Airport at (0, 0). Place aircraft 5nm north (latitude +5/60 degrees),
+	// so the bearing from aircraft to airport is ~180° (due south).
+	airportLoc := math.Point2LL{0, 0}
+	acPos := math.Point2LL{0, 5.0 / 60} // 5nm north
+
+	tests := []struct {
+		name           string
+		heading        float32
+		shouldBePastFilter bool // true = bearing difference <= 120
+	}{
+		{"Heading south toward airport", 180, true},
+		{"Heading southwest", 225, true},
+		{"Heading southeast", 135, true},
+		{"Heading east (abeam)", 90, true},   // 90° off nose
+		{"Heading west (abeam)", 270, true},   // 90° off nose
+		{"Heading north away from airport", 0, false},  // 180° off nose
+		{"Heading NNE away", 30, false},       // 150° off nose
+		{"Heading NNW away", 330, false},      // 150° off nose
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nmPerLong := float32(52)
+			magVar := float32(0)
+			bearing := math.Heading2LL(acPos, airportLoc, nmPerLong, magVar)
+			diff := math.HeadingDifference(tt.heading, bearing)
+			pastFilter := diff <= 120
+
+			if pastFilter != tt.shouldBePastFilter {
+				t.Errorf("heading=%.0f bearing=%.0f diff=%.0f: got pastFilter=%v, want %v",
+					tt.heading, bearing, diff, pastFilter, tt.shouldBePastFilter)
+			}
+		})
+	}
+}
+
+func TestVisualRequestDistanceFactor(t *testing.T) {
+	tests := []struct {
+		name       string
+		dist       float32
+		wantFactor float32
+		tolerance  float32
+	}{
+		{"At airport", 0, 1.0, 0.01},
+		{"At 3nm", 3, 1.0, 0.01},
+		{"At 9nm (midpoint)", 9, 0.625, 0.01},
+		{"At 15nm", 15, 0.25, 0.01},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := VisualDistanceFactor(tt.dist)
+			diff := got - tt.wantFactor
+			if diff < 0 {
+				diff = -diff
+			}
+			if diff > tt.tolerance {
+				t.Errorf("VisualDistanceFactor(%.1f) = %.4f, want %.4f (±%.2f)",
+					tt.dist, got, tt.wantFactor, tt.tolerance)
+			}
+		})
+	}
+}
+
+// setupTestRunway installs a minimal runway into the global aviation DB
+// for the duration of the test, then removes it on cleanup.
+func setupTestRunway(t *testing.T, icao string, rwy av.Runway) {
+	t.Helper()
+	if av.DB == nil {
+		av.DB = &av.StaticDatabase{Airports: map[string]av.FAAAirport{}}
+	}
+	old, hadAirport := av.DB.Airports[icao]
+	ap := av.FAAAirport{Id: icao, Runways: []av.Runway{rwy}}
+	av.DB.Airports[icao] = ap
+	t.Cleanup(func() {
+		if hadAirport {
+			av.DB.Airports[icao] = old
+		} else {
+			delete(av.DB.Airports, icao)
+		}
+	})
+}
+
+func TestVisualApproachWaypoints(t *testing.T) {
+	// Runway 36 at (0,0), heading 360 (north). Centerline extends south.
+	rwy := av.Runway{
+		Id:                      "36",
+		Heading:                 360,
+		Threshold:               math.Point2LL{0, 0},
+		Elevation:               100,
+		ThresholdCrossingHeight: 50,
+	}
+	setupTestRunway(t, "KTEST", rwy)
+
+	nmPerLong := float32(52) // ~40°N
+
+	tests := []struct {
+		name           string
+		pos            math.Point2LL
+		heading        float32
+		wantNil        bool   // expect go-around (nil)
+		wantBase       bool   // expect a _BASE waypoint
+		baseSide       string // "left" or "right" of centerline (looking inbound, i.e. north)
+	}{
+		{
+			name:    "Aligned on centerline, 8nm south",
+			pos:     math.Point2LL{0, -8.0 / 60}, // 8nm south
+			heading: 360,                           // heading north
+			wantBase: false,
+		},
+		{
+			name:    "Slightly offset (1nm east), 8nm south",
+			pos:     math.Point2LL{1.0 / nmPerLong, -8.0 / 60}, // 1nm east, 8nm south
+			heading: 360,
+			wantBase: false, // within 1.5nm threshold
+		},
+		{
+			name:     "Offset 3nm east, 8nm south — base turn right",
+			pos:      math.Point2LL{3.0 / nmPerLong, -8.0 / 60},
+			heading:  360,
+			wantBase: true,
+			baseSide: "right",
+		},
+		{
+			name:     "Offset 3nm west, 8nm south — base turn left",
+			pos:      math.Point2LL{-3.0 / nmPerLong, -8.0 / 60},
+			heading:  360,
+			wantBase: true,
+			baseSide: "left",
+		},
+		{
+			name:    "Behind threshold — go around",
+			pos:     math.Point2LL{0, 1.0 / 60}, // 1nm north of threshold
+			heading: 360,
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := nav.Nav{
+				FlightState: nav.FlightState{
+					Position:          tt.pos,
+					Heading:           tt.heading,
+					NmPerLongitude:    nmPerLong,
+					MagneticVariation: 0,
+					ArrivalAirport:    av.Waypoint{Fix: "KTEST"},
+				},
+				Approach: nav.NavApproach{
+					AssignedId: "V36",
+					Assigned:   &av.Approach{Type: av.ChartedVisualApproach, Runway: "36"},
+				},
+			}
+
+			intent, ok := n.ClearedDirectVisual("36", time.Time{})
+
+			if tt.wantNil {
+				if ok {
+					t.Fatalf("expected nil (go-around), got intent=%v", intent)
+				}
+				return
+			}
+			if !ok {
+				t.Fatal("expected waypoints, got nil (go-around)")
+			}
+
+			wps := n.Waypoints
+			if tt.wantBase {
+				// Expect: _BASE, _3NM_FINAL, _THRESHOLD
+				if len(wps) != 3 {
+					t.Fatalf("expected 3 waypoints, got %d: %v", len(wps), wpNames(wps))
+				}
+				if wps[0].Fix != "_36_BASE" {
+					t.Errorf("first waypoint = %q, want _36_BASE", wps[0].Fix)
+				}
+				if wps[1].Fix != "_36_3NM_FINAL" {
+					t.Errorf("second waypoint = %q, want _36_3NM_FINAL", wps[1].Fix)
+				}
+
+				// Verify the base waypoint is on the correct side.
+				baseNM := math.LL2NM(wps[0].Location, nmPerLong)
+				thresholdNM := math.LL2NM(rwy.Threshold, nmPerLong)
+				// For runway 36 (heading north), east is positive x.
+				dx := baseNM[0] - thresholdNM[0]
+				if tt.baseSide == "right" && dx <= 0 {
+					t.Errorf("base waypoint should be to the right (east), dx=%.2f", dx)
+				}
+				if tt.baseSide == "left" && dx >= 0 {
+					t.Errorf("base waypoint should be to the left (west), dx=%.2f", dx)
+				}
+			} else {
+				// Expect: _3NM_FINAL, _THRESHOLD
+				if len(wps) != 2 {
+					t.Fatalf("expected 2 waypoints, got %d: %v", len(wps), wpNames(wps))
+				}
+				if wps[0].Fix != "_36_3NM_FINAL" {
+					t.Errorf("first waypoint = %q, want _36_3NM_FINAL", wps[0].Fix)
+				}
+			}
+
+			// Last waypoint should always be the threshold with Land set.
+			last := wps[len(wps)-1]
+			if last.Fix != "_36_THRESHOLD" {
+				t.Errorf("last waypoint = %q, want _36_THRESHOLD", last.Fix)
+			}
+			if !last.Land {
+				t.Error("threshold waypoint should have Land=true")
+			}
+			if !last.FlyOver {
+				t.Error("threshold waypoint should have FlyOver=true")
+			}
+
+			// 3nm final should have an at-or-above altitude restriction.
+			var final3nm av.Waypoint
+			for _, wp := range wps {
+				if wp.Fix == "_36_3NM_FINAL" {
+					final3nm = wp
+				}
+			}
+			if final3nm.AltitudeRestriction == nil {
+				t.Error("3nm final should have an altitude restriction")
+			} else if final3nm.AltitudeRestriction.Range[0] == 0 {
+				t.Error("3nm final altitude lower bound should be non-zero")
+			}
+		})
+	}
+}
+
+func wpNames(wps []av.Waypoint) []string {
+	names := make([]string, len(wps))
+	for i, wp := range wps {
+		names[i] = wp.Fix
+	}
+	return names
+}
+
+func TestVisualRequestVisibilityFactor(t *testing.T) {
+	tests := []struct {
+		name       string
+		vis        float32
+		wantFactor float32
+		tolerance  float32
+	}{
+		{"3SM (VMC minimum)", 3, 0.3, 0.01},
+		{"5SM", 5, 0.5, 0.01},
+		{"10SM (clear)", 10, 1.0, 0.01},
+		{"15SM (unlimited)", 15, 1.0, 0.01},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := VisualVisibilityFactor(tt.vis)
+			diff := got - tt.wantFactor
+			if diff < 0 {
+				diff = -diff
+			}
+			if diff > tt.tolerance {
+				t.Errorf("VisualVisibilityFactor(%.0f) = %.4f, want %.4f (±%.2f)",
+					tt.vis, got, tt.wantFactor, tt.tolerance)
+			}
+		})
+	}
+}

--- a/sim/visual_approach_test.go
+++ b/sim/visual_approach_test.go
@@ -121,8 +121,8 @@ func TestCheckVisualEligibility(t *testing.T) {
 			wantField: false,
 		},
 		{
-			name:      "Nil assigned approach",
-			sim:       makeVisualTestSim(airportLoc, "13L"),
+			name: "Nil assigned approach",
+			sim:  makeVisualTestSim(airportLoc, "13L"),
 			ac: func() *Aircraft {
 				ac := makeVisualTestAircraft(math.Point2LL{0, 5.0 / 60}, 180)
 				ac.Nav.Approach.Assigned = nil
@@ -241,18 +241,18 @@ func TestVisualRequestBearingFilter(t *testing.T) {
 	acPos := math.Point2LL{0, 5.0 / 60} // 5nm north
 
 	tests := []struct {
-		name           string
-		heading        float32
+		name               string
+		heading            float32
 		shouldBePastFilter bool // true = bearing difference <= 120
 	}{
 		{"Heading south toward airport", 180, true},
 		{"Heading southwest", 225, true},
 		{"Heading southeast", 135, true},
-		{"Heading east (abeam)", 90, true},   // 90° off nose
-		{"Heading west (abeam)", 270, true},   // 90° off nose
-		{"Heading north away from airport", 0, false},  // 180° off nose
-		{"Heading NNE away", 30, false},       // 150° off nose
-		{"Heading NNW away", 330, false},      // 150° off nose
+		{"Heading east (abeam)", 90, true},            // 90° off nose
+		{"Heading west (abeam)", 270, true},           // 90° off nose
+		{"Heading north away from airport", 0, false}, // 180° off nose
+		{"Heading NNE away", 30, false},               // 150° off nose
+		{"Heading NNW away", 330, false},              // 150° off nose
 	}
 
 	for _, tt := range tests {
@@ -332,23 +332,23 @@ func TestVisualApproachWaypoints(t *testing.T) {
 	nmPerLong := float32(52) // ~40°N
 
 	tests := []struct {
-		name           string
-		pos            math.Point2LL
-		heading        float32
-		wantNil        bool   // expect go-around (nil)
-		wantBase       bool   // expect a _BASE waypoint
-		baseSide       string // "left" or "right" of centerline (looking inbound, i.e. north)
+		name     string
+		pos      math.Point2LL
+		heading  float32
+		wantNil  bool   // expect go-around (nil)
+		wantBase bool   // expect a _BASE waypoint
+		baseSide string // "left" or "right" of centerline (looking inbound, i.e. north)
 	}{
 		{
-			name:    "Aligned on centerline, 8nm south",
-			pos:     math.Point2LL{0, -8.0 / 60}, // 8nm south
-			heading: 360,                           // heading north
+			name:     "Aligned on centerline, 8nm south",
+			pos:      math.Point2LL{0, -8.0 / 60}, // 8nm south
+			heading:  360,                         // heading north
 			wantBase: false,
 		},
 		{
-			name:    "Slightly offset (1nm east), 8nm south",
-			pos:     math.Point2LL{1.0 / nmPerLong, -8.0 / 60}, // 1nm east, 8nm south
-			heading: 360,
+			name:     "Slightly offset (1nm east), 8nm south",
+			pos:      math.Point2LL{1.0 / nmPerLong, -8.0 / 60}, // 1nm east, 8nm south
+			heading:  360,
 			wantBase: false, // within 1.5nm threshold
 		},
 		{

--- a/sim/visual_approach_test.go
+++ b/sim/visual_approach_test.go
@@ -271,34 +271,6 @@ func TestVisualRequestBearingFilter(t *testing.T) {
 	}
 }
 
-func TestVisualRequestDistanceFactor(t *testing.T) {
-	tests := []struct {
-		name       string
-		dist       float32
-		wantFactor float32
-		tolerance  float32
-	}{
-		{"At airport", 0, 1.0, 0.01},
-		{"At 3nm", 3, 1.0, 0.01},
-		{"At 9nm (midpoint)", 9, 0.625, 0.01},
-		{"At 15nm", 15, 0.25, 0.01},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := VisualDistanceFactor(tt.dist)
-			diff := got - tt.wantFactor
-			if diff < 0 {
-				diff = -diff
-			}
-			if diff > tt.tolerance {
-				t.Errorf("VisualDistanceFactor(%.1f) = %.4f, want %.4f (±%.2f)",
-					tt.dist, got, tt.wantFactor, tt.tolerance)
-			}
-		})
-	}
-}
-
 // setupTestRunway installs a minimal runway into the global aviation DB
 // for the duration of the test, then removes it on cleanup.
 func setupTestRunway(t *testing.T, icao string, rwy av.Runway) {
@@ -469,32 +441,4 @@ func wpNames(wps []av.Waypoint) []string {
 		names[i] = wp.Fix
 	}
 	return names
-}
-
-func TestVisualRequestVisibilityFactor(t *testing.T) {
-	tests := []struct {
-		name       string
-		vis        float32
-		wantFactor float32
-		tolerance  float32
-	}{
-		{"3SM (VMC minimum)", 3, 0.3, 0.01},
-		{"5SM", 5, 0.5, 0.01},
-		{"10SM (clear)", 10, 1.0, 0.01},
-		{"15SM (unlimited)", 15, 1.0, 0.01},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := VisualVisibilityFactor(tt.vis)
-			diff := got - tt.wantFactor
-			if diff < 0 {
-				diff = -diff
-			}
-			if diff > tt.tolerance {
-				t.Errorf("VisualVisibilityFactor(%.0f) = %.4f, want %.4f (±%.2f)",
-					tt.vis, got, tt.wantFactor, tt.tolerance)
-			}
-		})
-	}
 }

--- a/sim/visual_approach_test.go
+++ b/sim/visual_approach_test.go
@@ -1,15 +1,216 @@
 package sim
 
 import (
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
 	av "github.com/mmp/vice/aviation"
+	"github.com/mmp/vice/log"
 	"github.com/mmp/vice/math"
 	"github.com/mmp/vice/nav"
 	vrand "github.com/mmp/vice/rand"
 	"github.com/mmp/vice/wx"
 )
+
+// VisualScenario is a test helper for stepping through multi-stage visual
+// approach flows. It sets up a minimal Sim with one aircraft and lets
+// tests issue commands and inspect both intents and pending transmissions.
+type VisualScenario struct {
+	t   *testing.T
+	Sim *Sim
+	AC  *Aircraft
+
+	callsign av.ADSBCallsign
+	tcw      TCW
+}
+
+// NewVisualScenario creates a scenario with an airport at the given location,
+// VMC METAR, and a single aircraft positioned at acPos heading in the given
+// direction. The aircraft has an ILS approach assigned for the given runway.
+func NewVisualScenario(t *testing.T, airportLoc math.Point2LL, runway string, acPos math.Point2LL, heading float32) *VisualScenario {
+	t.Helper()
+
+	callsign := av.ADSBCallsign("AAL123")
+	tcw := TCW("TEST")
+	freq := ControlPosition("125.0")
+
+	ac := &Aircraft{
+		ADSBCallsign:        callsign,
+		TypeOfFlight:        av.FlightTypeArrival,
+		ControllerFrequency: freq,
+		FlightPlan: av.FlightPlan{
+			ArrivalAirport: "KJFK",
+		},
+		Nav: nav.Nav{
+			FlightState: nav.FlightState{
+				Position:          acPos,
+				Heading:           heading,
+				Altitude:          3000,
+				NmPerLongitude:    52,
+				MagneticVariation: 0,
+				ArrivalAirport:    av.Waypoint{Fix: "KJFK"},
+				ArrivalAirportLocation: airportLoc,
+				ArrivalAirportElevation: 13,
+			},
+			Approach: nav.NavApproach{
+				AssignedId: "I" + runway,
+				Assigned: &av.Approach{
+					Type:   av.ILSApproach,
+					Runway: runway,
+				},
+			},
+		},
+	}
+
+	// Create a discard logger for tests.
+	lg := &log.Logger{Logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+
+	sim := &Sim{
+		lg:   lg,
+		Rand: vrand.Make(),
+		State: &CommonState{
+			DynamicState: DynamicState{
+				METAR: map[string]wx.METAR{
+					"KJFK": {Raw: "KJFK 10SM BKN050"},
+				},
+				SimTime:              time.Now(),
+				CurrentConsolidation: map[TCW]*TCPConsolidation{tcw: {PrimaryTCP: TCP(freq)}},
+			},
+			Airports: map[string]*av.Airport{
+				"KJFK": {
+					Location: airportLoc,
+					Approaches: map[string]*av.Approach{
+						"V" + runway: {Type: av.ChartedVisualApproach, Runway: runway},
+						"I" + runway: {Type: av.ILSApproach, Runway: runway},
+					},
+				},
+			},
+		},
+		Aircraft:        map[av.ADSBCallsign]*Aircraft{callsign: ac},
+		PendingContacts: make(map[TCP][]PendingContact),
+		PrivilegedTCWs:  map[TCW]bool{tcw: true},
+	}
+
+	return &VisualScenario{t: t, Sim: sim, AC: ac, callsign: callsign, tcw: tcw}
+}
+
+// SetMETAR replaces the METAR for KJFK.
+func (vs *VisualScenario) SetMETAR(raw string) {
+	vs.Sim.State.METAR["KJFK"] = wx.METAR{Raw: raw}
+}
+
+// SetPosition moves the aircraft.
+func (vs *VisualScenario) SetPosition(pos math.Point2LL) {
+	vs.AC.Nav.FlightState.Position = pos
+}
+
+// SetAltitude changes the aircraft altitude.
+func (vs *VisualScenario) SetAltitude(alt float32) {
+	vs.AC.Nav.FlightState.Altitude = alt
+}
+
+// AirportAdvisory issues an AP command and returns the intent.
+func (vs *VisualScenario) AirportAdvisory(oclock, miles int) av.CommandIntent {
+	vs.t.Helper()
+	cmd := fmt.Sprintf("AP/%d/%d", oclock, miles)
+	intent, err := vs.Sim.AirportAdvisory(vs.tcw, vs.callsign, cmd)
+	if err != nil {
+		vs.t.Fatalf("AirportAdvisory(%s) error: %v", cmd, err)
+	}
+	return intent
+}
+
+// ClearedVisual issues a CVA command and returns the intent.
+func (vs *VisualScenario) ClearedVisual(runway string) (av.CommandIntent, error) {
+	vs.t.Helper()
+	return vs.Sim.ClearedVisualApproach(vs.tcw, vs.callsign, runway)
+}
+
+// AdvanceTime moves sim time forward by d.
+func (vs *VisualScenario) AdvanceTime(d time.Duration) {
+	vs.Sim.State.SimTime = vs.Sim.State.SimTime.Add(d)
+}
+
+// CheckDelayedFieldInSight runs the delayed field-in-sight check.
+func (vs *VisualScenario) CheckDelayedFieldInSight() {
+	vs.Sim.checkDelayedFieldInSight(vs.AC)
+}
+
+// CheckSpontaneousVisual runs the spontaneous visual request check.
+func (vs *VisualScenario) CheckSpontaneousVisual() {
+	vs.Sim.checkSpontaneousVisualRequest(vs.AC)
+}
+
+// PendingTransmissions returns all pending transmission types for this aircraft.
+func (vs *VisualScenario) PendingTransmissions() []PendingTransmissionType {
+	var types []PendingTransmissionType
+	for _, pcs := range vs.Sim.PendingContacts {
+		for _, pc := range pcs {
+			if pc.ADSBCallsign == vs.callsign {
+				types = append(types, pc.Type)
+			}
+		}
+	}
+	return types
+}
+
+// HasPendingTransmission checks if a specific transmission type is pending.
+func (vs *VisualScenario) HasPendingTransmission(txType PendingTransmissionType) bool {
+	for _, t := range vs.PendingTransmissions() {
+		if t == txType {
+			return true
+		}
+	}
+	return false
+}
+
+// ClearPendingTransmissions removes all pending transmissions.
+func (vs *VisualScenario) ClearPendingTransmissions() {
+	vs.Sim.PendingContacts = make(map[TCP][]PendingContact)
+}
+
+// ExpectFieldInSight asserts the intent is FieldInSightIntent with HasField=true.
+func (vs *VisualScenario) ExpectFieldInSight(intent av.CommandIntent) {
+	vs.t.Helper()
+	fi, ok := intent.(av.FieldInSightIntent)
+	if !ok {
+		vs.t.Fatalf("expected FieldInSightIntent, got %T", intent)
+	}
+	if !fi.HasField {
+		vs.t.Error("expected HasField=true")
+	}
+}
+
+// ExpectLooking asserts the intent is FieldInSightIntent with Looking=true.
+func (vs *VisualScenario) ExpectLooking(intent av.CommandIntent) {
+	vs.t.Helper()
+	fi, ok := intent.(av.FieldInSightIntent)
+	if !ok {
+		vs.t.Fatalf("expected FieldInSightIntent, got %T", intent)
+	}
+	if !fi.Looking {
+		vs.t.Error("expected Looking=true")
+	}
+	if fi.HasField {
+		vs.t.Error("expected HasField=false when Looking")
+	}
+}
+
+// ExpectIMC asserts the intent is FieldInSightIntent with neither HasField nor Looking.
+func (vs *VisualScenario) ExpectIMC(intent av.CommandIntent) {
+	vs.t.Helper()
+	fi, ok := intent.(av.FieldInSightIntent)
+	if !ok {
+		vs.t.Fatalf("expected FieldInSightIntent, got %T", intent)
+	}
+	if fi.HasField || fi.Looking {
+		vs.t.Errorf("expected IMC response (HasField=false, Looking=false), got HasField=%v Looking=%v", fi.HasField, fi.Looking)
+	}
+}
 
 // makeVisualTestAircraft creates an arrival aircraft with an ILS approach
 // assigned, on frequency, positioned at the given location heading in the
@@ -129,14 +330,14 @@ func TestCheckVisualEligibility(t *testing.T) {
 			wantField: false,
 		},
 		{
-			name: "Nil assigned approach",
+			name: "Nil assigned approach — still sees field, just no runway",
 			sim:  makeVisualTestSim(airportLoc, "13L"),
 			ac: func() *Aircraft {
 				ac := makeVisualTestAircraft(math.Point2LL{0, 5.0 / 60}, 180)
 				ac.Nav.Approach.Assigned = nil
 				return ac
 			}(),
-			wantField: false,
+			wantField: true,
 		},
 		{
 			name: "Unknown arrival airport",
@@ -486,7 +687,7 @@ func TestVisualApproachWaypoints(t *testing.T) {
 				t.Error("threshold waypoint should have FlyOver=true")
 			}
 
-			// 3nm final should have an at-or-above altitude restriction.
+			// 3nm final should have an "at" altitude restriction.
 			var final3nm av.Waypoint
 			for _, wp := range wps {
 				if wp.Fix == "_36_3NM_FINAL" {
@@ -495,8 +696,8 @@ func TestVisualApproachWaypoints(t *testing.T) {
 			}
 			if alt := final3nm.AltitudeRestriction(); alt == nil {
 				t.Error("3nm final should have an altitude restriction")
-			} else if alt.Range[0] == 0 {
-				t.Error("3nm final altitude lower bound should be non-zero")
+			} else if alt.Range[0] == 0 || alt.Range[0] != alt.Range[1] {
+				t.Errorf("3nm final altitude should be 'at' (range[0]==range[1]), got %v", alt.Range)
 			}
 		})
 	}
@@ -667,7 +868,7 @@ func TestDelayedFieldInSight(t *testing.T) {
 	}
 }
 
-func TestCVRequiresFieldInSight(t *testing.T) {
+func TestCVARequiresFieldInSight(t *testing.T) {
 	tests := []struct {
 		name      string
 		setup     func(ac *Aircraft)
@@ -698,8 +899,272 @@ func TestCVRequiresFieldInSight(t *testing.T) {
 			// Mirror the gate check in ClearedVisualApproach.
 			allowed := ac.FieldInSight || ac.RequestedVisual
 			if allowed != tt.wantAllow {
-				t.Errorf("CV gate: allowed=%v, want %v", allowed, tt.wantAllow)
+				t.Errorf("CVA gate: allowed=%v, want %v", allowed, tt.wantAllow)
 			}
 		})
 	}
+}
+
+func TestEVACommandReturnsGenericExpect(t *testing.T) {
+	// EVA commands should return a generic "Visual Runway XX" expect intent,
+	// NOT resolve to a charted visual approach name like "Belmont Visual".
+	tests := []struct {
+		name    string
+		command string // e.g. "EVA22L"
+		wantRwy string // expected in ApproachName
+	}{
+		{"EVA22L", "EVA22L", "22L"},
+		{"EVA13R", "EVA13R", "13R"},
+		{"EVA31", "EVA31", "31"},
+		{"EVA4R", "EVA4R", "4R"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Simulate the EVA handler logic from RunAircraftCommands.
+			if !strings.HasPrefix(tt.command, "EVA") || len(tt.command) <= 3 {
+				t.Fatal("bad test command")
+			}
+			runway := tt.command[3:]
+			intent := av.ApproachIntent{
+				Type:         av.ApproachExpect,
+				ApproachName: "Visual Runway " + runway,
+			}
+
+			if intent.Type != av.ApproachExpect {
+				t.Errorf("intent type = %v, want ApproachExpect", intent.Type)
+			}
+			wantName := "Visual Runway " + tt.wantRwy
+			if intent.ApproachName != wantName {
+				t.Errorf("ApproachName = %q, want %q", intent.ApproachName, wantName)
+			}
+			// Must NOT contain charted visual names.
+			for _, bad := range []string{"Belmont", "River", "Expressway"} {
+				if strings.Contains(intent.ApproachName, bad) {
+					t.Errorf("ApproachName %q should not contain charted visual name %q", intent.ApproachName, bad)
+				}
+			}
+		})
+	}
+}
+
+func TestSpontaneousTransmissionsUseContactType(t *testing.T) {
+	// Pilot-initiated transmissions (field in sight, traffic in sight,
+	// visual request) should use MakeContactTransmission, not
+	// MakeReadbackTransmission. Contact transmissions get the
+	// "Approach, {callsign}, ..." prefix automatically; readback
+	// transmissions get "{message}, {callsign}" suffix format.
+	tests := []struct {
+		name    string
+		makeFn  func() *av.RadioTransmission
+		wantTyp int
+	}{
+		{
+			name:    "traffic in sight",
+			makeFn:  func() *av.RadioTransmission { return av.MakeContactTransmission("[traffic in sight]") },
+			wantTyp: av.RadioTransmissionContact,
+		},
+		{
+			name:    "field in sight",
+			makeFn:  func() *av.RadioTransmission { return av.MakeContactTransmission("[field in sight]") },
+			wantTyp: av.RadioTransmissionContact,
+		},
+		{
+			name:    "negative field",
+			makeFn:  func() *av.RadioTransmission { return av.MakeContactTransmission("[negative field]") },
+			wantTyp: av.RadioTransmissionContact,
+		},
+		{
+			name: "visual request",
+			makeFn: func() *av.RadioTransmission {
+				return av.MakeContactTransmission("[field in sight], [requesting the visual] runway {rwy}", "13L")
+			},
+			wantTyp: av.RadioTransmissionContact,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rt := tt.makeFn()
+			if rt.Type != av.RadioTransmissionType(tt.wantTyp) {
+				t.Errorf("Type = %v, want RadioTransmissionContact (%d)", rt.Type, tt.wantTyp)
+			}
+		})
+	}
+}
+
+func TestTransmissionStringsNoDoubleApproach(t *testing.T) {
+	// The transmission template strings for spontaneous pilot messages
+	// should NOT contain "approach" or "{callsign}" — those are added
+	// automatically by the radio transmission system.
+	templates := []struct {
+		name     string
+		template string
+	}{
+		{"traffic in sight", "[we've got the traffic|we have the traffic in sight|traffic in sight now]"},
+		{"field in sight", "[we have the field in sight now|field in sight|we have the airport in sight now]"},
+		{"negative field", "[negative field|field not in sight|no joy on the field]"},
+		{"visual request", "[field in sight|we have the airport in sight], [requesting the visual|can we get the visual] [approach |]runway {rwy}"},
+	}
+
+	for _, tt := range templates {
+		t.Run(tt.name, func(t *testing.T) {
+			// Should not start with "[approach" or contain "{callsign}"
+			if strings.HasPrefix(tt.template, "[approach") {
+				t.Errorf("template starts with [approach — this will cause double 'approach' in output")
+			}
+			if strings.Contains(tt.template, "{callsign}") {
+				t.Errorf("template contains {callsign} — callsign is added automatically by MakeContactTransmission")
+			}
+		})
+	}
+}
+
+// === Scenario tests using VisualScenario helper ===
+
+func TestScenarioAPThenClearedVisual(t *testing.T) {
+	// Full flow: AP advisory → field in sight → CVA clearance.
+	airportLoc := math.Point2LL{0, 0}
+	setupTestRunway(t, "KJFK", av.Runway{Id: "36", Heading: 360, Threshold: airportLoc, Elevation: 13})
+
+	// Aircraft 5nm south heading north — on extended centerline for runway 36.
+	vs := NewVisualScenario(t, airportLoc, "36", math.Point2LL{0, -5.0 / 60}, 360)
+
+	// Issue AP: 12 o'clock, 5 miles. Should get field in sight or looking.
+	intent := vs.AirportAdvisory(12, 5)
+	fi, ok := intent.(av.FieldInSightIntent)
+	if !ok {
+		t.Fatalf("expected FieldInSightIntent, got %T", intent)
+	}
+
+	if fi.HasField {
+		// Great — pilot sees the field. Should accept CVA now.
+		intent, err := vs.ClearedVisual("36")
+		if err != nil {
+			t.Fatalf("ClearedVisual error: %v", err)
+		}
+		if intent == nil {
+			t.Fatal("expected non-nil intent from CVA")
+		}
+	} else if fi.Looking {
+		// Pilot is looking — advance time and check delayed callback.
+		vs.AdvanceTime(25 * time.Second)
+		vs.CheckDelayedFieldInSight()
+
+		if vs.AC.FieldInSight {
+			// Now CVA should work.
+			intent, err := vs.ClearedVisual("36")
+			if err != nil {
+				t.Fatalf("ClearedVisual after delayed field: %v", err)
+			}
+			if intent == nil {
+				t.Fatal("expected non-nil intent from CVA after delayed field")
+			}
+		}
+	}
+}
+
+func TestScenarioCVARefusedWithoutFieldInSight(t *testing.T) {
+	airportLoc := math.Point2LL{0, 0}
+	setupTestRunway(t, "KJFK", av.Runway{Id: "13L", Heading: 130, Threshold: airportLoc, Elevation: 13})
+
+	vs := NewVisualScenario(t, airportLoc, "13L", math.Point2LL{0, 5.0 / 60}, 180)
+
+	// Try CVA without field in sight — should be refused.
+	intent, err := vs.ClearedVisual("13L")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := intent.(av.UnableIntent); !ok {
+		t.Errorf("expected UnableIntent without field in sight, got %T", intent)
+	}
+}
+
+func TestScenarioAPInIMC(t *testing.T) {
+	airportLoc := math.Point2LL{0, 0}
+	setupTestRunway(t, "KJFK", av.Runway{Id: "13L", Heading: 130, Threshold: airportLoc, Elevation: 13})
+
+	vs := NewVisualScenario(t, airportLoc, "13L", math.Point2LL{0, 5.0 / 60}, 180)
+	vs.SetMETAR("KJFK 1SM OVC003") // IMC
+
+	intent := vs.AirportAdvisory(12, 5)
+	vs.ExpectIMC(intent)
+}
+
+func TestScenarioAPBadDirection(t *testing.T) {
+	// Airport is south, but controller says 6 o'clock (behind).
+	airportLoc := math.Point2LL{0, 0}
+	setupTestRunway(t, "KJFK", av.Runway{Id: "13L", Heading: 130, Threshold: airportLoc, Elevation: 13})
+
+	vs := NewVisualScenario(t, airportLoc, "13L", math.Point2LL{0, 5.0 / 60}, 180)
+
+	intent := vs.AirportAdvisory(6, 5) // 6 o'clock = behind = wrong
+	vs.ExpectLooking(intent)
+}
+
+func TestScenarioSpontaneousFieldInSight(t *testing.T) {
+	airportLoc := math.Point2LL{0, 0}
+	setupTestRunway(t, "KJFK", av.Runway{Id: "13L", Heading: 130, Threshold: airportLoc, Elevation: 13})
+
+	vs := NewVisualScenario(t, airportLoc, "13L", math.Point2LL{0, 5.0 / 60}, 180)
+	vs.AC.WantsVisual = true
+	vs.AC.WantsVisualRequest = false
+
+	// First check sets VisualRequestTime (delay).
+	vs.CheckSpontaneousVisual()
+	if vs.AC.FieldInSight {
+		t.Fatal("field in sight should not be immediate — delay expected")
+	}
+	if vs.AC.VisualRequestTime.IsZero() {
+		t.Fatal("VisualRequestTime should be set after first eligibility check")
+	}
+
+	// Advance past the delay.
+	vs.AdvanceTime(10 * time.Second)
+	vs.CheckSpontaneousVisual()
+
+	if !vs.AC.FieldInSight {
+		t.Error("expected FieldInSight after delay expired")
+	}
+	if !vs.HasPendingTransmission(PendingTransmissionFieldInSight) {
+		t.Error("expected PendingTransmissionFieldInSight to be enqueued")
+	}
+}
+
+func TestScenarioSpontaneousVisualRequest(t *testing.T) {
+	airportLoc := math.Point2LL{0, 0}
+	setupTestRunway(t, "KJFK", av.Runway{Id: "13L", Heading: 130, Threshold: airportLoc, Elevation: 13})
+
+	vs := NewVisualScenario(t, airportLoc, "13L", math.Point2LL{0, 5.0 / 60}, 180)
+	vs.AC.WantsVisual = true
+	vs.AC.WantsVisualRequest = true
+
+	// First check → sets delay.
+	vs.CheckSpontaneousVisual()
+
+	// Advance past delay.
+	vs.AdvanceTime(10 * time.Second)
+	vs.CheckSpontaneousVisual()
+
+	if !vs.AC.FieldInSight {
+		t.Error("expected FieldInSight")
+	}
+	if !vs.AC.RequestedVisual {
+		t.Error("expected RequestedVisual when WantsVisualRequest=true")
+	}
+	if !vs.HasPendingTransmission(PendingTransmissionRequestVisual) {
+		t.Error("expected PendingTransmissionRequestVisual to be enqueued")
+	}
+}
+
+func TestScenarioAboveCeilingIMC(t *testing.T) {
+	airportLoc := math.Point2LL{0, 0}
+	setupTestRunway(t, "KJFK", av.Runway{Id: "13L", Heading: 130, Threshold: airportLoc, Elevation: 13})
+
+	vs := NewVisualScenario(t, airportLoc, "13L", math.Point2LL{0, 5.0 / 60}, 180)
+	vs.SetMETAR("KJFK 10SM BKN030") // 3000ft ceiling, VMC surface
+	vs.SetAltitude(4000)             // above ceiling
+
+	intent := vs.AirportAdvisory(12, 5)
+	vs.ExpectIMC(intent) // Aircraft in clouds → IMC response
 }

--- a/stt/handlers.go
+++ b/stt/handlers.go
@@ -922,7 +922,7 @@ func registerAllCommands() {
 
 	// === AIRPORT ADVISORY ===
 	registerSTTCommand(
-		"airport [at] [your] {num:1-12} o'clock {num:1-50} [miles|mile]",
+		"[airport|field] [at] [your] {num:1-12} o'clock {num:1-50} [miles|mile]",
 		func(oclock int, miles int) string {
 			return fmt.Sprintf("AP/%d/%d", oclock, miles)
 		},
@@ -930,11 +930,11 @@ func registerAllCommands() {
 		WithPriority(10),
 	)
 	registerSTTCommand(
-		"field [at] [your] {num:1-12} o'clock {num:1-50} [miles|mile]",
+		"report [the] [field|airport] in sight [at] [your] {num:1-12} o'clock {num:1-50} [miles|mile]",
 		func(oclock int, miles int) string {
 			return fmt.Sprintf("AP/%d/%d", oclock, miles)
 		},
-		WithName("airport_advisory_field"),
+		WithName("airport_advisory_report"),
 		WithPriority(10),
 	)
 }

--- a/stt/handlers.go
+++ b/stt/handlers.go
@@ -920,11 +920,21 @@ func registerAllCommands() {
 		WithPriority(15),
 	)
 
-	// === FIELD IN SIGHT ===
+	// === AIRPORT ADVISORY ===
 	registerSTTCommand(
-		"[do you] [have the|have] field in sight|[do you] [have the|have] airport in sight",
-		func() string { return "FS" },
-		WithName("field_in_sight"),
+		"airport [at] [your] {num:1-12} o'clock {num:1-50} [miles|mile]",
+		func(oclock int, miles int) string {
+			return fmt.Sprintf("AP/%d/%d", oclock, miles)
+		},
+		WithName("airport_advisory"),
+		WithPriority(10),
+	)
+	registerSTTCommand(
+		"field [at] [your] {num:1-12} o'clock {num:1-50} [miles|mile]",
+		func(oclock int, miles int) string {
+			return fmt.Sprintf("AP/%d/%d", oclock, miles)
+		},
+		WithName("airport_advisory_field"),
 		WithPriority(10),
 	)
 }

--- a/stt/handlers.go
+++ b/stt/handlers.go
@@ -922,11 +922,19 @@ func registerAllCommands() {
 
 	// === AIRPORT ADVISORY ===
 	registerSTTCommand(
-		"[airport|field] [at] [your] {num:1-12} o'clock {num:1-50} [miles|mile]",
+		"airport [at] [your] {num:1-12} o'clock {num:1-50} [miles|mile]",
 		func(oclock int, miles int) string {
 			return fmt.Sprintf("AP/%d/%d", oclock, miles)
 		},
 		WithName("airport_advisory"),
+		WithPriority(10),
+	)
+	registerSTTCommand(
+		"field [at] [your] {num:1-12} o'clock {num:1-50} [miles|mile]",
+		func(oclock int, miles int) string {
+			return fmt.Sprintf("AP/%d/%d", oclock, miles)
+		},
+		WithName("airport_advisory_field"),
 		WithPriority(10),
 	)
 	registerSTTCommand(

--- a/stt/handlers.go
+++ b/stt/handlers.go
@@ -605,6 +605,31 @@ func registerAllCommands() {
 	)
 
 	registerSTTCommand(
+		"cleared [the] visual [approach] [runway] {num:1-36} left",
+		func(rwy int) string { return fmt.Sprintf("CV%dL", rwy) },
+		WithName("cleared_visual_left"),
+		WithPriority(17),
+	)
+	registerSTTCommand(
+		"cleared [the] visual [approach] [runway] {num:1-36} right",
+		func(rwy int) string { return fmt.Sprintf("CV%dR", rwy) },
+		WithName("cleared_visual_right"),
+		WithPriority(17),
+	)
+	registerSTTCommand(
+		"cleared [the] visual [approach] [runway] {num:1-36} center",
+		func(rwy int) string { return fmt.Sprintf("CV%dC", rwy) },
+		WithName("cleared_visual_center"),
+		WithPriority(17),
+	)
+	registerSTTCommand(
+		"cleared [the] visual [approach] [runway] {num:1-36}",
+		func(rwy int) string { return fmt.Sprintf("CV%d", rwy) },
+		WithName("cleared_visual"),
+		WithPriority(16),
+	)
+
+	registerSTTCommand(
 		"cleared [approach] [for] {approach}",
 		func(appr string) string { return fmt.Sprintf("C%s", appr) },
 		WithName("cleared_approach"),
@@ -893,5 +918,13 @@ func registerAllCommands() {
 		func(letter string) string { return "ATIS/" + letter },
 		WithName("advise_have_information"),
 		WithPriority(15),
+	)
+
+	// === FIELD IN SIGHT ===
+	registerSTTCommand(
+		"[do you] [have the|have] field in sight|[do you] [have the|have] airport in sight",
+		func() string { return "FS" },
+		WithName("field_in_sight"),
+		WithPriority(10),
 	)
 }

--- a/stt/handlers.go
+++ b/stt/handlers.go
@@ -604,27 +604,80 @@ func registerAllCommands() {
 		WithPriority(15),
 	)
 
+	// "expect visual approach runway XX" — higher priority than generic "expect {approach_lahso}"
+	// to prevent "expect visual approach runway 22L" from matching a charted visual via {approach_lahso}.
+	registerSTTCommand(
+		"expect [the|vectors] [for] [to] visual [approach] [runway] {num:1-36} left",
+		func(rwy int) string { return fmt.Sprintf("EVA%dL", rwy) },
+		WithName("expect_visual_left"),
+		WithPriority(17),
+	)
+	registerSTTCommand(
+		"expect [the|vectors] [for] [to] visual [approach] [runway] {num:1-36} right",
+		func(rwy int) string { return fmt.Sprintf("EVA%dR", rwy) },
+		WithName("expect_visual_right"),
+		WithPriority(17),
+	)
+	registerSTTCommand(
+		"expect [the|vectors] [for] [to] visual [approach] [runway] {num:1-36} center",
+		func(rwy int) string { return fmt.Sprintf("EVA%dC", rwy) },
+		WithName("expect_visual_center"),
+		WithPriority(17),
+	)
+	registerSTTCommand(
+		"expect [the|vectors] [for] [to] visual [approach] [runway] {num:1-36}",
+		func(rwy int) string { return fmt.Sprintf("EVA%d", rwy) },
+		WithName("expect_visual"),
+		WithPriority(16),
+	)
+
+	// "vectors visual approach runway XX" — same priority as cleared visual
+	registerSTTCommand(
+		"vector|vectors [for] [to] [the] visual [approach] [runway] {num:1-36} left",
+		func(rwy int) string { return fmt.Sprintf("EVA%dL", rwy) },
+		WithName("vectors_visual_left"),
+		WithPriority(17),
+	)
+	registerSTTCommand(
+		"vector|vectors [for] [to] [the] visual [approach] [runway] {num:1-36} right",
+		func(rwy int) string { return fmt.Sprintf("EVA%dR", rwy) },
+		WithName("vectors_visual_right"),
+		WithPriority(17),
+	)
+	registerSTTCommand(
+		"vector|vectors [for] [to] [the] visual [approach] [runway] {num:1-36} center",
+		func(rwy int) string { return fmt.Sprintf("EVA%dC", rwy) },
+		WithName("vectors_visual_center"),
+		WithPriority(17),
+	)
+	registerSTTCommand(
+		"vector|vectors [for] [to] [the] visual [approach] [runway] {num:1-36}",
+		func(rwy int) string { return fmt.Sprintf("EVA%d", rwy) },
+		WithName("vectors_visual"),
+		WithPriority(16),
+	)
+
 	registerSTTCommand(
 		"cleared [the] visual [approach] [runway] {num:1-36} left",
-		func(rwy int) string { return fmt.Sprintf("CV%dL", rwy) },
+		func(rwy int) string { return fmt.Sprintf("CVA%dL", rwy) },
 		WithName("cleared_visual_left"),
 		WithPriority(17),
 	)
 	registerSTTCommand(
 		"cleared [the] visual [approach] [runway] {num:1-36} right",
-		func(rwy int) string { return fmt.Sprintf("CV%dR", rwy) },
+		func(rwy int) string { return fmt.Sprintf("CVA%dR", rwy) },
 		WithName("cleared_visual_right"),
 		WithPriority(17),
 	)
 	registerSTTCommand(
 		"cleared [the] visual [approach] [runway] {num:1-36} center",
-		func(rwy int) string { return fmt.Sprintf("CV%dC", rwy) },
+		func(rwy int) string { return fmt.Sprintf("CVA%dC", rwy) },
 		WithName("cleared_visual_center"),
 		WithPriority(17),
 	)
 	registerSTTCommand(
 		"cleared [the] visual [approach] [runway] {num:1-36}",
-		func(rwy int) string { return fmt.Sprintf("CV%d", rwy) },
+		func(rwy int) string { return fmt.Sprintf("CVA%d", rwy) },
 		WithName("cleared_visual"),
 		WithPriority(16),
 	)
@@ -944,5 +997,15 @@ func registerAllCommands() {
 		},
 		WithName("airport_advisory_report"),
 		WithPriority(10),
+	)
+	// Variant that accepts any leading word(s) before o'clock (e.g., "kennedy is at
+	// your 11 o'clock 8 miles"). The {fix} type absorbs the airport name token.
+	registerSTTCommand(
+		"{fix} [is] [at] [your] {num:1-12} o'clock {num:1-50} [miles|mile]",
+		func(_ string, oclock int, miles int) string {
+			return fmt.Sprintf("AP/%d/%d", oclock, miles)
+		},
+		WithName("airport_advisory_named"),
+		WithPriority(9), // Lower priority so explicit "airport"/"field" patterns win
 	)
 }

--- a/stt/provider_test.go
+++ b/stt/provider_test.go
@@ -1844,7 +1844,7 @@ func TestVisualApproachSTTPatterns(t *testing.T) {
 				State: "arrival",
 				CandidateApproaches: map[string]string{
 					"Visual belmont runway two two left": "VB2L", // charted visual — should NOT match
-					"I L S runway two two left":         "I22L",
+					"I L S runway two two left":          "I22L",
 				},
 			},
 			expected: []string{"EVA22L"},

--- a/stt/tests/delta_forty_three_expect_visual_approach_runway_on.json
+++ b/stt/tests/delta_forty_three_expect_visual_approach_runway_on.json
@@ -15,7 +15,7 @@
   "processor": "GPU: NVIDIA GeForce RTX 5080 (15889MB)",
   "whisper_model": "ggml-medium.en-jlvatc-q5_0.bin",
   "callsign": "DAL43",
-  "command": "EVR1",
+  "command": "EVA12R",
   "stt_aircraft": {
     "Delta 43": {
       "Callsign": "DAL43",

--- a/stt/tests/frontier_flight_two_13_73_cleared_visual_runway_tw.json
+++ b/stt/tests/frontier_flight_two_13_73_cleared_visual_runway_tw.json
@@ -15,7 +15,7 @@
   "processor": "GPU: Apple M1, 8 CPU / 8 GPU cores, 8GB",
   "whisper_model": "ggml-medium.en-jlvatc-q5_0.bin",
   "callsign": "FFT1373",
-  "command": "CV26",
+  "command": "CVA26",
   "stt_aircraft": {
     "Frontier Flight 13 73": {
       "Callsign": "FFT1373",

--- a/stt/tests/southwest_two_47_cleared_visual_runway_two_six.json
+++ b/stt/tests/southwest_two_47_cleared_visual_runway_two_six.json
@@ -15,7 +15,7 @@
   "processor": "GPU: Apple M1, 8 CPU / 8 GPU cores, 8GB",
   "whisper_model": "ggml-medium.en-jlvatc-q5_0.bin",
   "callsign": "SWA247",
-  "command": "CV26",
+  "command": "CVA26",
   "stt_aircraft": {
     "Alaska 72 88": {
       "Callsign": "ASA7288",

--- a/stt/tests/suncountry_five_zero_five_expect_a_visual_approach.json
+++ b/stt/tests/suncountry_five_zero_five_expect_a_visual_approach.json
@@ -15,7 +15,7 @@
   "processor": "GPU: NVIDIA GeForce RTX 5080 (15889MB)",
   "whisper_model": "ggml-medium.en-jlvatc-q5_0.bin",
   "callsign": "SCX505",
-  "command": "EVR1",
+  "command": "EVA12R",
   "stt_aircraft": {
     "Delta 43": {
       "Callsign": "DAL43",

--- a/website/index.html
+++ b/website/index.html
@@ -1002,6 +1002,19 @@ A11, A80, A90, AAC, ABE, ABQ, AGS, ALB, ASE, AUS, AVL, BGR, BHM, BIL, BNA, BOI, 
                     but not descend until it is cleared for the approach.)</td>
                     <td><code>I</code></td>
                   </tr>
+                  <tr>
+                    <td><code>CV</code><i>runway</i></td>
+                    <td>Clears the aircraft for a visual approach to the
+                    specified runway. The aircraft will fly a straight-in
+                    if aligned or insert a base turn if offset from the
+                    centerline.</td>
+                    <td><code>CV13L</code></td>
+                  </tr>
+                  <tr>
+                    <td><code>FS</code></td>
+                    <td>Asks the pilot if they have the field in sight.</td>
+                    <td><code>FS</code></td>
+                  </tr>
                 </tbody>
               </table>
 
@@ -1350,6 +1363,17 @@ A11, A80, A90, AAC, ABE, ABQ, AGS, ALB, ASE, AUS, AVL, BGR, BHM, BIL, BNA, BOI, 
                   <td>
                     <i>Cancel approach clearance</i>
                   </td>
+                </tr>
+                <tr><td>Cleared Visual Approach</td>
+                  <td>
+                    <i>Cleared visual (runway)</i> /  <i>Cleared the visual approach runway (runway)</i>
+                  </td>
+                </tr>
+                <tr><td>Field in Sight</td>
+                  <td>
+                    <i>Do you have the field in sight</i> /  <i>Have the field in sight</i> /  <i>Do you have the airport in sight</i>
+                  </td>
+                </tr>
               </tbody>
             </table>
             <h3>VFR Aircraft</h3>

--- a/website/index.html
+++ b/website/index.html
@@ -1003,17 +1003,23 @@ A11, A80, A90, AAC, ABE, ABQ, AGS, ALB, ASE, AUS, AVL, BGR, BHM, BIL, BNA, BOI, 
                     <td><code>I</code></td>
                   </tr>
                   <tr>
+                    <td><code>AP/</code><i>oclock</i><code>/</code><i>miles</i></td>
+                    <td>Tells the pilot where to look for the airport
+                    (e.g., "airport, 2 o'clock, 8 miles"). The pilot
+                    responds "field in sight" or "looking" depending
+                    on conditions. The pilot must have the field in
+                    sight before you can clear the visual approach.</td>
+                    <td><code>AP/2/8</code></td>
+                  </tr>
+                  <tr>
                     <td><code>CV</code><i>runway</i></td>
                     <td>Clears the aircraft for a visual approach to the
-                    specified runway. The aircraft will fly a straight-in
+                    specified runway. Requires the pilot to have the
+                    field in sight (via AP command or spontaneous
+                    report). The aircraft will fly a straight-in
                     if aligned or insert a base turn if offset from the
                     centerline.</td>
                     <td><code>CV13L</code></td>
-                  </tr>
-                  <tr>
-                    <td><code>FS</code></td>
-                    <td>Asks the pilot if they have the field in sight.</td>
-                    <td><code>FS</code></td>
                   </tr>
                 </tbody>
               </table>
@@ -1369,9 +1375,9 @@ A11, A80, A90, AAC, ABE, ABQ, AGS, ALB, ASE, AUS, AVL, BGR, BHM, BIL, BNA, BOI, 
                     <i>Cleared visual (runway)</i> /  <i>Cleared the visual approach runway (runway)</i>
                   </td>
                 </tr>
-                <tr><td>Field in Sight</td>
+                <tr><td>Airport Advisory</td>
                   <td>
-                    <i>Do you have the field in sight</i> /  <i>Have the field in sight</i> /  <i>Do you have the airport in sight</i>
+                    <i>Airport (N) o'clock (N) miles</i> /  <i>Field (N) o'clock (N) miles</i>
                   </td>
                 </tr>
               </tbody>

--- a/website/index.html
+++ b/website/index.html
@@ -1016,7 +1016,8 @@ A11, A80, A90, AAC, ABE, ABQ, AGS, ALB, ASE, AUS, AVL, BGR, BHM, BIL, BNA, BOI, 
                     <td>Clears the aircraft for a visual approach to the
                     specified runway. Requires the pilot to have the
                     field in sight (via AP command or spontaneous
-                    report). The aircraft will fly a straight-in
+                    report) or preceding traffic in sight (via traffic
+                    advisory). The aircraft will fly a straight-in
                     if aligned or insert a base turn if offset from the
                     centerline.</td>
                     <td><code>CV13L</code></td>

--- a/website/index.html
+++ b/website/index.html
@@ -1012,7 +1012,7 @@ A11, A80, A90, AAC, ABE, ABQ, AGS, ALB, ASE, AUS, AVL, BGR, BHM, BIL, BNA, BOI, 
                     <td><code>AP/2/8</code></td>
                   </tr>
                   <tr>
-                    <td><code>CV</code><i>runway</i></td>
+                    <td><code>CVA</code><i>runway</i></td>
                     <td>Clears the aircraft for a visual approach to the
                     specified runway. Requires the pilot to have the
                     field in sight (via AP command or spontaneous
@@ -1020,7 +1020,7 @@ A11, A80, A90, AAC, ABE, ABQ, AGS, ALB, ASE, AUS, AVL, BGR, BHM, BIL, BNA, BOI, 
                     advisory). The aircraft will fly a straight-in
                     if aligned or insert a base turn if offset from the
                     centerline.</td>
-                    <td><code>CV13L</code></td>
+                    <td><code>CVA13L</code></td>
                   </tr>
                 </tbody>
               </table>


### PR DESCRIPTION
I took a stab at adding visual approach support. I tried to make some reasonable assumptions, but happy to iterate based on feedback.

Pilots spontaneously request the visual when they have the field in sight, controllers can ask (FS), and controllers can clear direct visual approaches (CV<runway>). Charted visual approaches (e.g., Belmont Visual) remain separate via the C command. STT equivalents are included for all new commands.

  - Pilots report "field in sight, requesting the visual" when VMC, within 15nm, and airport visible. Probability scales with distance and visibility. The controller decides whether to clear a plain visual (CV) or a charted visual procedure (C).
  - FS command queries the pilot for field in sight.
  - CV<runway> clears a direct visual: flies straight-in when aligned, inserts a base-turn waypoint when offset >1.5nm from centerline. 

  **Assumptions**
   Pilot behavior
  - Pilots always request "the visual" generically - the controller decides whether to clear a plain visual (CV) or a charted visual procedure (C).
  - Pilots have roughly a 3% chance per second of requesting the visual when close in clear weather, lower when further out or in marginal VFR. Once they've requested, they don't ask again.
  - Field-in-sight is modeled as VMC weather + within 15nm + airport within 120° of the nose. No terrain or obstruction modeling for now.

  Flight path
  - No downwind/base/final pattern - in Class B airspace the controller has hopefully somewhat positioned the aircraft, so we just need to get them turned onto final.
  - Aircraft offset more than 1.5nm from the centerline get a base-turn waypoint so they don't cut diagonally across to final. It's placed far enough out (~4.5nm) that they roll out on a normal 3nm final.
  - The 3nm final point has a "don't be below 900ft AGL" restriction matching a standard 3° glideslope. The base-turn point has no altitude constraint - pilot manages their own descent like they would in real life.
  - If the aircraft can't set up a stable approach (first waypoint is behind it), CV triggers a go-around rather than returning an error.

  **Test plan**
  - Clear a visual approach (CV13L) for an aircraft on or near the extended centerline — it should fly straight to a 3nm final and land normally.
  - Clear a visual for an aircraft well off to the side — it should turn toward a base leg first, then turn onto final, rather than cutting diagonally.
  - Ask a pilot if they have the field in sight (FS) in VMC and IMC — they should say yes and no respectively.
  - Fly some arrivals in VMC and wait — pilots should eventually call in requesting the visual on their own.