### PR TITLE
Fix doubled keyboard input in imgui widgets by removing AddInputCharactersUTF8 call

### DIFF
--- a/platform/glfw.go
+++ b/platform/glfw.go
@@ -461,7 +461,7 @@ func (g *glfwPlatform) updateKeyModifiers() {
 
 func (g *glfwPlatform) charChange(window *glfw.Window, char rune) {
 	g.anyEvents = true
-	g.imguiIO.AddInputCharactersUTF8(string(char))
+	// imgui character input is handled by implglfw.InstallCallbacks.
 	g.inputCharacters = g.inputCharacters + string(char)
 }
 


### PR DESCRIPTION
Characters were appearing twice when typing into imgui input widgets (e.g., arrival/departure rate fields)

Root cause: both the imgui backend (implglfw.InstallCallbacks) and our custom charChange callback were calling AddInputCharactersUTF8, and the backend chains to our callback, so both fire on every keystroke

Removed the duplicate call from charChange; the imgui backend handles its own character input, our callback just tracks inputCharacters for vice's command input pipeline