### PR TITLE
Add test bench panel for easier dev testing

### DIFF
--- a/cmd/vice/config.go
+++ b/cmd/vice/config.go
@@ -66,6 +66,7 @@ type ConfigNoSim struct {
 	InhibitDiscordActivity util.AtomicBool
 	NotifiedTargetGenMode  bool
 	DisableTextToSpeech    bool
+	DevMode                bool
 
 	UserWorkstation    string
 	ControllerInitials string

--- a/cmd/vice/main.go
+++ b/cmd/vice/main.go
@@ -69,6 +69,7 @@ var (
 	replayDuration    = flag.String("replay-duration", "3600", "replay `duration` in seconds or 'until:CALLSIGN'")
 	waypointCommands  = flag.String("waypoint-commands", "", "waypoint `commands` in format 'FIX:CMD CMD CMD, FIX:CMD ...,'")
 	starsRandoms      = flag.Bool("starsrandoms", false, "run STARS command fuzz testing with full UI (randomly picks a scenario)")
+	devMode           = flag.Bool("dev", false, "enable developer tools")
 )
 
 func setupSignalHandler(profiler *util.Profiler) {

--- a/cmd/vice/simconfig.go
+++ b/cmd/vice/simconfig.go
@@ -1323,6 +1323,24 @@ func (c *NewSimConfiguration) DrawConfigurationUI(p platform.Platform, config *C
 	// TRAFFIC RATES section
 	drawSectionHeader("Traffic Rates")
 
+	// In developer mode, offer a quick toggle to disable all traffic.
+	if *devMode || config.DevMode {
+		lc := &c.ScenarioSpec.LaunchConfig
+		noTraffic := lc.DepartureRateScale == 0 && lc.InboundFlowRateScale == 0 &&
+			lc.VFRDepartureRateScale == 0
+		if imgui.Checkbox("No traffic (test bench)", &noTraffic) {
+			if noTraffic {
+				lc.DepartureRateScale = 0
+				lc.InboundFlowRateScale = 0
+				lc.VFRDepartureRateScale = 0
+			} else {
+				lc.DepartureRateScale = 1
+				lc.InboundFlowRateScale = 1
+				lc.VFRDepartureRateScale = 1
+			}
+		}
+	}
+
 	// Rate limit warning
 	const rateLimit = 100.0
 	if !c.ScenarioSpec.LaunchConfig.CheckRateLimits(rateLimit) {

--- a/cmd/vice/testbench.go
+++ b/cmd/vice/testbench.go
@@ -498,6 +498,8 @@ func (ds *TestBench) buildAircraft(spec TestBenchAircraftSpec, airport *av.Airpo
 		heading = spec.Heading
 	}
 
+	// Aircraft type is hardcoded to B738 for now; may want to make this
+	// configurable if we need to test category-specific behavior.
 	ac := sim.Aircraft{
 		ADSBCallsign:        av.ADSBCallsign(spec.Callsign),
 		TypeOfFlight:        av.FlightTypeArrival,

--- a/cmd/vice/testbench.go
+++ b/cmd/vice/testbench.go
@@ -791,6 +791,19 @@ func (tb *TestBench) drawTestCase(section string, tc *TestBenchCase) {
 					cs = tb.defaultCallsign(tc)
 				}
 				imgui.Text(fmt.Sprintf("%s %s", cs, step.Command))
+				if isActive && tb.spawnedTest == tc {
+					imgui.SameLine()
+					if imgui.ArrowButton(fmt.Sprintf("##send_%d", i), imgui.DirRight) {
+						tb.client.RunAircraftCommands(client.AircraftCommandRequest{
+							Callsign: cs,
+							Commands: step.Command,
+						}, func(errStr string, remaining string) {
+							if errStr != "" {
+								tb.lg.Warnf("test bench send: %s: %s", cs, errStr)
+							}
+						})
+					}
+				}
 			}
 		}
 

--- a/cmd/vice/testbench.go
+++ b/cmd/vice/testbench.go
@@ -1,0 +1,757 @@
+// Copyright(c) 2022-2026 vice contributors, licensed under the GNU Public License, Version 3.
+// SPDX: GPL-3.0-only
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	av "github.com/mmp/vice/aviation"
+	"github.com/mmp/vice/client"
+	"github.com/mmp/vice/log"
+	"github.com/mmp/vice/math"
+	"github.com/mmp/vice/nav"
+	"github.com/mmp/vice/platform"
+	"github.com/mmp/vice/rand"
+	"github.com/mmp/vice/sim"
+	"github.com/mmp/vice/util"
+
+	"github.com/AllenDang/cimgui-go/imgui"
+)
+
+// TestBenchConfig maps section names to test cases.
+type TestBenchConfig map[string][]TestBenchCase
+
+type TestBenchCase struct {
+	Label    string                  `json:"label"`
+	Aircraft []TestBenchAircraftSpec `json:"aircraft,omitempty"`
+	Steps    []TestBenchStep         `json:"steps,omitempty"`
+	Group    string                  `json:"group,omitempty"`
+	Airport  string                  `json:"airport,omitempty"`
+	// Departure-based spawn (uses CreateDeparture)
+	Departure bool   `json:"departure,omitempty"`
+	Runway    string `json:"runway,omitempty"`
+	Category  string `json:"category,omitempty"`
+}
+
+type TestBenchStep struct {
+	Command        string `json:"command,omitempty"`
+	Callsign       string `json:"callsign,omitempty"`
+	ExpectReadback string `json:"expect_readback,omitempty"`
+	RejectReadback string `json:"reject_readback,omitempty"`
+	WaitFor        string `json:"wait_for,omitempty"`
+}
+
+type TestBenchAircraftSpec struct {
+	Callsign   string  `json:"callsign"`
+	DistanceNM float32 `json:"distance_nm"`
+	Altitude   float32 `json:"altitude,omitempty"` // explicit altitude; 0 = use fix restriction
+	Speed      float32 `json:"speed"`
+	Heading    float32 `json:"heading,omitempty"`     // aircraft heading; 0 = inbound to fix/airport
+	Bearing    float32 `json:"bearing,omitempty"`     // bearing FROM reference to place aircraft
+	RelativeTo string  `json:"relative_to,omitempty"` // fix name or placeholder (e.g. "{if}"); empty = airport
+
+	TrafficInSight bool   `json:"traffic_in_sight,omitempty"`
+	Note           string `json:"note,omitempty"`
+}
+
+type TestBench struct {
+	client *client.ControlClient
+	lg     *log.Logger
+	config TestBenchConfig
+	events *sim.EventsSubscription
+
+	selectedApproach  int
+	approaches        []debugApproachInfo // cached list of available approaches
+	selectedDeparture int
+	departures        []debugDepartureInfo // cached list of available departure runways
+
+	// Spawned aircraft tracking (for clear button)
+	spawnedAircraft []sim.Aircraft
+	spawnedTest     *TestBenchCase // which test case owns spawnedAircraft
+
+	// Test step tracking
+	activeTest     *TestBenchCase
+	currentStep    int
+	stepResults    []string // per-step: "pass", "fail", or ""
+	lastReadback   string
+	lastReadbackCS av.ADSBCallsign
+	statusMessage  string
+}
+
+type debugApproachInfo struct {
+	airport    string
+	approachId string
+	approach   *av.Approach
+}
+
+type debugDepartureInfo struct {
+	airport  string
+	runway   string
+	category string
+}
+
+// approachFixNames returns the IAF, IF, and FAF fix names from the first
+// route of the given approach that defines them.
+func approachFixNames(ap *av.Approach) (iaf, ifFix, faf string) {
+	for _, route := range ap.Waypoints {
+		for _, wp := range route {
+			if wp.IAF() && iaf == "" {
+				iaf = wp.Fix
+			}
+			if wp.IF() && ifFix == "" {
+				ifFix = wp.Fix
+			}
+			if wp.FAF() && faf == "" {
+				faf = wp.Fix
+			}
+		}
+		if iaf != "" || ifFix != "" || faf != "" {
+			return
+		}
+	}
+	return
+}
+
+// resolveStep substitutes placeholders in a step's strings with values
+// from the currently selected approach:
+//
+//	{approach}      → approach ID (e.g. "I2L")
+//	{approach_name} → full name (e.g. "ILS Runway 22L")
+//	{iaf}           → Initial Approach Fix name
+//	{if}            → Intermediate Fix name
+//	{faf}           → Final Approach Fix name
+func (ds *TestBench) resolveStep(step TestBenchStep) TestBenchStep {
+	if ds.selectedApproach < 0 || ds.selectedApproach >= len(ds.approaches) {
+		return step
+	}
+	ap := ds.approaches[ds.selectedApproach]
+	iaf, ifFix, faf := approachFixNames(ap.approach)
+
+	r := strings.NewReplacer(
+		"{approach}", ap.approachId,
+		"{approach_name}", ap.approach.FullName,
+		"{iaf}", iaf,
+		"{if}", ifFix,
+		"{faf}", faf,
+	)
+	step.Command = r.Replace(step.Command)
+	step.ExpectReadback = r.Replace(step.ExpectReadback)
+	step.RejectReadback = r.Replace(step.RejectReadback)
+	return step
+}
+
+func NewTestBench(c *client.ControlClient, es *sim.EventStream, lg *log.Logger) *TestBench {
+	ds := &TestBench{
+		client: c,
+		lg:     lg,
+		events: es.Subscribe(),
+	}
+
+	// Load debug scenarios via the resource system so the path is
+	// resolved regardless of the working directory.
+	if util.ResourceExists("test_bench_scenarios.json") {
+		data := util.LoadResourceBytes("test_bench_scenarios.json")
+		if err := json.Unmarshal(data, &ds.config); err != nil {
+			lg.Errorf("test bench: error parsing test_bench_scenarios.json: %v", err)
+			ds.config = make(TestBenchConfig)
+		}
+	} else {
+		lg.Warnf("test bench: resources/test_bench_scenarios.json not found")
+		ds.config = make(TestBenchConfig)
+	}
+
+	ds.refreshSelections()
+	return ds
+}
+
+func (ds *TestBench) refreshSelections() {
+	ds.approaches = nil
+	for _, rwy := range ds.client.State.ArrivalRunways {
+		ap := ds.client.State.Airports[rwy.Airport]
+		if ap == nil {
+			continue
+		}
+		for _, name := range util.SortedMapKeys(ap.Approaches) {
+			appr := ap.Approaches[name]
+			if appr.Runway == string(rwy.Runway.Base()) {
+				ds.approaches = append(ds.approaches, debugApproachInfo{
+					airport:    rwy.Airport,
+					approachId: name,
+					approach:   appr,
+				})
+			}
+		}
+	}
+
+	ds.departures = nil
+	for _, dr := range ds.client.State.DepartureRunways {
+		ds.departures = append(ds.departures, debugDepartureInfo{
+			airport:  dr.Airport,
+			runway:   string(dr.Runway),
+			category: dr.Category,
+		})
+	}
+}
+
+func (ds *TestBench) resetTestState() {
+	ds.activeTest = nil
+	ds.currentStep = 0
+	ds.stepResults = nil
+	ds.lastReadback = ""
+	ds.lastReadbackCS = ""
+}
+
+func (ds *TestBench) Draw(show *bool, p platform.Platform) {
+	// Process events for readback tracking
+	ds.processEvents()
+
+	imgui.SetNextWindowSizeConstraints(imgui.Vec2{400, 200}, imgui.Vec2{800, float32(p.WindowSize()[1]) * 19 / 20})
+	imgui.BeginV("Test Bench", show, imgui.WindowFlagsAlwaysAutoResize)
+
+	// Approach selector
+	if len(ds.approaches) > 0 {
+		label := ds.approachLabel(ds.selectedApproach)
+		imgui.Text("Approach:")
+		imgui.SameLine()
+		imgui.SetNextItemWidth(250)
+		if imgui.BeginCombo("##approach", label) {
+			for i := range ds.approaches {
+				if imgui.SelectableBoolV(ds.approachLabel(i), i == ds.selectedApproach, 0, imgui.Vec2{}) {
+					ds.selectedApproach = i
+					ds.resetTestState()
+				}
+			}
+			imgui.EndCombo()
+		}
+	} else {
+		imgui.TextColored(imgui.Vec4{1, 1, 0, 1}, "No arrival approaches available")
+	}
+
+	// Departure runway selector
+	if len(ds.departures) > 0 {
+		label := ds.departureLabel(ds.selectedDeparture)
+		imgui.Text("Departure:")
+		imgui.SameLine()
+		imgui.SetNextItemWidth(250)
+		if imgui.BeginCombo("##departure", label) {
+			for i := range ds.departures {
+				if imgui.SelectableBoolV(ds.departureLabel(i), i == ds.selectedDeparture, 0, imgui.Vec2{}) {
+					ds.selectedDeparture = i
+				}
+			}
+			imgui.EndCombo()
+		}
+	}
+
+	if ds.statusMessage != "" {
+		imgui.TextColored(imgui.Vec4{0, 1, 0, 1}, ds.statusMessage)
+	}
+
+	imgui.Separator()
+
+	// Draw sections
+	for _, section := range util.SortedMapKeys(ds.config) {
+		cases := ds.config[section]
+		if imgui.CollapsingHeaderBoolPtr(section, nil) {
+			for i := range cases {
+				ds.drawTestCase(section, &cases[i])
+			}
+		}
+	}
+
+	imgui.End()
+}
+
+func (ds *TestBench) approachLabel(idx int) string {
+	if idx < 0 || idx >= len(ds.approaches) {
+		return "(none)"
+	}
+	a := ds.approaches[idx]
+	return fmt.Sprintf("%s - %s (%s)", a.approachId, a.approach.FullName, a.airport)
+}
+
+func (ds *TestBench) departureLabel(idx int) string {
+	if idx < 0 || idx >= len(ds.departures) {
+		return "(none)"
+	}
+	d := ds.departures[idx]
+	if d.category != "" {
+		return fmt.Sprintf("%s %s (%s)", d.airport, d.runway, d.category)
+	}
+	return fmt.Sprintf("%s %s", d.airport, d.runway)
+}
+
+func (ds *TestBench) drawTestCase(section string, tc *TestBenchCase) {
+	id := section + "/" + tc.Label
+	imgui.PushIDStr(id)
+	defer imgui.PopID()
+
+	// Bordered group for each test case
+	imgui.BeginGroup()
+
+	imgui.Text(tc.Label)
+	imgui.SameLine()
+
+	if tc.Group != "" {
+		if imgui.Button("Spawn STAR") {
+			ds.spawnSTAR(tc)
+		}
+	} else if tc.Departure {
+		if imgui.Button("Spawn Departure") {
+			ds.spawnDeparture(tc)
+		}
+	} else if len(tc.Aircraft) > 0 {
+		if imgui.Button("Spawn") {
+			ds.spawnAircraft(tc)
+		}
+	}
+
+	// Clear button — only shown on the test case whose aircraft are active
+	if ds.spawnedTest == tc && len(ds.spawnedAircraft) > 0 {
+		imgui.SameLine()
+		if imgui.Button("Clear") {
+			ds.client.DeleteAircraft(ds.spawnedAircraft, func(err error) {
+				if err != nil {
+					ds.lg.Warnf("test bench: clear aircraft: %v", err)
+				}
+			})
+			ds.spawnedAircraft = nil
+			ds.spawnedTest = nil
+			ds.resetTestState()
+			ds.statusMessage = "Cleared spawned aircraft"
+		}
+	}
+
+	// Show aircraft specs
+	for _, spec := range tc.Aircraft {
+		note := ""
+		if spec.Note != "" {
+			note = " (" + spec.Note + ")"
+		}
+		flags := ""
+		if spec.TrafficInSight {
+			flags += " TIS"
+		}
+		altStr := fmt.Sprintf("%.0fft", spec.Altitude)
+		if spec.Altitude == 0 && spec.RelativeTo != "" {
+			altStr = "fix alt"
+		}
+		refStr := ""
+		if spec.RelativeTo != "" {
+			refStr = fmt.Sprintf(" from %s", spec.RelativeTo)
+		}
+		imgui.TextColored(imgui.Vec4{0.7, 0.7, 0.7, 1},
+			fmt.Sprintf("  %s: %.0fnm%s/%s/%.0fkts%s%s", spec.Callsign,
+				spec.DistanceNM, refStr, altStr, spec.Speed, flags, note))
+	}
+
+	// Show test steps
+	if len(tc.Steps) > 0 {
+		for i, rawStep := range tc.Steps {
+			step := ds.resolveStep(rawStep)
+			isActive := ds.activeTest == tc && ds.currentStep == i
+
+			// Per-step result indicator
+			result := ""
+			if ds.activeTest == tc && i < len(ds.stepResults) {
+				result = ds.stepResults[i]
+			}
+
+			if result == "pass" {
+				imgui.TextColored(imgui.Vec4{0, 1, 0, 1}, "  +")
+			} else if result == "fail" {
+				imgui.TextColored(imgui.Vec4{1, 0, 0, 1}, "  X")
+			} else if isActive {
+				imgui.Text("  >")
+			} else {
+				imgui.Text("   ")
+			}
+			imgui.SameLine()
+
+			if step.WaitFor != "" {
+				imgui.TextColored(imgui.Vec4{0.5, 0.8, 1, 1},
+					fmt.Sprintf("[wait: %s]", step.WaitFor))
+			} else {
+				cs := av.ADSBCallsign(step.Callsign)
+				if cs == "" {
+					cs = ds.defaultCallsign(tc)
+				}
+				imgui.Text(fmt.Sprintf("%s %s", cs, step.Command))
+			}
+		}
+
+		// Show last captured readback
+		if ds.activeTest == tc && ds.lastReadback != "" {
+			imgui.TextColored(imgui.Vec4{0.8, 0.8, 0, 1},
+				fmt.Sprintf("    Readback [%s]: %s", ds.lastReadbackCS, ds.lastReadback))
+		}
+	}
+
+	imgui.EndGroup()
+	imgui.Separator()
+}
+
+func (ds *TestBench) spawnAircraft(tc *TestBenchCase) {
+	if ds.selectedApproach < 0 || ds.selectedApproach >= len(ds.approaches) {
+		ds.statusMessage = "No approach selected"
+		return
+	}
+
+	apInfo := ds.approaches[ds.selectedApproach]
+	airport := ds.client.State.Airports[apInfo.airport]
+	if airport == nil {
+		ds.statusMessage = "Airport not found: " + apInfo.airport
+		return
+	}
+
+	nmPerLong := ds.client.State.NmPerLongitude
+	magVar := ds.client.State.MagneticVariation
+	rwyHeading := apInfo.approach.RunwayHeading(nmPerLong, magVar)
+	ctrlFreq := sim.ControlPosition(ds.client.State.PrimaryPositionForTCW(ds.client.State.UserTCW))
+
+	// Clear any previously spawned aircraft before spawning new ones.
+	if len(ds.spawnedAircraft) > 0 {
+		ds.client.DeleteAircraft(ds.spawnedAircraft, func(err error) {
+			if err != nil {
+				ds.lg.Warnf("test bench: auto-clear: %v", err)
+			}
+		})
+	}
+
+	ds.spawnedAircraft = nil
+	for _, spec := range tc.Aircraft {
+		ac := ds.buildAircraft(spec, airport, apInfo, rwyHeading, nmPerLong, magVar, ctrlFreq)
+		ds.client.LaunchArrivalOverflight(ac)
+		ds.spawnedAircraft = append(ds.spawnedAircraft, ac)
+		ds.lg.Infof("test bench: launched %s at %.1fnm/%.0fft", spec.Callsign, spec.DistanceNM, ac.Nav.FlightState.Altitude)
+	}
+
+	ds.spawnedTest = tc
+	ds.activateSteps(tc)
+
+	ds.statusMessage = fmt.Sprintf("Spawned %d aircraft for \"%s\"", len(tc.Aircraft), tc.Label)
+}
+
+// resolveFixRef resolves a fix name (possibly a placeholder like "{if}")
+// to its location and altitude restriction from the selected approach.
+func (ds *TestBench) resolveFixRef(name string, apInfo debugApproachInfo) (loc math.Point2LL, alt float32, ok bool) {
+	// Resolve placeholders.
+	iaf, ifFix, faf := approachFixNames(apInfo.approach)
+	name = strings.NewReplacer("{iaf}", iaf, "{if}", ifFix, "{faf}", faf).Replace(name)
+
+	// Find the fix in the approach waypoints.
+	for _, route := range apInfo.approach.Waypoints {
+		for _, wp := range route {
+			if wp.Fix == name {
+				var fixAlt float32
+				if ar := wp.AltitudeRestriction(); ar != nil {
+					fixAlt = ar.Range[0]
+				}
+				return wp.Location, fixAlt, true
+			}
+		}
+	}
+
+	// Fall back to the global waypoint database.
+	if p, found := av.DB.LookupWaypoint(name); found {
+		return p, 0, true
+	}
+	return math.Point2LL{}, 0, false
+}
+
+func (ds *TestBench) buildAircraft(spec TestBenchAircraftSpec, airport *av.Airport,
+	apInfo debugApproachInfo, rwyHeading, nmPerLong, magVar float32,
+	ctrlFreq sim.ControlPosition) sim.Aircraft {
+
+	// Determine reference point and altitude.
+	// If relative_to is set, position relative to that fix;
+	// otherwise position relative to the airport.
+	refPos := airport.Location
+	altitude := spec.Altitude
+
+	if spec.RelativeTo != "" {
+		if fixLoc, fixAlt, ok := ds.resolveFixRef(spec.RelativeTo, apInfo); ok {
+			refPos = fixLoc
+			if altitude == 0 && fixAlt > 0 {
+				altitude = fixAlt
+			}
+		} else {
+			ds.lg.Warnf("test bench: couldn't resolve fix %q", spec.RelativeTo)
+		}
+	}
+
+	// Determine the bearing from reference to place the aircraft.
+	// Default: on extended centerline (reciprocal of runway heading).
+	bearing := rwyHeading + 180
+	if spec.Bearing != 0 {
+		bearing = spec.Bearing
+	}
+
+	pos := math.Offset2LL(refPos, bearing, spec.DistanceNM, nmPerLong, magVar)
+
+	// Aircraft heading: default is inbound (runway heading).
+	heading := rwyHeading
+	if spec.Heading != 0 {
+		heading = spec.Heading
+	}
+
+	ac := sim.Aircraft{
+		ADSBCallsign:        av.ADSBCallsign(spec.Callsign),
+		TypeOfFlight:        av.FlightTypeArrival,
+		Mode:                av.TransponderModeAltitude,
+		ControllerFrequency: ctrlFreq,
+		FlightPlan: av.FlightPlan{
+			ArrivalAirport: apInfo.airport,
+			AircraftType:   "B738",
+			Rules:          av.FlightRulesIFR,
+		},
+		Nav: nav.Nav{
+			Rand:           rand.Make(),
+			FixAssignments: make(map[string]nav.NavFixAssignment),
+			Perf:           av.DB.AircraftPerformance["B738"],
+			Altitude: nav.NavAltitude{
+				Assigned: &altitude,
+			},
+			Speed: nav.NavSpeed{
+				Assigned: &spec.Speed,
+			},
+			FlightState: nav.FlightState{
+				Position:                pos,
+				Heading:                 heading,
+				Altitude:                altitude,
+				IAS:                     spec.Speed,
+				GS:                      spec.Speed,
+				NmPerLongitude:          nmPerLong,
+				MagneticVariation:       magVar,
+				ArrivalAirport:          av.Waypoint{Fix: apInfo.airport, Location: airport.Location},
+				ArrivalAirportLocation:  airport.Location,
+				ArrivalAirportElevation: float32(av.DB.Airports[apInfo.airport].Elevation),
+			},
+			Approach: nav.NavApproach{},
+		},
+		TrafficInSight: spec.TrafficInSight,
+		NASFlightPlan: &sim.NASFlightPlan{
+			ACID:               sim.ACID(spec.Callsign),
+			ArrivalAirport:     apInfo.airport,
+			Rules:              av.FlightRulesIFR,
+			TypeOfFlight:       av.FlightTypeArrival,
+			AircraftCount:      1,
+			AircraftType:       "B738",
+			TrackingController: ctrlFreq,
+			OwningTCW:          ds.client.State.UserTCW,
+		},
+	}
+
+	return ac
+}
+
+func (ds *TestBench) spawnSTAR(tc *TestBenchCase) {
+	airport := tc.Airport
+	if airport == "" {
+		airport = ds.client.State.PrimaryAirport
+	}
+
+	var ac sim.Aircraft
+	ds.client.CreateArrival(tc.Group, airport, &ac, func(err error) {
+		if err != nil {
+			ds.lg.Warnf("test bench: CreateArrival %s: %v", tc.Group, err)
+			ds.statusMessage = fmt.Sprintf("STAR spawn failed: %v", err)
+		} else {
+			ds.spawnedAircraft = append(ds.spawnedAircraft, ac)
+			ds.spawnedTest = tc
+			ds.lg.Infof("test bench: STAR %s spawned for %s (%s)", tc.Group, airport, ac.ADSBCallsign)
+			ds.statusMessage = fmt.Sprintf("Spawned STAR %s at %s (%s)", tc.Group, airport, ac.ADSBCallsign)
+			ds.activateSteps(tc)
+		}
+	})
+}
+
+func (ds *TestBench) spawnDeparture(tc *TestBenchCase) {
+	airport := tc.Airport
+	runway := tc.Runway
+	category := tc.Category
+
+	// Use the departure dropdown selection if the scenario doesn't specify.
+	if airport == "" || runway == "" {
+		if ds.selectedDeparture >= 0 && ds.selectedDeparture < len(ds.departures) {
+			d := ds.departures[ds.selectedDeparture]
+			if airport == "" {
+				airport = d.airport
+			}
+			if runway == "" {
+				runway = d.runway
+				category = d.category
+			}
+		} else {
+			ds.statusMessage = "No departure runway selected"
+			return
+		}
+	}
+	if airport == "" || runway == "" {
+		ds.statusMessage = "No departure runway selected"
+		return
+	}
+
+	var ac sim.Aircraft
+	ds.client.CreateDeparture(airport, runway, category, av.FlightRulesIFR, &ac, func(err error) {
+		if err != nil {
+			ds.lg.Warnf("test bench: CreateDeparture: %v", err)
+			ds.statusMessage = fmt.Sprintf("Departure spawn failed: %v", err)
+		} else {
+			// Launch the departure immediately (same pattern as LaunchControl).
+			// CreateDeparture builds the aircraft; LaunchDeparture puts it on scope.
+			ds.client.LaunchDeparture(ac, runway)
+
+			ds.spawnedAircraft = append(ds.spawnedAircraft, ac)
+			ds.spawnedTest = tc
+			ds.lg.Infof("test bench: departure %s launched at %s rwy %s", ac.ADSBCallsign, airport, runway)
+			ds.statusMessage = fmt.Sprintf("Launched departure %s at %s rwy %s", ac.ADSBCallsign, airport, runway)
+			ds.activateSteps(tc)
+		}
+	})
+}
+
+// isTestCallsign checks whether the given callsign belongs to one of the
+// test case's aircraft — either from the JSON spec or from sim-spawned aircraft.
+func (ds *TestBench) isTestCallsign(tc *TestBenchCase, cs av.ADSBCallsign) bool {
+	for _, spec := range tc.Aircraft {
+		if av.ADSBCallsign(spec.Callsign) == cs {
+			return true
+		}
+	}
+	// For departures/STARs, check spawned aircraft (callsign assigned by sim).
+	if ds.spawnedTest == tc {
+		for _, ac := range ds.spawnedAircraft {
+			if ac.ADSBCallsign == cs {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// defaultCallsign returns the callsign to use when a step doesn't specify one.
+func (ds *TestBench) defaultCallsign(tc *TestBenchCase) av.ADSBCallsign {
+	if len(tc.Aircraft) > 0 {
+		return av.ADSBCallsign(tc.Aircraft[0].Callsign)
+	}
+	if ds.spawnedTest == tc && len(ds.spawnedAircraft) > 0 {
+		return ds.spawnedAircraft[0].ADSBCallsign
+	}
+	return ""
+}
+
+func (ds *TestBench) processEvents() {
+	if ds.activeTest == nil {
+		// Still drain events so the subscription doesn't fall behind.
+		ds.events.Get()
+		return
+	}
+
+	for _, event := range ds.events.Get() {
+		if event.Type != sim.RadioTransmissionEvent {
+			continue
+		}
+
+		// Check if this is from one of our test callsigns.
+		tc := ds.activeTest
+		if !ds.isTestCallsign(tc, event.ADSBCallsign) {
+			continue
+		}
+
+		if ds.currentStep >= len(tc.Steps) {
+			continue
+		}
+		step := ds.resolveStep(tc.Steps[ds.currentStep])
+
+		// For wait_for steps, accept contact/unexpected transmissions
+		// (spontaneous pilot reports).
+		if step.WaitFor != "" {
+			text := strings.ToLower(event.WrittenText)
+			matched := false
+			switch step.WaitFor {
+			case "check_in":
+				matched = event.RadioTransmissionType == av.RadioTransmissionContact
+			case "field_in_sight":
+				matched = strings.Contains(text, "field in sight") ||
+					strings.Contains(text, "airport in sight")
+			case "approach_clearance_request":
+				matched = strings.Contains(text, "cleared for the approach") ||
+					strings.Contains(text, "looking for the approach") ||
+					strings.Contains(text, "need the approach")
+			case "go_around":
+				matched = strings.Contains(text, "going around") ||
+					strings.Contains(text, "on the go")
+			}
+			if matched {
+				ds.stepResults[ds.currentStep] = "pass"
+				ds.lastReadback = event.WrittenText
+				ds.lastReadbackCS = event.ADSBCallsign
+				ds.advanceStep()
+			}
+			continue
+		}
+
+		// For command steps, only evaluate actual readbacks — not
+		// check-ins (contact) or other spontaneous transmissions.
+		if event.RadioTransmissionType != av.RadioTransmissionReadback {
+			continue
+		}
+
+		// Check the step's target callsign
+		targetCS := av.ADSBCallsign(step.Callsign)
+		if targetCS == "" {
+			targetCS = ds.defaultCallsign(tc)
+		}
+		if targetCS != event.ADSBCallsign {
+			continue
+		}
+
+		ds.lastReadback = event.WrittenText
+		ds.lastReadbackCS = event.ADSBCallsign
+
+		// "Say again" means the pilot didn't understand; skip it so
+		// the controller can re-issue the command.
+		text := strings.ToLower(event.WrittenText)
+		if strings.Contains(text, "say again") {
+			continue
+		}
+
+		// Verify readback against WrittenText (the structured form,
+		// not the randomized spoken form).
+		pass := true
+		if step.ExpectReadback != "" && !strings.Contains(text, strings.ToLower(step.ExpectReadback)) {
+			pass = false
+		}
+		if step.RejectReadback != "" && strings.Contains(text, strings.ToLower(step.RejectReadback)) {
+			pass = false
+		}
+
+		ds.lg.Debugf("test bench: step %d cmd=%q expect=%q reject=%q written=%q pass=%v",
+			ds.currentStep, step.Command, step.ExpectReadback, step.RejectReadback, event.WrittenText, pass)
+
+		if pass {
+			ds.stepResults[ds.currentStep] = "pass"
+		} else {
+			ds.stepResults[ds.currentStep] = "fail"
+		}
+		ds.advanceStep()
+	}
+}
+
+func (ds *TestBench) activateSteps(tc *TestBenchCase) {
+	if len(tc.Steps) > 0 {
+		ds.activeTest = tc
+		ds.currentStep = 0
+		ds.stepResults = make([]string, len(tc.Steps))
+		ds.lastReadback = ""
+		ds.lastReadbackCS = ""
+	}
+}
+
+func (ds *TestBench) advanceStep() {
+	ds.currentStep++
+}

--- a/cmd/vice/testbench.go
+++ b/cmd/vice/testbench.go
@@ -102,16 +102,17 @@ func (a *AltitudeSpec) UnmarshalJSON(data []byte) error {
 }
 
 type TestBenchAircraftSpec struct {
-	Callsign      string  `json:"callsign,omitempty"`
-	AircraftType  string  `json:"aircraft_type,omitempty"` // e.g. "B738"; empty = sampled from airline or B738 fallback
-	DistanceNM    float32 `json:"distance_nm"`
-	Altitude      AltitudeSpec `json:"altitude,omitempty"` // number or "{altCeiling}" placeholder
-	Speed         float32 `json:"speed"`
-	Heading       float32 `json:"heading,omitempty"`        // aircraft heading; 0 = inbound to fix/airport
-	HeadingOffset float32 `json:"heading_offset,omitempty"` // added to default heading (runway heading)
-	Bearing       float32 `json:"bearing,omitempty"`        // bearing FROM reference to place aircraft
-	BearingOffset float32 `json:"bearing_offset,omitempty"` // added to default bearing (extended centerline)
-	RelativeTo    string  `json:"relative_to,omitempty"`    // fix name or placeholder (e.g. "{if}"); empty = airport
+	Callsign       string       `json:"callsign,omitempty"`
+	AircraftType   string       `json:"aircraft_type,omitempty"` // e.g. "B738"; empty = sampled from airline or B738 fallback
+	DistanceNM     float32      `json:"distance_nm"`
+	Altitude       AltitudeSpec `json:"altitude,omitempty"`        // number or "{altCeiling}" placeholder
+	AltitudeOffset float32      `json:"altitude_offset,omitempty"` // feet added after resolving altitude
+	Speed          float32      `json:"speed"`
+	Heading        float32      `json:"heading,omitempty"`        // aircraft heading; 0 = inbound to fix/airport
+	HeadingOffset  float32      `json:"heading_offset,omitempty"` // added to default heading (runway heading)
+	Bearing        float32      `json:"bearing,omitempty"`        // bearing FROM reference to place aircraft
+	BearingOffset  float32      `json:"bearing_offset,omitempty"` // added to default bearing (extended centerline)
+	RelativeTo     string       `json:"relative_to,omitempty"`    // fix name or placeholder (e.g. "{if}"); empty = airport
 
 	StarWaypoints  bool   `json:"star_waypoints,omitempty"` // populate Nav.Waypoints from a STAR at the airport
 	TrafficInSight bool   `json:"traffic_in_sight,omitempty"`
@@ -971,6 +972,8 @@ func (tb *TestBench) buildAircraftWithCallsign(spec TestBenchAircraftSpec, calls
 	default:
 		return sim.Aircraft{}, fmt.Errorf("unknown altitude placeholder %q", spec.Altitude.Placeholder)
 	}
+
+	altitude += spec.AltitudeOffset
 
 	if spec.RelativeTo != "" {
 		if fixLoc, fixAlt, ok := tb.resolveFixRef(spec.RelativeTo, apInfo); ok {

--- a/cmd/vice/testbench.go
+++ b/cmd/vice/testbench.go
@@ -90,9 +90,9 @@ type TestBench struct {
 	events *sim.EventsSubscription
 
 	selectedApproach  int
-	approaches        []debugApproachInfo // cached list of available approaches
+	approaches        []testBenchApproachInfo // cached list of available approaches
 	selectedDeparture int
-	departures        []debugDepartureInfo // cached list of available departure runways
+	departures        []testBenchDepartureInfo // cached list of available departure runways
 
 	// Spawned aircraft tracking (for clear button)
 	spawnedAircraft []sim.Aircraft
@@ -118,13 +118,13 @@ type TestBench struct {
 	statusMessage  string
 }
 
-type debugApproachInfo struct {
+type testBenchApproachInfo struct {
 	airport    string
 	approachId string
 	approach   *av.Approach
 }
 
-type debugDepartureInfo struct {
+type testBenchDepartureInfo struct {
 	airport  string
 	runway   string
 	category string
@@ -134,40 +134,40 @@ type debugDepartureInfo struct {
 // Constructor and setup
 
 func NewTestBench(c *client.ControlClient, es *sim.EventStream, lg *log.Logger) *TestBench {
-	ds := &TestBench{
+	tb := &TestBench{
 		client: c,
 		lg:     lg,
 		events: es.Subscribe(),
 	}
 
-	// Load debug scenarios via the resource system so the path is
+	// Load test scenarios via the resource system so the path is
 	// resolved regardless of the working directory.
 	if util.ResourceExists("test_bench_scenarios.json") {
 		data := util.LoadResourceBytes("test_bench_scenarios.json")
-		if err := json.Unmarshal(data, &ds.config); err != nil {
+		if err := json.Unmarshal(data, &tb.config); err != nil {
 			lg.Errorf("test bench: error parsing test_bench_scenarios.json: %v", err)
-			ds.config = make(TestBenchConfig)
+			tb.config = make(TestBenchConfig)
 		}
 	} else {
 		lg.Warnf("test bench: resources/test_bench_scenarios.json not found")
-		ds.config = make(TestBenchConfig)
+		tb.config = make(TestBenchConfig)
 	}
 
-	ds.refreshSelections()
-	return ds
+	tb.refreshSelections()
+	return tb
 }
 
-func (ds *TestBench) refreshSelections() {
-	ds.approaches = nil
-	for _, rwy := range ds.client.State.ArrivalRunways {
-		ap := ds.client.State.Airports[rwy.Airport]
+func (tb *TestBench) refreshSelections() {
+	tb.approaches = nil
+	for _, rwy := range tb.client.State.ArrivalRunways {
+		ap := tb.client.State.Airports[rwy.Airport]
 		if ap == nil {
 			continue
 		}
 		for _, name := range util.SortedMapKeys(ap.Approaches) {
 			appr := ap.Approaches[name]
 			if appr.Runway == string(rwy.Runway.Base()) {
-				ds.approaches = append(ds.approaches, debugApproachInfo{
+				tb.approaches = append(tb.approaches, testBenchApproachInfo{
 					airport:    rwy.Airport,
 					approachId: name,
 					approach:   appr,
@@ -176,9 +176,9 @@ func (ds *TestBench) refreshSelections() {
 		}
 	}
 
-	ds.departures = nil
-	for _, dr := range ds.client.State.DepartureRunways {
-		ds.departures = append(ds.departures, debugDepartureInfo{
+	tb.departures = nil
+	for _, dr := range tb.client.State.DepartureRunways {
+		tb.departures = append(tb.departures, testBenchDepartureInfo{
 			airport:  dr.Airport,
 			runway:   string(dr.Runway),
 			category: dr.Category,
@@ -186,13 +186,13 @@ func (ds *TestBench) refreshSelections() {
 	}
 }
 
-func (ds *TestBench) resetTestState() {
-	ds.activeTest = nil
-	ds.currentStep = 0
-	ds.stepResults = nil
-	ds.lastReadback = ""
-	ds.lastReadbackCS = ""
-	ds.callsignMap = nil
+func (tb *TestBench) resetTestState() {
+	tb.activeTest = nil
+	tb.currentStep = 0
+	tb.stepResults = nil
+	tb.lastReadback = ""
+	tb.lastReadbackCS = ""
+	tb.callsignMap = nil
 }
 
 ///////////////////////////////////////////////////////////////////////////
@@ -230,11 +230,16 @@ func approachFixNames(ap *av.Approach) (iaf, ifFix, faf string) {
 //	{faf}           → Final Approach Fix name
 //	{hold_fix}      → fix ID for commands, written name for readbacks
 //	{star_fix}      → first fix of a randomly selected STAR
-func (ds *TestBench) resolveStep(tc *TestBenchCase, step TestBenchStep) TestBenchStep {
-	if ds.selectedApproach < 0 || ds.selectedApproach >= len(ds.approaches) {
+func (tb *TestBench) resolveStep(tc *TestBenchCase, step TestBenchStep) TestBenchStep {
+	if tb.selectedApproach < 0 || tb.selectedApproach >= len(tb.approaches) {
 		return step
 	}
-	ap := ds.approaches[ds.selectedApproach]
+
+	// Copy the slice so we don't permanently mutate the JSON-parsed config
+	// (resolveStep is called every frame during drawTestCase).
+	step.ExpectReadback = append([]string(nil), step.ExpectReadback...)
+
+	ap := tb.approaches[tb.selectedApproach]
 	iaf, ifFix, faf := approachFixNames(ap.approach)
 
 	// Commands use the fix ID (e.g. "LENDY") for the command parser;
@@ -246,22 +251,26 @@ func (ds *TestBench) resolveStep(tc *TestBenchCase, step TestBenchStep) TestBenc
 		"{iaf}", iaf,
 		"{if}", ifFix,
 		"{faf}", faf,
-		"{star_fix}", ds.starFix,
+		"{star_fix}", tb.starFix,
 	)
-	step.Command = strings.ReplaceAll(r.Replace(step.Command), "{hold_fix}", ds.holdFix)
+	step.Command = strings.ReplaceAll(r.Replace(step.Command), "{hold_fix}", tb.holdFix)
 	for i, s := range step.ExpectReadback {
-		step.ExpectReadback[i] = strings.ReplaceAll(r.Replace(s), "{hold_fix}", ds.holdFixName)
+		step.ExpectReadback[i] = strings.ReplaceAll(r.Replace(s), "{hold_fix}", tb.holdFixName)
 	}
-	step.RejectReadback = strings.ReplaceAll(r.Replace(step.RejectReadback), "{hold_fix}", ds.holdFixName)
+	step.RejectReadback = strings.ReplaceAll(r.Replace(step.RejectReadback), "{hold_fix}", tb.holdFixName)
 
 	// Resolve per-aircraft index references like "{0}", "{hdg0}" to the
 	// generated callsign or heading for that aircraft spec index.
-	if ds.spawnedTest == tc && ds.callsignMap != nil {
-		step.Callsign = ds.resolveCallsignRef(step.Callsign)
+	if tb.spawnedTest == tc && tb.callsignMap != nil {
+		step.Callsign = tb.resolveCallsignRef(step.Callsign)
 		// Replace {hdgN} with the 3-digit zero-padded heading for aircraft N.
-		for idx, hdg := range ds.headingMap {
+		for idx, hdg := range tb.headingMap {
 			placeholder := fmt.Sprintf("{hdg%d}", idx)
-			formatted := fmt.Sprintf("%03d", int(hdg+0.5)%360)
+			h := int(hdg+0.5) % 360
+			if h == 0 {
+				h = 360
+			}
+			formatted := fmt.Sprintf("%03d", h)
 			step.Command = strings.ReplaceAll(step.Command, placeholder, formatted)
 			for i, s := range step.ExpectReadback {
 				step.ExpectReadback[i] = strings.ReplaceAll(s, placeholder, formatted)
@@ -276,7 +285,7 @@ func (ds *TestBench) resolveStep(tc *TestBenchCase, step TestBenchStep) TestBenc
 // resolveCallsignRef maps a callsign reference to the actual spawned callsign.
 // It handles index references like "{0}", "{1}" for multi-aircraft tests.
 // An empty string passes through unchanged (defaultCallsign handles that case).
-func (ds *TestBench) resolveCallsignRef(ref string) string {
+func (tb *TestBench) resolveCallsignRef(ref string) string {
 	if ref == "" {
 		return ""
 	}
@@ -290,7 +299,7 @@ func (ds *TestBench) resolveCallsignRef(ref string) string {
 			}
 			idx = idx*10 + int(ch-'0')
 		}
-		if cs, ok := ds.callsignMap[idx]; ok {
+		if cs, ok := tb.callsignMap[idx]; ok {
 			return cs
 		}
 	}
@@ -299,12 +308,12 @@ func (ds *TestBench) resolveCallsignRef(ref string) string {
 
 // resolveFixRef resolves a fix name (possibly a placeholder like "{if}")
 // to its location and altitude restriction from the selected approach.
-func (ds *TestBench) resolveFixRef(name string, apInfo debugApproachInfo) (loc math.Point2LL, alt float32, ok bool) {
+func (tb *TestBench) resolveFixRef(name string, apInfo testBenchApproachInfo) (loc math.Point2LL, alt float32, ok bool) {
 	// Resolve placeholders.
 	iaf, ifFix, faf := approachFixNames(apInfo.approach)
 	name = strings.NewReplacer(
 		"{iaf}", iaf, "{if}", ifFix, "{faf}", faf,
-		"{hold_fix}", ds.holdFix, "{star_fix}", ds.starFix,
+		"{hold_fix}", tb.holdFix, "{star_fix}", tb.starFix,
 	).Replace(name)
 
 	// Find the fix in the approach waypoints.
@@ -339,17 +348,21 @@ func fixWrittenName(fix string) string {
 
 // resolveRuntimePlaceholders picks random fixes for {hold_fix} and {star_fix}
 // based on the selected approach's airport.
-func (ds *TestBench) resolveRuntimePlaceholders(apInfo debugApproachInfo) {
-	ds.holdFix = ""
-	ds.holdFixName = ""
-	ds.starFix = ""
-	ds.starWaypoints = nil
+func (tb *TestBench) resolveRuntimePlaceholders(apInfo testBenchApproachInfo) {
+	tb.holdFix = ""
+	tb.holdFixName = ""
+	tb.starFix = ""
+	tb.starWaypoints = nil
 
 	r := rand.Make()
 
 	// Pick a random published hold near this airport. A fix has a published
 	// hold if it appears in EnrouteHolds (which is what HoldAtFix validates).
-	airportLoc := av.DB.Airports[apInfo.airport].Location
+	dbAirport, ok := av.DB.Airports[apInfo.airport]
+	if !ok {
+		return
+	}
+	airportLoc := dbAirport.Location
 	var holdFixes []string
 	for fix := range av.DB.EnrouteHolds {
 		if loc, ok := av.DB.LookupWaypoint(fix); ok && math.NMDistance2LL(airportLoc, loc) <= 25 {
@@ -357,16 +370,15 @@ func (ds *TestBench) resolveRuntimePlaceholders(apInfo debugApproachInfo) {
 		}
 	}
 	if len(holdFixes) > 0 {
-		ds.holdFix = holdFixes[r.Intn(len(holdFixes))]
-		ds.holdFixName = fixWrittenName(ds.holdFix)
+		tb.holdFix = holdFixes[r.Intn(len(holdFixes))]
+		tb.holdFixName = fixWrittenName(tb.holdFix)
 	}
 
 	// Pick a random STAR that's active in the current scenario. Use the
 	// arrival's own waypoints if available (scoped to the scenario's
 	// airspace); otherwise look up the STAR in the DB.
-	dbAirport := av.DB.Airports[apInfo.airport]
 	var starWaypointSets []av.WaypointArray
-	for _, flow := range ds.client.State.InboundFlows {
+	for _, flow := range tb.client.State.InboundFlows {
 		for _, arr := range flow.Arrivals {
 			if arr.STAR == "" {
 				continue
@@ -386,12 +398,12 @@ func (ds *TestBench) resolveRuntimePlaceholders(apInfo debugApproachInfo) {
 	}
 	if len(starWaypointSets) > 0 {
 		wps := starWaypointSets[r.Intn(len(starWaypointSets))]
-		ds.starWaypoints = util.DuplicateSlice(wps)
-		for i := range ds.starWaypoints {
-			ds.starWaypoints[i].SetOnSTAR(true)
+		tb.starWaypoints = util.DuplicateSlice(wps)
+		for i := range tb.starWaypoints {
+			tb.starWaypoints[i].SetOnSTAR(true)
 		}
-		if len(ds.starWaypoints) > 0 {
-			ds.starFix = ds.starWaypoints[0].Fix
+		if len(tb.starWaypoints) > 0 {
+			tb.starFix = tb.starWaypoints[0].Fix
 		}
 	}
 }
@@ -399,24 +411,24 @@ func (ds *TestBench) resolveRuntimePlaceholders(apInfo debugApproachInfo) {
 ///////////////////////////////////////////////////////////////////////////
 // UI drawing
 
-func (ds *TestBench) Draw(show *bool, p platform.Platform) {
+func (tb *TestBench) Draw(show *bool, p platform.Platform) {
 	// Process events for readback tracking
-	ds.processEvents()
+	tb.processEvents()
 
 	imgui.SetNextWindowSizeConstraints(imgui.Vec2{400, 200}, imgui.Vec2{800, float32(p.WindowSize()[1]) * 19 / 20})
 	imgui.BeginV("Test Bench", show, imgui.WindowFlagsAlwaysAutoResize)
 
 	// Approach selector
-	if len(ds.approaches) > 0 {
-		label := ds.approachLabel(ds.selectedApproach)
+	if len(tb.approaches) > 0 {
+		label := tb.approachLabel(tb.selectedApproach)
 		imgui.Text("Approach:")
 		imgui.SameLine()
 		imgui.SetNextItemWidth(250)
 		if imgui.BeginCombo("##approach", label) {
-			for i := range ds.approaches {
-				if imgui.SelectableBoolV(ds.approachLabel(i), i == ds.selectedApproach, 0, imgui.Vec2{}) {
-					ds.selectedApproach = i
-					ds.resetTestState()
+			for i := range tb.approaches {
+				if imgui.SelectableBoolV(tb.approachLabel(i), i == tb.selectedApproach, 0, imgui.Vec2{}) {
+					tb.selectedApproach = i
+					tb.resetTestState()
 				}
 			}
 			imgui.EndCombo()
@@ -426,33 +438,33 @@ func (ds *TestBench) Draw(show *bool, p platform.Platform) {
 	}
 
 	// Departure runway selector
-	if len(ds.departures) > 0 {
-		label := ds.departureLabel(ds.selectedDeparture)
+	if len(tb.departures) > 0 {
+		label := tb.departureLabel(tb.selectedDeparture)
 		imgui.Text("Departure:")
 		imgui.SameLine()
 		imgui.SetNextItemWidth(250)
 		if imgui.BeginCombo("##departure", label) {
-			for i := range ds.departures {
-				if imgui.SelectableBoolV(ds.departureLabel(i), i == ds.selectedDeparture, 0, imgui.Vec2{}) {
-					ds.selectedDeparture = i
+			for i := range tb.departures {
+				if imgui.SelectableBoolV(tb.departureLabel(i), i == tb.selectedDeparture, 0, imgui.Vec2{}) {
+					tb.selectedDeparture = i
 				}
 			}
 			imgui.EndCombo()
 		}
 	}
 
-	if ds.statusMessage != "" {
-		imgui.TextColored(imgui.Vec4{0, 1, 0, 1}, ds.statusMessage)
+	if tb.statusMessage != "" {
+		imgui.TextColored(imgui.Vec4{0, 1, 0, 1}, tb.statusMessage)
 	}
 
 	imgui.Separator()
 
 	// Draw sections
-	for _, section := range util.SortedMapKeys(ds.config) {
-		cases := ds.config[section]
+	for _, section := range util.SortedMapKeys(tb.config) {
+		cases := tb.config[section]
 		if imgui.CollapsingHeaderBoolPtr(section, nil) {
 			for i := range cases {
-				ds.drawTestCase(section, &cases[i])
+				tb.drawTestCase(section, &cases[i])
 			}
 		}
 	}
@@ -460,26 +472,26 @@ func (ds *TestBench) Draw(show *bool, p platform.Platform) {
 	imgui.End()
 }
 
-func (ds *TestBench) approachLabel(idx int) string {
-	if idx < 0 || idx >= len(ds.approaches) {
+func (tb *TestBench) approachLabel(idx int) string {
+	if idx < 0 || idx >= len(tb.approaches) {
 		return "(none)"
 	}
-	a := ds.approaches[idx]
+	a := tb.approaches[idx]
 	return fmt.Sprintf("%s - %s (%s)", a.approachId, a.approach.FullName, a.airport)
 }
 
-func (ds *TestBench) departureLabel(idx int) string {
-	if idx < 0 || idx >= len(ds.departures) {
+func (tb *TestBench) departureLabel(idx int) string {
+	if idx < 0 || idx >= len(tb.departures) {
 		return "(none)"
 	}
-	d := ds.departures[idx]
+	d := tb.departures[idx]
 	if d.category != "" {
 		return fmt.Sprintf("%s %s (%s)", d.airport, d.runway, d.category)
 	}
 	return fmt.Sprintf("%s %s", d.airport, d.runway)
 }
 
-func (ds *TestBench) drawTestCase(section string, tc *TestBenchCase) {
+func (tb *TestBench) drawTestCase(section string, tc *TestBenchCase) {
 	id := section + "/" + tc.Label
 	imgui.PushIDStr(id)
 	defer imgui.PopID()
@@ -492,31 +504,31 @@ func (ds *TestBench) drawTestCase(section string, tc *TestBenchCase) {
 
 	if tc.Group != "" {
 		if imgui.Button("Spawn STAR") {
-			ds.spawnSTAR(tc)
+			tb.spawnSTAR(tc)
 		}
 	} else if tc.Departure {
 		if imgui.Button("Spawn Departure") {
-			ds.spawnDeparture(tc)
+			tb.spawnDeparture(tc)
 		}
 	} else if len(tc.Aircraft) > 0 {
 		if imgui.Button("Spawn") {
-			ds.spawnAircraft(tc)
+			tb.spawnAircraft(tc)
 		}
 	}
 
 	// Clear button — only shown on the test case whose aircraft are active
-	if ds.spawnedTest == tc && len(ds.spawnedAircraft) > 0 {
+	if tb.spawnedTest == tc && len(tb.spawnedAircraft) > 0 {
 		imgui.SameLine()
 		if imgui.Button("Clear") {
-			ds.client.DeleteAircraft(ds.spawnedAircraft, func(err error) {
+			tb.client.DeleteAircraft(tb.spawnedAircraft, func(err error) {
 				if err != nil {
-					ds.lg.Warnf("test bench: clear aircraft: %v", err)
+					tb.lg.Warnf("test bench: clear aircraft: %v", err)
 				}
 			})
-			ds.spawnedAircraft = nil
-			ds.spawnedTest = nil
-			ds.resetTestState()
-			ds.statusMessage = "Cleared spawned aircraft"
+			tb.spawnedAircraft = nil
+			tb.spawnedTest = nil
+			tb.resetTestState()
+			tb.statusMessage = "Cleared spawned aircraft"
 		}
 	}
 
@@ -540,8 +552,8 @@ func (ds *TestBench) drawTestCase(section string, tc *TestBenchCase) {
 		}
 		// Show the generated callsign if available, otherwise the spec callsign or index.
 		displayCS := spec.Callsign
-		if ds.spawnedTest == tc {
-			if cs, ok := ds.callsignMap[i]; ok {
+		if tb.spawnedTest == tc {
+			if cs, ok := tb.callsignMap[i]; ok {
 				displayCS = cs
 			}
 		}
@@ -556,13 +568,13 @@ func (ds *TestBench) drawTestCase(section string, tc *TestBenchCase) {
 	// Show test steps
 	if len(tc.Steps) > 0 {
 		for i, rawStep := range tc.Steps {
-			step := ds.resolveStep(tc, rawStep)
-			isActive := ds.activeTest == tc && ds.currentStep == i
+			step := tb.resolveStep(tc, rawStep)
+			isActive := tb.activeTest == tc && tb.currentStep == i
 
 			// Per-step result indicator
 			result := ""
-			if ds.activeTest == tc && i < len(ds.stepResults) {
-				result = ds.stepResults[i]
+			if tb.activeTest == tc && i < len(tb.stepResults) {
+				result = tb.stepResults[i]
 			}
 
 			if result == "pass" {
@@ -582,16 +594,16 @@ func (ds *TestBench) drawTestCase(section string, tc *TestBenchCase) {
 			} else {
 				cs := av.ADSBCallsign(step.Callsign)
 				if cs == "" {
-					cs = ds.defaultCallsign(tc)
+					cs = tb.defaultCallsign(tc)
 				}
 				imgui.Text(fmt.Sprintf("%s %s", cs, step.Command))
 			}
 		}
 
 		// Show last captured readback
-		if ds.activeTest == tc && ds.lastReadback != "" {
+		if tb.activeTest == tc && tb.lastReadback != "" {
 			imgui.TextColored(imgui.Vec4{0.8, 0.8, 0, 1},
-				fmt.Sprintf("    Readback [%s]: %s", ds.lastReadbackCS, ds.lastReadback))
+				fmt.Sprintf("    Readback [%s]: %s", tb.lastReadbackCS, tb.lastReadback))
 		}
 	}
 
@@ -605,61 +617,61 @@ func (ds *TestBench) drawTestCase(section string, tc *TestBenchCase) {
 // generateCallsign samples a random arrival airline from the scenario's
 // inbound flows for the given airport and returns a realistic callsign and
 // aircraft type (e.g. "AAL1234", "B738").
-func (ds *TestBench) generateCallsign(airport string, existingCallsigns []av.ADSBCallsign) (callsign, acType string) {
+func (tb *TestBench) generateCallsign(airport string, existingCallsigns []av.ADSBCallsign) (callsign, acType string) {
 	// Collect all arrival airlines destined for this airport.
 	var airlines []av.ArrivalAirline
-	for _, flow := range ds.client.State.InboundFlows {
+	for _, flow := range tb.client.State.InboundFlows {
 		for _, arr := range flow.Arrivals {
 			airlines = append(airlines, arr.Airlines[airport]...)
 		}
 	}
 	if len(airlines) == 0 {
-		ds.lg.Warnf("test bench: no arrival airlines found for %s", airport)
+		tb.lg.Warnf("test bench: no arrival airlines found for %s", airport)
 		return "", "B738"
 	}
 
 	r := rand.Make()
 	al := rand.SampleSlice(r, airlines)
 	acType, callsign = al.AirlineSpecifier.SampleAcTypeAndCallsign(
-		r, existingCallsigns, false, al.Airport, airport, ds.lg)
+		r, existingCallsigns, false, al.Airport, airport, tb.lg)
 	if acType == "" {
 		acType = "B738"
 	}
 	return callsign, acType
 }
 
-func (ds *TestBench) spawnAircraft(tc *TestBenchCase) {
-	if ds.selectedApproach < 0 || ds.selectedApproach >= len(ds.approaches) {
-		ds.statusMessage = "No approach selected"
+func (tb *TestBench) spawnAircraft(tc *TestBenchCase) {
+	if tb.selectedApproach < 0 || tb.selectedApproach >= len(tb.approaches) {
+		tb.statusMessage = "No approach selected"
 		return
 	}
 
-	apInfo := ds.approaches[ds.selectedApproach]
-	airport := ds.client.State.Airports[apInfo.airport]
+	apInfo := tb.approaches[tb.selectedApproach]
+	airport := tb.client.State.Airports[apInfo.airport]
 	if airport == nil {
-		ds.statusMessage = "Airport not found: " + apInfo.airport
+		tb.statusMessage = "Airport not found: " + apInfo.airport
 		return
 	}
 
-	nmPerLong := ds.client.State.NmPerLongitude
-	magVar := ds.client.State.MagneticVariation
+	nmPerLong := tb.client.State.NmPerLongitude
+	magVar := tb.client.State.MagneticVariation
 	rwyHeading := apInfo.approach.RunwayHeading(nmPerLong, magVar)
-	ctrlFreq := sim.ControlPosition(ds.client.State.PrimaryPositionForTCW(ds.client.State.UserTCW))
+	ctrlFreq := sim.ControlPosition(tb.client.State.PrimaryPositionForTCW(tb.client.State.UserTCW))
 
 	// Clear any previously spawned aircraft before spawning new ones.
-	if len(ds.spawnedAircraft) > 0 {
-		ds.client.DeleteAircraft(ds.spawnedAircraft, func(err error) {
+	if len(tb.spawnedAircraft) > 0 {
+		tb.client.DeleteAircraft(tb.spawnedAircraft, func(err error) {
 			if err != nil {
-				ds.lg.Warnf("test bench: auto-clear: %v", err)
+				tb.lg.Warnf("test bench: auto-clear: %v", err)
 			}
 		})
 	}
 
-	ds.spawnedAircraft = nil
-	ds.spawnedTest = tc
-	ds.callsignMap = make(map[int]string)
-	ds.headingMap = make(map[int]float32)
-	ds.resolveRuntimePlaceholders(apInfo)
+	tb.spawnedAircraft = nil
+	tb.spawnedTest = tc
+	tb.callsignMap = make(map[int]string)
+	tb.headingMap = make(map[int]float32)
+	tb.resolveRuntimePlaceholders(apInfo)
 	var existingCallsigns []av.ADSBCallsign
 	for i, spec := range tc.Aircraft {
 		acType := spec.AircraftType
@@ -667,36 +679,36 @@ func (ds *TestBench) spawnAircraft(tc *TestBenchCase) {
 		// Generate a realistic callsign (and aircraft type) if the spec doesn't provide one.
 		if callsign == "" {
 			var genType string
-			callsign, genType = ds.generateCallsign(apInfo.airport, existingCallsigns)
+			callsign, genType = tb.generateCallsign(apInfo.airport, existingCallsigns)
 			if callsign == "" {
-				ds.statusMessage = "Failed to generate callsign — no matching airlines"
+				tb.statusMessage = "Failed to generate callsign — no matching airlines"
 				return
 			}
 			if acType == "" {
 				acType = genType
 			}
 		}
-		ds.callsignMap[i] = callsign
+		tb.callsignMap[i] = callsign
 		existingCallsigns = append(existingCallsigns, av.ADSBCallsign(callsign))
 
-		ac, err := ds.buildAircraftWithCallsign(spec, callsign, acType, airport, apInfo, rwyHeading, nmPerLong, magVar, ctrlFreq)
+		ac, err := tb.buildAircraftWithCallsign(spec, callsign, acType, airport, apInfo, rwyHeading, nmPerLong, magVar, ctrlFreq)
 		if err != nil {
-			ds.statusMessage = fmt.Sprintf("Aircraft #%d: %v", i, err)
+			tb.statusMessage = fmt.Sprintf("Aircraft #%d: %v", i, err)
 			return
 		}
-		ds.headingMap[i] = ac.Nav.FlightState.Heading
-		ds.client.LaunchArrivalOverflight(ac)
-		ds.spawnedAircraft = append(ds.spawnedAircraft, ac)
-		ds.lg.Infof("test bench: launched %s at %.1fnm/%.0fft", callsign, spec.DistanceNM, ac.Nav.FlightState.Altitude)
+		tb.headingMap[i] = ac.Nav.FlightState.Heading
+		tb.client.LaunchArrivalOverflight(ac)
+		tb.spawnedAircraft = append(tb.spawnedAircraft, ac)
+		tb.lg.Infof("test bench: launched %s at %.1fnm/%.0fft", callsign, spec.DistanceNM, ac.Nav.FlightState.Altitude)
 	}
 
-	ds.activateSteps(tc)
+	tb.activateSteps(tc)
 
-	ds.statusMessage = fmt.Sprintf("Spawned %d aircraft for \"%s\"", len(tc.Aircraft), tc.Label)
+	tb.statusMessage = fmt.Sprintf("Spawned %d aircraft for \"%s\"", len(tc.Aircraft), tc.Label)
 }
 
-func (ds *TestBench) buildAircraftWithCallsign(spec TestBenchAircraftSpec, callsign, acType string,
-	airport *av.Airport, apInfo debugApproachInfo, rwyHeading, nmPerLong, magVar float32,
+func (tb *TestBench) buildAircraftWithCallsign(spec TestBenchAircraftSpec, callsign, acType string,
+	airport *av.Airport, apInfo testBenchApproachInfo, rwyHeading, nmPerLong, magVar float32,
 	ctrlFreq sim.ControlPosition) (sim.Aircraft, error) {
 
 	// Determine reference point and altitude.
@@ -706,7 +718,7 @@ func (ds *TestBench) buildAircraftWithCallsign(spec TestBenchAircraftSpec, calls
 	altitude := spec.Altitude
 
 	if spec.RelativeTo != "" {
-		if fixLoc, fixAlt, ok := ds.resolveFixRef(spec.RelativeTo, apInfo); ok {
+		if fixLoc, fixAlt, ok := tb.resolveFixRef(spec.RelativeTo, apInfo); ok {
 			refPos = fixLoc
 			if altitude == 0 {
 				if fixAlt > 0 {
@@ -718,9 +730,9 @@ func (ds *TestBench) buildAircraftWithCallsign(spec TestBenchAircraftSpec, calls
 		} else {
 			return sim.Aircraft{}, fmt.Errorf("couldn't resolve fix %q", spec.RelativeTo)
 		}
-	} else if spec.StarWaypoints && len(ds.starWaypoints) > 0 {
+	} else if spec.StarWaypoints && len(tb.starWaypoints) > 0 {
 		// Default to positioning near the first STAR waypoint.
-		refPos = ds.starWaypoints[0].Location
+		refPos = tb.starWaypoints[0].Location
 	}
 
 	// Determine the bearing from reference to place the aircraft.
@@ -794,47 +806,47 @@ func (ds *TestBench) buildAircraftWithCallsign(spec TestBenchAircraftSpec, calls
 			AircraftCount:      1,
 			AircraftType:       acType,
 			TrackingController: ctrlFreq,
-			OwningTCW:          ds.client.State.UserTCW,
+			OwningTCW:          tb.client.State.UserTCW,
 		},
 	}
 
-	if spec.StarWaypoints && len(ds.starWaypoints) > 0 {
-		ac.Nav.Waypoints = util.DuplicateSlice(ds.starWaypoints)
+	if spec.StarWaypoints && len(tb.starWaypoints) > 0 {
+		ac.Nav.Waypoints = util.DuplicateSlice(tb.starWaypoints)
 	}
 
 	return ac, nil
 }
 
-func (ds *TestBench) spawnSTAR(tc *TestBenchCase) {
+func (tb *TestBench) spawnSTAR(tc *TestBenchCase) {
 	airport := tc.Airport
 	if airport == "" {
-		airport = ds.client.State.PrimaryAirport
+		airport = tb.client.State.PrimaryAirport
 	}
 
 	var ac sim.Aircraft
-	ds.client.CreateArrival(tc.Group, airport, &ac, func(err error) {
+	tb.client.CreateArrival(tc.Group, airport, &ac, func(err error) {
 		if err != nil {
-			ds.lg.Warnf("test bench: CreateArrival %s: %v", tc.Group, err)
-			ds.statusMessage = fmt.Sprintf("STAR spawn failed: %v", err)
+			tb.lg.Warnf("test bench: CreateArrival %s: %v", tc.Group, err)
+			tb.statusMessage = fmt.Sprintf("STAR spawn failed: %v", err)
 		} else {
-			ds.spawnedAircraft = append(ds.spawnedAircraft, ac)
-			ds.spawnedTest = tc
-			ds.lg.Infof("test bench: STAR %s spawned for %s (%s)", tc.Group, airport, ac.ADSBCallsign)
-			ds.statusMessage = fmt.Sprintf("Spawned STAR %s at %s (%s)", tc.Group, airport, ac.ADSBCallsign)
-			ds.activateSteps(tc)
+			tb.spawnedAircraft = append(tb.spawnedAircraft, ac)
+			tb.spawnedTest = tc
+			tb.lg.Infof("test bench: STAR %s spawned for %s (%s)", tc.Group, airport, ac.ADSBCallsign)
+			tb.statusMessage = fmt.Sprintf("Spawned STAR %s at %s (%s)", tc.Group, airport, ac.ADSBCallsign)
+			tb.activateSteps(tc)
 		}
 	})
 }
 
-func (ds *TestBench) spawnDeparture(tc *TestBenchCase) {
+func (tb *TestBench) spawnDeparture(tc *TestBenchCase) {
 	airport := tc.Airport
 	runway := tc.Runway
 	category := tc.Category
 
 	// Use the departure dropdown selection if the scenario doesn't specify.
 	if airport == "" || runway == "" {
-		if ds.selectedDeparture >= 0 && ds.selectedDeparture < len(ds.departures) {
-			d := ds.departures[ds.selectedDeparture]
+		if tb.selectedDeparture >= 0 && tb.selectedDeparture < len(tb.departures) {
+			d := tb.departures[tb.selectedDeparture]
 			if airport == "" {
 				airport = d.airport
 			}
@@ -843,30 +855,30 @@ func (ds *TestBench) spawnDeparture(tc *TestBenchCase) {
 				category = d.category
 			}
 		} else {
-			ds.statusMessage = "No departure runway selected"
+			tb.statusMessage = "No departure runway selected"
 			return
 		}
 	}
 	if airport == "" || runway == "" {
-		ds.statusMessage = "No departure runway selected"
+		tb.statusMessage = "No departure runway selected"
 		return
 	}
 
 	var ac sim.Aircraft
-	ds.client.CreateDeparture(airport, runway, category, av.FlightRulesIFR, &ac, func(err error) {
+	tb.client.CreateDeparture(airport, runway, category, av.FlightRulesIFR, &ac, func(err error) {
 		if err != nil {
-			ds.lg.Warnf("test bench: CreateDeparture: %v", err)
-			ds.statusMessage = fmt.Sprintf("Departure spawn failed: %v", err)
+			tb.lg.Warnf("test bench: CreateDeparture: %v", err)
+			tb.statusMessage = fmt.Sprintf("Departure spawn failed: %v", err)
 		} else {
 			// Launch the departure immediately (same pattern as LaunchControl).
 			// CreateDeparture builds the aircraft; LaunchDeparture puts it on scope.
-			ds.client.LaunchDeparture(ac, runway)
+			tb.client.LaunchDeparture(ac, runway)
 
-			ds.spawnedAircraft = append(ds.spawnedAircraft, ac)
-			ds.spawnedTest = tc
-			ds.lg.Infof("test bench: departure %s launched at %s rwy %s", ac.ADSBCallsign, airport, runway)
-			ds.statusMessage = fmt.Sprintf("Launched departure %s at %s rwy %s", ac.ADSBCallsign, airport, runway)
-			ds.activateSteps(tc)
+			tb.spawnedAircraft = append(tb.spawnedAircraft, ac)
+			tb.spawnedTest = tc
+			tb.lg.Infof("test bench: departure %s launched at %s rwy %s", ac.ADSBCallsign, airport, runway)
+			tb.statusMessage = fmt.Sprintf("Launched departure %s at %s rwy %s", ac.ADSBCallsign, airport, runway)
+			tb.activateSteps(tc)
 		}
 	})
 }
@@ -876,10 +888,10 @@ func (ds *TestBench) spawnDeparture(tc *TestBenchCase) {
 
 // isTestCallsign checks whether the given callsign belongs to one of the
 // test case's aircraft — either from the callsign map, JSON spec, or sim-spawned aircraft.
-func (ds *TestBench) isTestCallsign(tc *TestBenchCase, cs av.ADSBCallsign) bool {
+func (tb *TestBench) isTestCallsign(tc *TestBenchCase, cs av.ADSBCallsign) bool {
 	// Check generated callsigns (only for the active spawned test).
-	if ds.spawnedTest == tc {
-		for _, mapped := range ds.callsignMap {
+	if tb.spawnedTest == tc {
+		for _, mapped := range tb.callsignMap {
 			if av.ADSBCallsign(mapped) == cs {
 				return true
 			}
@@ -891,8 +903,8 @@ func (ds *TestBench) isTestCallsign(tc *TestBenchCase, cs av.ADSBCallsign) bool 
 		}
 	}
 	// For departures/STARs, check spawned aircraft (callsign assigned by sim).
-	if ds.spawnedTest == tc {
-		for _, ac := range ds.spawnedAircraft {
+	if tb.spawnedTest == tc {
+		for _, ac := range tb.spawnedAircraft {
 			if ac.ADSBCallsign == cs {
 				return true
 			}
@@ -902,18 +914,18 @@ func (ds *TestBench) isTestCallsign(tc *TestBenchCase, cs av.ADSBCallsign) bool 
 }
 
 // defaultCallsign returns the callsign to use when a step doesn't specify one.
-func (ds *TestBench) defaultCallsign(tc *TestBenchCase) av.ADSBCallsign {
+func (tb *TestBench) defaultCallsign(tc *TestBenchCase) av.ADSBCallsign {
 	// Use the callsign map first (populated at spawn time with generated callsigns).
-	if ds.spawnedTest == tc {
-		if cs, ok := ds.callsignMap[0]; ok {
+	if tb.spawnedTest == tc {
+		if cs, ok := tb.callsignMap[0]; ok {
 			return av.ADSBCallsign(cs)
 		}
 	}
 	if len(tc.Aircraft) > 0 {
 		return av.ADSBCallsign(tc.Aircraft[0].Callsign)
 	}
-	if ds.spawnedTest == tc && len(ds.spawnedAircraft) > 0 {
-		return ds.spawnedAircraft[0].ADSBCallsign
+	if tb.spawnedTest == tc && len(tb.spawnedAircraft) > 0 {
+		return tb.spawnedAircraft[0].ADSBCallsign
 	}
 	return ""
 }
@@ -950,49 +962,49 @@ func matchWaitFor(waitFor string, event sim.Event) bool {
 	return false
 }
 
-func (ds *TestBench) processEvents() {
-	if ds.activeTest == nil {
+func (tb *TestBench) processEvents() {
+	if tb.activeTest == nil {
 		// Still drain events so the subscription doesn't fall behind.
-		ds.events.Get()
+		tb.events.Get()
 		return
 	}
 
-	tc := ds.activeTest
+	tc := tb.activeTest
 
-	for _, event := range ds.events.Get() {
+	for _, event := range tb.events.Get() {
 		if event.Type != sim.RadioTransmissionEvent {
 			continue
 		}
-		if !ds.isTestCallsign(tc, event.ADSBCallsign) {
+		if !tb.isTestCallsign(tc, event.ADSBCallsign) {
 			continue
 		}
-		if ds.currentStep >= len(tc.Steps) {
+		if tb.currentStep >= len(tc.Steps) {
 			continue
 		}
 
-		step := ds.resolveStep(tc, tc.Steps[ds.currentStep])
+		step := tb.resolveStep(tc, tc.Steps[tb.currentStep])
 		if step.WaitFor != "" {
-			ds.processWaitForStep(step, event)
+			tb.processWaitForStep(step, event)
 		} else {
-			ds.processCommandStep(tc, step, event)
+			tb.processCommandStep(tc, step, event)
 		}
 	}
 }
 
 // processWaitForStep handles a wait_for step by checking whether the event
 // matches the expected condition (check_in, field_in_sight, etc.).
-func (ds *TestBench) processWaitForStep(step TestBenchStep, event sim.Event) {
+func (tb *TestBench) processWaitForStep(step TestBenchStep, event sim.Event) {
 	if matchWaitFor(step.WaitFor, event) {
-		ds.stepResults[ds.currentStep] = "pass"
-		ds.lastReadback = event.WrittenText
-		ds.lastReadbackCS = event.ADSBCallsign
-		ds.advanceStep()
+		tb.stepResults[tb.currentStep] = "pass"
+		tb.lastReadback = event.WrittenText
+		tb.lastReadbackCS = event.ADSBCallsign
+		tb.advanceStep()
 	}
 }
 
 // processCommandStep handles a command step by verifying the pilot's readback
 // against the expected/rejected text patterns.
-func (ds *TestBench) processCommandStep(tc *TestBenchCase, step TestBenchStep, event sim.Event) {
+func (tb *TestBench) processCommandStep(tc *TestBenchCase, step TestBenchStep, event sim.Event) {
 	// Only evaluate actual readbacks — not check-ins or spontaneous transmissions.
 	if event.RadioTransmissionType != av.RadioTransmissionReadback {
 		return
@@ -1001,14 +1013,14 @@ func (ds *TestBench) processCommandStep(tc *TestBenchCase, step TestBenchStep, e
 	// Check the step's target callsign.
 	targetCS := av.ADSBCallsign(step.Callsign)
 	if targetCS == "" {
-		targetCS = ds.defaultCallsign(tc)
+		targetCS = tb.defaultCallsign(tc)
 	}
 	if targetCS != event.ADSBCallsign {
 		return
 	}
 
-	ds.lastReadback = event.WrittenText
-	ds.lastReadbackCS = event.ADSBCallsign
+	tb.lastReadback = event.WrittenText
+	tb.lastReadbackCS = event.ADSBCallsign
 
 	// "Say again" means the pilot didn't understand; skip it so
 	// the controller can re-issue the command.
@@ -1021,16 +1033,16 @@ func (ds *TestBench) processCommandStep(tc *TestBenchCase, step TestBenchStep, e
 	// "fire and forget" step — pass the readback through so the
 	// next step (e.g. wait_for) can evaluate it.
 	if len(step.ExpectReadback) == 0 && step.RejectReadback == "" {
-		ds.stepResults[ds.currentStep] = "pass"
-		ds.advanceStep()
+		tb.stepResults[tb.currentStep] = "pass"
+		tb.advanceStep()
 		// Re-evaluate this same event against the new current step.
-		if ds.currentStep < len(tc.Steps) {
-			next := ds.resolveStep(tc, tc.Steps[ds.currentStep])
+		if tb.currentStep < len(tc.Steps) {
+			next := tb.resolveStep(tc, tc.Steps[tb.currentStep])
 			if next.WaitFor != "" && matchWaitFor(next.WaitFor, event) {
-				ds.stepResults[ds.currentStep] = "pass"
-				ds.lastReadback = event.WrittenText
-				ds.lastReadbackCS = event.ADSBCallsign
-				ds.advanceStep()
+				tb.stepResults[tb.currentStep] = "pass"
+				tb.lastReadback = event.WrittenText
+				tb.lastReadbackCS = event.ADSBCallsign
+				tb.advanceStep()
 			}
 		}
 		return
@@ -1053,27 +1065,27 @@ func (ds *TestBench) processCommandStep(tc *TestBenchCase, step TestBenchStep, e
 		pass = false
 	}
 
-	ds.lg.Debugf("test bench: step %d cmd=%q expect=%v reject=%q written=%q pass=%v",
-		ds.currentStep, step.Command, step.ExpectReadback, step.RejectReadback, event.WrittenText, pass)
+	tb.lg.Debugf("test bench: step %d cmd=%q expect=%v reject=%q written=%q pass=%v",
+		tb.currentStep, step.Command, step.ExpectReadback, step.RejectReadback, event.WrittenText, pass)
 
 	if pass {
-		ds.stepResults[ds.currentStep] = "pass"
+		tb.stepResults[tb.currentStep] = "pass"
 	} else {
-		ds.stepResults[ds.currentStep] = "fail"
+		tb.stepResults[tb.currentStep] = "fail"
 	}
-	ds.advanceStep()
+	tb.advanceStep()
 }
 
-func (ds *TestBench) activateSteps(tc *TestBenchCase) {
+func (tb *TestBench) activateSteps(tc *TestBenchCase) {
 	if len(tc.Steps) > 0 {
-		ds.activeTest = tc
-		ds.currentStep = 0
-		ds.stepResults = make([]string, len(tc.Steps))
-		ds.lastReadback = ""
-		ds.lastReadbackCS = ""
+		tb.activeTest = tc
+		tb.currentStep = 0
+		tb.stepResults = make([]string, len(tc.Steps))
+		tb.lastReadback = ""
+		tb.lastReadbackCS = ""
 	}
 }
 
-func (ds *TestBench) advanceStep() {
-	ds.currentStep++
+func (tb *TestBench) advanceStep() {
+	tb.currentStep++
 }

--- a/cmd/vice/testbench_test.go
+++ b/cmd/vice/testbench_test.go
@@ -316,7 +316,7 @@ func TestSpeculativeAdvance(t *testing.T) {
 		tc := &TestBenchCase{
 			Steps: []TestBenchStep{
 				{Command: "S210", ExpectReadback: StringOrArray{"210 knots"}},
-				{Command: "E{approach}"},                                        // fire-and-forget
+				{Command: "E{approach}"}, // fire-and-forget
 				{Command: "D050", ExpectReadback: StringOrArray{"5,000"}},
 			},
 		}
@@ -339,7 +339,7 @@ func TestSpeculativeAdvance(t *testing.T) {
 		tc := &TestBenchCase{
 			Steps: []TestBenchStep{
 				{WaitFor: "field_in_sight"},
-				{Command: "CVA"},                                                // fire-and-forget after wait
+				{Command: "CVA"}, // fire-and-forget after wait
 				{Command: "D050", ExpectReadback: StringOrArray{"5,000"}},
 			},
 		}
@@ -361,7 +361,7 @@ func TestSpeculativeAdvance(t *testing.T) {
 	t.Run("advances through matching wait_for", func(t *testing.T) {
 		tc := &TestBenchCase{
 			Steps: []TestBenchStep{
-				{Command: "TRAFFIC/12/3/50"},       // fire-and-forget
+				{Command: "TRAFFIC/12/3/50"}, // fire-and-forget
 				{WaitFor: "traffic_in_sight"},
 			},
 		}
@@ -407,7 +407,7 @@ func TestSpeculativeAdvance(t *testing.T) {
 	t.Run("stops at non-matching wait_for", func(t *testing.T) {
 		tc := &TestBenchCase{
 			Steps: []TestBenchStep{
-				{Command: "E{approach}"},     // fire-and-forget
+				{Command: "E{approach}"}, // fire-and-forget
 				{WaitFor: "go_around"},
 			},
 		}
@@ -447,8 +447,8 @@ func TestSpeculativeAdvance(t *testing.T) {
 		tc := &TestBenchCase{
 			Steps: []TestBenchStep{
 				{WaitFor: "field_in_sight"},
-				{Command: "E{approach}"},                                  // fire-and-forget after wait
-				{Command: "D{if}"},                                        // fire-and-forget after fire-and-forget
+				{Command: "E{approach}"}, // fire-and-forget after wait
+				{Command: "D{if}"},       // fire-and-forget after fire-and-forget
 				{WaitFor: "approach_clearance_request"},
 			},
 		}

--- a/cmd/vice/testbench_test.go
+++ b/cmd/vice/testbench_test.go
@@ -1,0 +1,449 @@
+// Copyright(c) 2022-2026 vice contributors, licensed under the GNU Public License, Version 3.
+// SPDX: GPL-3.0-only
+
+package main
+
+import (
+	"testing"
+
+	av "github.com/mmp/vice/aviation"
+	"github.com/mmp/vice/sim"
+)
+
+func TestMatchReadback(t *testing.T) {
+	tests := []struct {
+		name   string
+		text   string
+		step   TestBenchStep
+		expect string
+	}{
+		{
+			name:   "no expectations passes",
+			text:   "anything at all",
+			step:   TestBenchStep{},
+			expect: "pass",
+		},
+		{
+			name:   "matching expect",
+			text:   "descending to 5,000",
+			step:   TestBenchStep{ExpectReadback: StringOrArray{"5,000"}},
+			expect: "pass",
+		},
+		{
+			name:   "no match returns empty",
+			text:   "descending to 5,000",
+			step:   TestBenchStep{ExpectReadback: StringOrArray{"6,000"}},
+			expect: "",
+		},
+		{
+			name:   "any of multiple expects",
+			text:   "slowing as much as we can",
+			step:   TestBenchStep{ExpectReadback: StringOrArray{"slowest practical speed", "slowing as much as we can"}},
+			expect: "pass",
+		},
+		{
+			name:   "reject overrides pass",
+			text:   "traffic in sight, will maintain visual separation",
+			step:   TestBenchStep{ExpectReadback: StringOrArray{"traffic in sight"}, RejectReadback: "visual separation"},
+			expect: "fail",
+		},
+		{
+			name:   "reject without match",
+			text:   "traffic in sight",
+			step:   TestBenchStep{ExpectReadback: StringOrArray{"traffic in sight"}, RejectReadback: "visual separation"},
+			expect: "pass",
+		},
+		{
+			name:   "case insensitive expect",
+			text:   "DESCENDING TO 5,000",
+			step:   TestBenchStep{ExpectReadback: StringOrArray{"5,000"}},
+			expect: "pass",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := matchReadback(tt.text, tt.step)
+			if got != tt.expect {
+				t.Errorf("matchReadback(%q, ...) = %q, want %q", tt.text, got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestMatchWaitFor(t *testing.T) {
+	tests := []struct {
+		name    string
+		waitFor string
+		event   sim.Event
+		expect  bool
+	}{
+		{
+			name:    "check_in matches contact type",
+			waitFor: "check_in",
+			event:   sim.Event{RadioTransmissionType: av.RadioTransmissionContact},
+			expect:  true,
+		},
+		{
+			name:    "check_in rejects readback type",
+			waitFor: "check_in",
+			event:   sim.Event{RadioTransmissionType: av.RadioTransmissionReadback, WrittenText: "checking in"},
+			expect:  false,
+		},
+		{
+			name:    "approach_clearance_request",
+			waitFor: "approach_clearance_request",
+			event:   sim.Event{WrittenText: "looking for the approach"},
+			expect:  true,
+		},
+		{
+			name:    "go_around",
+			waitFor: "go_around",
+			event:   sim.Event{WrittenText: "going around"},
+			expect:  true,
+		},
+		{
+			name:    "traffic_in_sight matches",
+			waitFor: "traffic_in_sight",
+			event:   sim.Event{WrittenText: "we have the traffic"},
+			expect:  true,
+		},
+		{
+			name:    "traffic_in_sight rejects looking",
+			waitFor: "traffic_in_sight",
+			event:   sim.Event{WrittenText: "looking"},
+			expect:  false,
+		},
+		{
+			name:    "traffic_response matches looking",
+			waitFor: "traffic_response",
+			event:   sim.Event{WrittenText: "looking"},
+			expect:  true,
+		},
+		{
+			name:    "traffic_response matches in sight",
+			waitFor: "traffic_response",
+			event:   sim.Event{WrittenText: "traffic in sight"},
+			expect:  true,
+		},
+		{
+			name:    "traffic_response matches imc",
+			waitFor: "traffic_response",
+			event:   sim.Event{WrittenText: "we're in IMC"},
+			expect:  true,
+		},
+		{
+			name:    "unknown wait_for never matches",
+			waitFor: "nonexistent",
+			event:   sim.Event{WrittenText: "anything"},
+			expect:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := matchWaitFor(tt.waitFor, tt.event)
+			if got != tt.expect {
+				t.Errorf("matchWaitFor(%q, ...) = %v, want %v", tt.waitFor, got, tt.expect)
+			}
+		})
+	}
+}
+
+// newTestBench creates a minimal TestBench with the given case activated.
+func newTestBench(tc *TestBenchCase) *TestBench {
+	tb := &TestBench{
+		activeTest:  tc,
+		spawnedTest: tc,
+		currentStep: 0,
+		stepResults: make([]string, len(tc.Steps)),
+		callsignMap: map[int]string{0: "AAL123"},
+	}
+	return tb
+}
+
+func readbackEvent(cs string, text string) sim.Event {
+	return sim.Event{
+		ADSBCallsign:          av.ADSBCallsign(cs),
+		WrittenText:           text,
+		RadioTransmissionType: av.RadioTransmissionReadback,
+	}
+}
+
+func contactEvent(cs string, text string) sim.Event {
+	return sim.Event{
+		ADSBCallsign:          av.ADSBCallsign(cs),
+		WrittenText:           text,
+		RadioTransmissionType: av.RadioTransmissionContact,
+	}
+}
+
+func TestProcessCommandStep(t *testing.T) {
+	t.Run("advances on matching readback", func(t *testing.T) {
+		tc := &TestBenchCase{
+			Steps: []TestBenchStep{
+				{Command: "S210", ExpectReadback: StringOrArray{"210 knots"}},
+			},
+		}
+		tb := newTestBench(tc)
+		tb.processCommandStep(tc, tc.Steps[0], readbackEvent("AAL123", "210 knots"))
+		if tb.stepResults[0] != "pass" {
+			t.Errorf("step result = %q, want pass", tb.stepResults[0])
+		}
+		if tb.currentStep != 1 {
+			t.Errorf("currentStep = %d, want 1", tb.currentStep)
+		}
+	})
+
+	t.Run("ignores non-readback events", func(t *testing.T) {
+		tc := &TestBenchCase{
+			Steps: []TestBenchStep{
+				{Command: "S210", ExpectReadback: StringOrArray{"210 knots"}},
+			},
+		}
+		tb := newTestBench(tc)
+		tb.processCommandStep(tc, tc.Steps[0], contactEvent("AAL123", "210 knots"))
+		if tb.stepResults[0] != "" {
+			t.Errorf("step result = %q, want empty", tb.stepResults[0])
+		}
+	})
+
+	t.Run("ignores wrong callsign", func(t *testing.T) {
+		tc := &TestBenchCase{
+			Steps: []TestBenchStep{
+				{Command: "S210", ExpectReadback: StringOrArray{"210 knots"}},
+			},
+		}
+		tb := newTestBench(tc)
+		tb.processCommandStep(tc, tc.Steps[0], readbackEvent("UAL456", "210 knots"))
+		if tb.stepResults[0] != "" {
+			t.Errorf("step result = %q, want empty", tb.stepResults[0])
+		}
+	})
+
+	t.Run("ignores say again", func(t *testing.T) {
+		tc := &TestBenchCase{
+			Steps: []TestBenchStep{
+				{Command: "S210", ExpectReadback: StringOrArray{"210 knots"}},
+			},
+		}
+		tb := newTestBench(tc)
+		tb.processCommandStep(tc, tc.Steps[0], readbackEvent("AAL123", "say again?"))
+		if tb.stepResults[0] != "" {
+			t.Errorf("step result = %q, want empty", tb.stepResults[0])
+		}
+	})
+
+	t.Run("fire and forget advances immediately", func(t *testing.T) {
+		tc := &TestBenchCase{
+			Steps: []TestBenchStep{
+				{Command: "E{approach}"},
+			},
+		}
+		tb := newTestBench(tc)
+		tb.processCommandStep(tc, tc.Steps[0], readbackEvent("AAL123", "expect ILS 28R"))
+		if tb.stepResults[0] != "pass" {
+			t.Errorf("step result = %q, want pass", tb.stepResults[0])
+		}
+	})
+
+	t.Run("reject readback fails step", func(t *testing.T) {
+		tc := &TestBenchCase{
+			Steps: []TestBenchStep{
+				{Command: "H090", ExpectReadback: StringOrArray{"090"}, RejectReadback: "unable"},
+			},
+		}
+		tb := newTestBench(tc)
+		tb.processCommandStep(tc, tc.Steps[0], readbackEvent("AAL123", "unable heading 090"))
+		if tb.stepResults[0] != "fail" {
+			t.Errorf("step result = %q, want fail", tb.stepResults[0])
+		}
+	})
+
+	t.Run("non-matching readback leaves step pending", func(t *testing.T) {
+		tc := &TestBenchCase{
+			Steps: []TestBenchStep{
+				{Command: "S210", ExpectReadback: StringOrArray{"210 knots"}},
+			},
+		}
+		tb := newTestBench(tc)
+		tb.processCommandStep(tc, tc.Steps[0], readbackEvent("AAL123", "looking for the approach"))
+		if tb.stepResults[0] != "" {
+			t.Errorf("step result = %q, want empty", tb.stepResults[0])
+		}
+		if tb.currentStep != 0 {
+			t.Errorf("currentStep = %d, want 0", tb.currentStep)
+		}
+	})
+}
+
+func TestProcessWaitForStep(t *testing.T) {
+	t.Run("advances on match", func(t *testing.T) {
+		tc := &TestBenchCase{
+			Steps: []TestBenchStep{
+				{WaitFor: "check_in"},
+			},
+		}
+		tb := newTestBench(tc)
+		tb.processWaitForStep(tc.Steps[0], contactEvent("AAL123", "checking in at 5000"))
+		if tb.stepResults[0] != "pass" {
+			t.Errorf("step result = %q, want pass", tb.stepResults[0])
+		}
+		if tb.currentStep != 1 {
+			t.Errorf("currentStep = %d, want 1", tb.currentStep)
+		}
+	})
+
+	t.Run("stays on non-match", func(t *testing.T) {
+		tc := &TestBenchCase{
+			Steps: []TestBenchStep{
+				{WaitFor: "traffic_in_sight"},
+			},
+		}
+		tb := newTestBench(tc)
+		tb.processWaitForStep(tc.Steps[0], readbackEvent("AAL123", "looking"))
+		if tb.stepResults[0] != "" {
+			t.Errorf("step result = %q, want empty", tb.stepResults[0])
+		}
+		if tb.currentStep != 0 {
+			t.Errorf("currentStep = %d, want 0", tb.currentStep)
+		}
+	})
+}
+
+func TestSpeculativeAdvance(t *testing.T) {
+	t.Run("advances through fire-and-forget", func(t *testing.T) {
+		tc := &TestBenchCase{
+			Steps: []TestBenchStep{
+				{Command: "S210", ExpectReadback: StringOrArray{"210 knots"}},
+				{Command: "E{approach}"},                                        // fire-and-forget
+				{Command: "D050", ExpectReadback: StringOrArray{"5,000"}},
+			},
+		}
+		tb := newTestBench(tc)
+		// Simulate step 0 already passed.
+		tb.stepResults[0] = "pass"
+		tb.currentStep = 1
+
+		tb.speculativeAdvance(tc, readbackEvent("AAL123", "210 knots"))
+
+		// Should have advanced past fire-and-forget (step 1) and stopped at step 2.
+		if tb.stepResults[1] != "pass" {
+			t.Errorf("step 1 result = %q, want pass", tb.stepResults[1])
+		}
+		if tb.currentStep != 2 {
+			t.Errorf("currentStep = %d, want 2", tb.currentStep)
+		}
+	})
+
+	t.Run("advances through matching wait_for", func(t *testing.T) {
+		tc := &TestBenchCase{
+			Steps: []TestBenchStep{
+				{Command: "TRAFFIC/12/3/50"},       // fire-and-forget
+				{WaitFor: "traffic_in_sight"},
+			},
+		}
+		tb := newTestBench(tc)
+		tb.stepResults[0] = "pass"
+		tb.currentStep = 1
+
+		tb.speculativeAdvance(tc, sim.Event{WrittenText: "we have the traffic"})
+
+		if tb.stepResults[1] != "pass" {
+			t.Errorf("step 1 result = %q, want pass", tb.stepResults[1])
+		}
+		if tb.currentStep != 2 {
+			t.Errorf("currentStep = %d, want 2", tb.currentStep)
+		}
+	})
+
+	t.Run("stops at command with expect_readback", func(t *testing.T) {
+		tc := &TestBenchCase{
+			Steps: []TestBenchStep{
+				{WaitFor: "traffic_in_sight"},
+				{Command: "VISSEP", ExpectReadback: StringOrArray{"visual separation"}},
+			},
+		}
+		tb := newTestBench(tc)
+		tb.stepResults[0] = "pass"
+		tb.currentStep = 1
+
+		// The event text matches VISSEP's expect, but the command hasn't been
+		// issued yet so speculative advance must not match it.
+		tb.speculativeAdvance(tc, sim.Event{
+			WrittenText: "we have the traffic, will maintain visual separation",
+		})
+
+		if tb.stepResults[1] != "" {
+			t.Errorf("step 1 result = %q, want empty (should not advance)", tb.stepResults[1])
+		}
+		if tb.currentStep != 1 {
+			t.Errorf("currentStep = %d, want 1", tb.currentStep)
+		}
+	})
+
+	t.Run("stops at non-matching wait_for", func(t *testing.T) {
+		tc := &TestBenchCase{
+			Steps: []TestBenchStep{
+				{Command: "E{approach}"},     // fire-and-forget
+				{WaitFor: "go_around"},
+			},
+		}
+		tb := newTestBench(tc)
+		tb.stepResults[0] = "pass"
+		tb.currentStep = 1
+
+		tb.speculativeAdvance(tc, readbackEvent("AAL123", "expect ILS 28R"))
+
+		if tb.stepResults[1] != "" {
+			t.Errorf("step 1 result = %q, want empty", tb.stepResults[1])
+		}
+		if tb.currentStep != 1 {
+			t.Errorf("currentStep = %d, want 1", tb.currentStep)
+		}
+	})
+
+	t.Run("does not advance step 0", func(t *testing.T) {
+		tc := &TestBenchCase{
+			Steps: []TestBenchStep{
+				{Command: "S210", ExpectReadback: StringOrArray{"210 knots"}},
+			},
+		}
+		tb := newTestBench(tc)
+		// Step 0 hasn't been evaluated by processEvents yet.
+		tb.speculativeAdvance(tc, readbackEvent("AAL123", "210 knots"))
+
+		if tb.stepResults[0] != "" {
+			t.Errorf("step 0 result = %q, want empty", tb.stepResults[0])
+		}
+		if tb.currentStep != 0 {
+			t.Errorf("currentStep = %d, want 0", tb.currentStep)
+		}
+	})
+
+	t.Run("chains fire-and-forget then wait_for", func(t *testing.T) {
+		tc := &TestBenchCase{
+			Steps: []TestBenchStep{
+				{Command: "D050", ExpectReadback: StringOrArray{"5,000"}},
+				{Command: "E{approach}"},                                  // fire-and-forget
+				{Command: "D{if}"},                                        // fire-and-forget
+				{WaitFor: "approach_clearance_request"},
+			},
+		}
+		tb := newTestBench(tc)
+		tb.stepResults[0] = "pass"
+		tb.currentStep = 1
+
+		tb.speculativeAdvance(tc, sim.Event{WrittenText: "looking for the approach"})
+
+		// Should chain through both fire-and-forget steps and the wait_for.
+		if tb.currentStep != 4 {
+			t.Errorf("currentStep = %d, want 4", tb.currentStep)
+		}
+		for i := 1; i <= 3; i++ {
+			if tb.stepResults[i] != "pass" {
+				t.Errorf("step %d result = %q, want pass", i, tb.stepResults[i])
+			}
+		}
+	})
+}

--- a/cmd/vice/ui.go
+++ b/cmd/vice/ui.go
@@ -53,6 +53,9 @@ var (
 		showLaunchControl bool
 		showMessages      bool
 		showFlightStrips  bool
+		showTestBench     bool
+
+		testBenchWindow *TestBench
 
 		// STT state
 		pttRecording              bool
@@ -258,6 +261,15 @@ func uiDraw(mgr *client.ConnectionManager, config *Config, p platform.Platform, 
 			imgui.SetTooltip("Display online vice documentation")
 		}
 
+		if *devMode && controlClient != nil && controlClient.Connected() {
+			if imgui.Button(renderer.FontAwesomeIconWrench) {
+				ui.showTestBench = !ui.showTestBench
+			}
+			if imgui.IsItemHovered() {
+				imgui.SetTooltip("Test bench")
+			}
+		}
+
 		// Handle PTT key for STT recording
 		uiHandlePTTKey(p, controlClient, config, lg)
 
@@ -323,6 +335,13 @@ func uiDraw(mgr *client.ConnectionManager, config *Config, p platform.Platform, 
 			ui.launchControlWindow.Draw(eventStream, p)
 		}
 
+		if ui.showTestBench {
+			if ui.testBenchWindow == nil {
+				ui.testBenchWindow = NewTestBench(controlClient, eventStream, lg)
+			}
+			ui.testBenchWindow.Draw(&ui.showTestBench, p)
+		}
+
 		if ui.showMessages {
 			config.MessagesPane.DrawWindow(&ui.showMessages, controlClient, p, lg)
 		}
@@ -365,6 +384,7 @@ func uiDraw(mgr *client.ConnectionManager, config *Config, p platform.Platform, 
 
 func uiResetControlClient(c *client.ControlClient, p platform.Platform, lg *log.Logger) {
 	ui.launchControlWindow = nil
+	ui.testBenchWindow = nil
 	clear(acknowledgedATIS)
 }
 

--- a/cmd/vice/ui.go
+++ b/cmd/vice/ui.go
@@ -261,7 +261,7 @@ func uiDraw(mgr *client.ConnectionManager, config *Config, p platform.Platform, 
 			imgui.SetTooltip("Display online vice documentation")
 		}
 
-		if *devMode && controlClient != nil && controlClient.Connected() {
+		if (*devMode || config.DevMode) && controlClient != nil && controlClient.Connected() {
 			if imgui.Button(renderer.FontAwesomeIconWrench) {
 				ui.showTestBench = !ui.showTestBench
 			}
@@ -793,6 +793,8 @@ func uiDrawSettingsWindow(c *client.ControlClient, config *Config, activeRadarPa
 	if c != nil {
 		imgui.Checkbox("Disable text-to-speech", &config.DisableTextToSpeech)
 	}
+
+	imgui.Checkbox("Developer mode", &config.DevMode)
 
 	imgui.Separator()
 

--- a/cmd/vice/ui.go
+++ b/cmd/vice/ui.go
@@ -338,8 +338,14 @@ func uiDraw(mgr *client.ConnectionManager, config *Config, p platform.Platform, 
 		if ui.showTestBench {
 			if ui.testBenchWindow == nil {
 				ui.testBenchWindow = NewTestBench(controlClient, eventStream, lg)
+			} else {
+				ui.testBenchWindow.Resume()
 			}
 			ui.testBenchWindow.Draw(&ui.showTestBench, p)
+		} else if ui.testBenchWindow != nil {
+			// Release the event stream subscription when the window is
+			// hidden so it doesn't pin the EventStream offset.
+			ui.testBenchWindow.Pause()
 		}
 
 		if ui.showMessages {
@@ -384,7 +390,10 @@ func uiDraw(mgr *client.ConnectionManager, config *Config, p platform.Platform, 
 
 func uiResetControlClient(c *client.ControlClient, p platform.Platform, lg *log.Logger) {
 	ui.launchControlWindow = nil
-	ui.testBenchWindow = nil
+	if ui.testBenchWindow != nil {
+		ui.testBenchWindow.Close()
+		ui.testBenchWindow = nil
+	}
 	clear(acknowledgedATIS)
 }
 

--- a/renderer/font.go
+++ b/renderer/font.go
@@ -227,6 +227,7 @@ var (
 	FontAwesomeIconSun                 = faUsedIcons["Sun"]
 	FontAwesomeIconTrash               = faUsedIcons["Trash"]
 	FontAwesomeIconWind                = faUsedIcons["Wind"]
+	FontAwesomeIconWrench              = faUsedIcons["Wrench"]
 )
 
 var (
@@ -280,6 +281,7 @@ var (
 		"Sun":                 FontAwesomeString("Sun"),
 		"Trash":               FontAwesomeString("Trash"),
 		"Wind":                FontAwesomeString("Wind"),
+		"Wrench":              FontAwesomeString("Wrench"),
 	}
 	faBrandsUsedIcons map[string]string = map[string]string{
 		"Discord": FontAwesomeBrandsString("Discord"),

--- a/resources/test_bench_scenarios.json
+++ b/resources/test_bench_scenarios.json
@@ -85,6 +85,16 @@
       "steps": [
         {"command": "SPRES", "expect_readback": ["maintain present speed", "present speed", "maintaining"]}
       ]
+    },
+    {
+      "label": "Speed until fix",
+      "aircraft": [
+        {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000}
+      ],
+      "steps": [
+        {"command": "E{approach}", "expect_readback": "{approach_name}"},
+        {"command": "S180/U{faf}", "expect_readback": "until"}
+      ]
     }
   ],
   "Altitude + Speed Sequencing": [
@@ -145,18 +155,19 @@
     {
       "label": "Intercept localizer",
       "aircraft": [
-        {"distance_nm": 12, "relative_to": "{if}", "speed": 210, "altitude": 3000,
-         "bearing_offset": 30, "heading_offset": -30}
+        {"distance_nm": 5, "relative_to": "{faf}", "speed": 210, "altitude": 3000,
+         "bearing_offset": 40, "heading_offset": 30}
       ],
       "steps": [
         {"command": "E{approach}", "expect_readback": "{approach_name}"},
+        {"command": "H{hdg0}", "expect_readback": "{hdg0}"},
         {"command": "I", "expect_readback": "intercepting"}
       ]
     },
     {
       "label": "At fix, intercept localizer",
       "aircraft": [
-        {"distance_nm": 15, "relative_to": "{if}", "speed": 210, "altitude": 4000}
+        {"distance_nm": 8, "relative_to": "{if}", "speed": 210, "altitude": 4000}
       ],
       "steps": [
         {"command": "E{approach}", "expect_readback": "{approach_name}"},
@@ -167,7 +178,7 @@
     {
       "label": "At fix, cleared approach",
       "aircraft": [
-        {"distance_nm": 15, "relative_to": "{if}", "speed": 210, "altitude": 4000}
+        {"distance_nm": 8, "relative_to": "{if}", "speed": 210, "altitude": 4000}
       ],
       "steps": [
         {"command": "E{approach}", "expect_readback": "{approach_name}"},
@@ -185,18 +196,6 @@
       ],
       "steps": [
         {"command": "DVS", "expect_readback": "descend via the STAR"}
-      ]
-    }
-  ],
-  "Speed Until": [
-    {
-      "label": "Speed until fix",
-      "aircraft": [
-        {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000}
-      ],
-      "steps": [
-        {"command": "E{approach}", "expect_readback": "{approach_name}"},
-        {"command": "S180/U{faf}", "expect_readback": "until"}
       ]
     }
   ],
@@ -245,22 +244,42 @@
   ],
   "Traffic + Visual Separation": [
     {
-      "label": "Traffic advisory",
+      "label": "Traffic advisory, in sight",
       "aircraft": [
-        {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000}
+        {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000,
+         "traffic_in_sight": true},
+        {"distance_nm": 12, "relative_to": "{if}", "speed": 210, "altitude": 7000,
+         "bearing_offset": 10, "note": "traffic target"}
       ],
       "steps": [
-        {"command": "TRAFFIC/12/3/70", "expect_readback": ["looking", "traffic in sight", "we have the traffic", "in the clouds", "IMC"]}
+        {"callsign": "{0}", "command": "TRAFFIC/12/3/70"},
+        {"wait_for": "traffic_in_sight"}
       ]
     },
     {
-      "label": "Visual separation (traffic already in sight)",
+      "label": "Traffic advisory, negative contact",
       "aircraft": [
-        {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000,
-         "traffic_in_sight": true}
+        {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000},
+        {"distance_nm": 7, "relative_to": "{if}", "speed": 210, "altitude": 5000,
+         "bearing_offset": 30, "note": "traffic target"}
       ],
       "steps": [
-        {"command": "VISSEP", "expect_readback": ["visual separation", "maintain visual"]}
+        {"callsign": "{0}", "command": "TRAFFIC/2/8/50"},
+        {"wait_for": "traffic_response"}
+      ]
+    },
+    {
+      "label": "Traffic in sight, visual separation",
+      "aircraft": [
+        {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000,
+         "traffic_in_sight": true},
+        {"distance_nm": 12, "relative_to": "{if}", "speed": 210, "altitude": 7000,
+         "bearing_offset": 10, "note": "traffic target"}
+      ],
+      "steps": [
+        {"callsign": "{0}", "command": "TRAFFIC/12/3/70"},
+        {"wait_for": "traffic_in_sight"},
+        {"callsign": "{0}", "command": "VISSEP", "expect_readback": ["visual separation", "maintain visual"]}
       ]
     }
   ],

--- a/resources/test_bench_scenarios.json
+++ b/resources/test_bench_scenarios.json
@@ -46,7 +46,6 @@
         {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000}
       ],
       "steps": [
-        {"command": "E{approach}", "expect_readback": "{approach_name}"},
         {"command": "S210", "expect_readback": "210 knots"}
       ]
     },
@@ -56,7 +55,6 @@
         {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000}
       ],
       "steps": [
-        {"command": "E{approach}", "expect_readback": "{approach_name}"},
         {"command": "S210", "expect_readback": "210 knots"},
         {"command": "S", "expect_readback": "cancel speed"}
       ]
@@ -67,7 +65,6 @@
         {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000}
       ],
       "steps": [
-        {"command": "E{approach}", "expect_readback": "{approach_name}"},
         {"command": "SMIN", "expect_readback": ["slowest practical speed", "slowing as much as we can"]}
       ]
     },
@@ -77,7 +74,6 @@
         {"distance_nm": 15, "relative_to": "{if}", "speed": 210, "altitude": 7000}
       ],
       "steps": [
-        {"command": "E{approach}", "expect_readback": "{approach_name}"},
         {"command": "SMAX", "expect_readback": ["maximum forward speed", "maintaining maximum forward speed"]}
       ]
     },
@@ -87,7 +83,6 @@
         {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000}
       ],
       "steps": [
-        {"command": "E{approach}", "expect_readback": "{approach_name}"},
         {"command": "SPRES", "expect_readback": ["maintain present speed", "present speed", "maintaining"]}
       ]
     }
@@ -99,7 +94,6 @@
         {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000}
       ],
       "steps": [
-        {"command": "E{approach}", "expect_readback": "{approach_name}"},
         {"command": "D050", "expect_readback": "5,000"},
         {"command": "TS170", "expect_readback": "170 knots"}
       ]
@@ -110,7 +104,6 @@
         {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000}
       ],
       "steps": [
-        {"command": "E{approach}", "expect_readback": "{approach_name}"},
         {"command": "S210", "expect_readback": "210 knots"},
         {"command": "TD050", "expect_readback": "5,000"}
       ]
@@ -180,6 +173,94 @@
         {"command": "E{approach}", "expect_readback": "{approach_name}"},
         {"command": "D{if}", "expect_readback": "direct {if}"},
         {"command": "A{if}/C{approach}", "expect_readback": "cleared"}
+      ]
+    }
+  ],
+  "Descend via STAR": [
+    {
+      "label": "Descend via the STAR",
+      "aircraft": [
+        {"distance_nm": 3, "relative_to": "{star_fix}", "speed": 250, "altitude": 11000,
+         "star_waypoints": true}
+      ],
+      "steps": [
+        {"command": "DVS", "expect_readback": "descend via the STAR"}
+      ]
+    }
+  ],
+  "Speed Until": [
+    {
+      "label": "Speed until fix",
+      "aircraft": [
+        {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000}
+      ],
+      "steps": [
+        {"command": "E{approach}", "expect_readback": "{approach_name}"},
+        {"command": "S180/U{faf}", "expect_readback": "until"}
+      ]
+    }
+  ],
+  "Expedite Altitude": [
+    {
+      "label": "Expedite descent",
+      "aircraft": [
+        {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000}
+      ],
+      "steps": [
+        {"command": "D050", "expect_readback": "5,000"},
+        {"command": "ED", "expect_readback": ["expediting down to", "expedite"]}
+      ]
+    },
+    {
+      "label": "Expedite climb (departure)",
+      "departure": true,
+      "steps": [
+        {"wait_for": "check_in"},
+        {"command": "A110", "expect_readback": "11,000"},
+        {"command": "EC", "expect_readback": ["expediting up to", "expedite"]}
+      ]
+    }
+  ],
+  "Hold": [
+    {
+      "label": "Hold at fix (published)",
+      "aircraft": [
+        {"distance_nm": 15, "relative_to": "{hold_fix}", "speed": 210, "altitude": 5000}
+      ],
+      "steps": [
+        {"command": "D{hold_fix}", "expect_readback": "direct {hold_fix}"},
+        {"command": "H{hold_fix}", "expect_readback": "hold"}
+      ]
+    },
+    {
+      "label": "Hold at fix, left turns",
+      "aircraft": [
+        {"distance_nm": 15, "relative_to": "{hold_fix}", "speed": 210, "altitude": 5000}
+      ],
+      "steps": [
+        {"command": "D{hold_fix}", "expect_readback": "direct {hold_fix}"},
+        {"command": "H{hold_fix}/L", "expect_readback": "hold"}
+      ]
+    }
+  ],
+  "Traffic + Visual Separation": [
+    {
+      "label": "Traffic advisory",
+      "aircraft": [
+        {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000}
+      ],
+      "steps": [
+        {"command": "TRAFFIC/12/3/70", "expect_readback": ["looking", "traffic in sight", "we have the traffic", "in the clouds", "IMC"]}
+      ]
+    },
+    {
+      "label": "Visual separation (traffic already in sight)",
+      "aircraft": [
+        {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000,
+         "traffic_in_sight": true}
+      ],
+      "steps": [
+        {"command": "VISSEP", "expect_readback": ["visual separation", "maintain visual"]}
       ]
     }
   ],

--- a/resources/test_bench_scenarios.json
+++ b/resources/test_bench_scenarios.json
@@ -3,37 +3,37 @@
     {
       "label": "Direct to IF, clear before FAF",
       "aircraft": [
-        {"callsign": "TEST1", "distance_nm": 8, "relative_to": "{if}", "speed": 210}
+        {"distance_nm": 8, "relative_to": "{if}", "speed": 210}
       ],
       "steps": [
-        {"command": "E{approach}", "callsign": "TEST1", "expect_readback": "{approach_name}"},
-        {"command": "D{if}", "callsign": "TEST1", "expect_readback": "direct {if}"},
+        {"command": "E{approach}", "expect_readback": "{approach_name}"},
+        {"command": "D{if}", "expect_readback": "direct {if}"},
         {"wait_for": "approach_clearance_request"},
-        {"command": "C", "callsign": "TEST1", "expect_readback": "cleared"}
+        {"command": "C", "expect_readback": "cleared"}
       ]
     },
     {
       "label": "Direct to IF, standby then clear",
       "aircraft": [
-        {"callsign": "TEST1", "distance_nm": 8, "relative_to": "{if}", "speed": 210}
+        {"distance_nm": 8, "relative_to": "{if}", "speed": 210}
       ],
       "steps": [
-        {"command": "E{approach}", "callsign": "TEST1", "expect_readback": "{approach_name}"},
-        {"command": "D{if}", "callsign": "TEST1", "expect_readback": "direct {if}"},
+        {"command": "E{approach}", "expect_readback": "{approach_name}"},
+        {"command": "D{if}", "expect_readback": "direct {if}"},
         {"wait_for": "approach_clearance_request"},
-        {"command": "E", "callsign": "TEST1", "expect_readback": "{approach_name}"},
-        {"command": "C", "callsign": "TEST1", "expect_readback": "cleared"}
+        {"command": "E", "expect_readback": "{approach_name}"},
+        {"command": "C", "expect_readback": "cleared"}
       ]
     },
     {
       "label": "Direct to IF, no clearance (go-around)",
       "aircraft": [
-        {"callsign": "TEST1", "distance_nm": 8, "relative_to": "{if}", "speed": 210,
+        {"distance_nm": 8, "relative_to": "{if}", "speed": 210,
          "note": "do NOT clear - expect go-around at FAF"}
       ],
       "steps": [
-        {"command": "E{approach}", "callsign": "TEST1", "expect_readback": "{approach_name}"},
-        {"command": "D{if}", "callsign": "TEST1", "expect_readback": "direct {if}"},
+        {"command": "E{approach}", "expect_readback": "{approach_name}"},
+        {"command": "D{if}", "expect_readback": "direct {if}"},
         {"wait_for": "approach_clearance_request"},
         {"wait_for": "go_around"}
       ]

--- a/resources/test_bench_scenarios.json
+++ b/resources/test_bench_scenarios.json
@@ -1,0 +1,68 @@
+{
+  "Approach Clearance Requests": [
+    {
+      "label": "Direct to IF, clear before FAF",
+      "aircraft": [
+        {"callsign": "TEST1", "distance_nm": 8, "relative_to": "{if}", "speed": 210}
+      ],
+      "steps": [
+        {"command": "E{approach}", "callsign": "TEST1", "expect_readback": "{approach_name}"},
+        {"command": "D{if}", "callsign": "TEST1", "expect_readback": "direct {if}"},
+        {"wait_for": "approach_clearance_request"},
+        {"command": "C", "callsign": "TEST1", "expect_readback": "cleared"}
+      ]
+    },
+    {
+      "label": "Direct to IF, standby then clear",
+      "aircraft": [
+        {"callsign": "TEST1", "distance_nm": 8, "relative_to": "{if}", "speed": 210}
+      ],
+      "steps": [
+        {"command": "E{approach}", "callsign": "TEST1", "expect_readback": "{approach_name}"},
+        {"command": "D{if}", "callsign": "TEST1", "expect_readback": "direct {if}"},
+        {"wait_for": "approach_clearance_request"},
+        {"command": "E", "callsign": "TEST1", "expect_readback": "{approach_name}"},
+        {"command": "C", "callsign": "TEST1", "expect_readback": "cleared"}
+      ]
+    },
+    {
+      "label": "Direct to IF, no clearance (go-around)",
+      "aircraft": [
+        {"callsign": "TEST1", "distance_nm": 8, "relative_to": "{if}", "speed": 210,
+         "note": "do NOT clear - expect go-around at FAF"}
+      ],
+      "steps": [
+        {"command": "E{approach}", "callsign": "TEST1", "expect_readback": "{approach_name}"},
+        {"command": "D{if}", "callsign": "TEST1", "expect_readback": "direct {if}"},
+        {"wait_for": "approach_clearance_request"},
+        {"wait_for": "go_around"}
+      ]
+    }
+  ],
+  "Departure Basics": [
+    {
+      "label": "Heading assignment",
+      "departure": true,
+      "steps": [
+        {"wait_for": "check_in"},
+        {"command": "H090", "expect_readback": "090"}
+      ]
+    },
+    {
+      "label": "Altitude assignment",
+      "departure": true,
+      "steps": [
+        {"wait_for": "check_in"},
+        {"command": "A110", "expect_readback": "11,000"}
+      ]
+    },
+    {
+      "label": "Climb via SID",
+      "departure": true,
+      "steps": [
+        {"wait_for": "check_in"},
+        {"command": "CVS", "expect_readback": "climb via"}
+      ]
+    }
+  ]
+}

--- a/resources/test_bench_scenarios.json
+++ b/resources/test_bench_scenarios.json
@@ -39,6 +39,150 @@
       ]
     }
   ],
+  "Speed Assignments": [
+    {
+      "label": "Reduce speed",
+      "aircraft": [
+        {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000}
+      ],
+      "steps": [
+        {"command": "E{approach}", "expect_readback": "{approach_name}"},
+        {"command": "S210", "expect_readback": "210 knots"}
+      ]
+    },
+    {
+      "label": "Cancel speed restrictions",
+      "aircraft": [
+        {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000}
+      ],
+      "steps": [
+        {"command": "E{approach}", "expect_readback": "{approach_name}"},
+        {"command": "S210", "expect_readback": "210 knots"},
+        {"command": "S", "expect_readback": "cancel speed"}
+      ]
+    },
+    {
+      "label": "Slowest practical speed",
+      "aircraft": [
+        {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000}
+      ],
+      "steps": [
+        {"command": "E{approach}", "expect_readback": "{approach_name}"},
+        {"command": "SMIN", "expect_readback": ["slowest practical speed", "slowing as much as we can"]}
+      ]
+    },
+    {
+      "label": "Maximum forward speed",
+      "aircraft": [
+        {"distance_nm": 15, "relative_to": "{if}", "speed": 210, "altitude": 7000}
+      ],
+      "steps": [
+        {"command": "E{approach}", "expect_readback": "{approach_name}"},
+        {"command": "SMAX", "expect_readback": ["maximum forward speed", "maintaining maximum forward speed"]}
+      ]
+    },
+    {
+      "label": "Maintain present speed",
+      "aircraft": [
+        {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000}
+      ],
+      "steps": [
+        {"command": "E{approach}", "expect_readback": "{approach_name}"},
+        {"command": "SPRES", "expect_readback": ["maintain present speed", "present speed", "maintaining"]}
+      ]
+    }
+  ],
+  "Altitude + Speed Sequencing": [
+    {
+      "label": "Descend, then reduce speed",
+      "aircraft": [
+        {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000}
+      ],
+      "steps": [
+        {"command": "E{approach}", "expect_readback": "{approach_name}"},
+        {"command": "D050", "expect_readback": "5,000"},
+        {"command": "TS170", "expect_readback": "170 knots"}
+      ]
+    },
+    {
+      "label": "Reduce speed, then descend",
+      "aircraft": [
+        {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000}
+      ],
+      "steps": [
+        {"command": "E{approach}", "expect_readback": "{approach_name}"},
+        {"command": "S210", "expect_readback": "210 knots"},
+        {"command": "TD050", "expect_readback": "5,000"}
+      ]
+    }
+  ],
+  "Crossing Restrictions": [
+    {
+      "label": "Cross fix at altitude",
+      "aircraft": [
+        {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000}
+      ],
+      "steps": [
+        {"command": "E{approach}", "expect_readback": "{approach_name}"},
+        {"command": "C{faf}/A030", "expect_readback": "cross"}
+      ]
+    },
+    {
+      "label": "Cross fix at speed",
+      "aircraft": [
+        {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000}
+      ],
+      "steps": [
+        {"command": "E{approach}", "expect_readback": "{approach_name}"},
+        {"command": "C{faf}/S180", "expect_readback": "cross"}
+      ]
+    },
+    {
+      "label": "Cross fix at altitude and speed",
+      "aircraft": [
+        {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000}
+      ],
+      "steps": [
+        {"command": "E{approach}", "expect_readback": "{approach_name}"},
+        {"command": "C{faf}/A030/S180", "expect_readback": "cross"}
+      ]
+    }
+  ],
+  "Vectoring to Intercept": [
+    {
+      "label": "Intercept localizer",
+      "aircraft": [
+        {"distance_nm": 12, "relative_to": "{if}", "speed": 210, "altitude": 3000,
+         "bearing_offset": 30, "heading_offset": -30}
+      ],
+      "steps": [
+        {"command": "E{approach}", "expect_readback": "{approach_name}"},
+        {"command": "I", "expect_readback": "intercepting"}
+      ]
+    },
+    {
+      "label": "At fix, intercept localizer",
+      "aircraft": [
+        {"distance_nm": 15, "relative_to": "{if}", "speed": 210, "altitude": 4000}
+      ],
+      "steps": [
+        {"command": "E{approach}", "expect_readback": "{approach_name}"},
+        {"command": "D{if}", "expect_readback": "direct {if}"},
+        {"command": "A{if}/I", "expect_readback": ["{if}", "intercept", "join"]}
+      ]
+    },
+    {
+      "label": "At fix, cleared approach",
+      "aircraft": [
+        {"distance_nm": 15, "relative_to": "{if}", "speed": 210, "altitude": 4000}
+      ],
+      "steps": [
+        {"command": "E{approach}", "expect_readback": "{approach_name}"},
+        {"command": "D{if}", "expect_readback": "direct {if}"},
+        {"command": "A{if}/C{approach}", "expect_readback": "cleared"}
+      ]
+    }
+  ],
   "Departure Basics": [
     {
       "label": "Heading assignment",

--- a/resources/test_bench_scenarios.json
+++ b/resources/test_bench_scenarios.json
@@ -248,11 +248,11 @@
       "aircraft": [
         {"distance_nm": 15, "speed": 250, "altitude": "{altCeiling}",
          "traffic_in_sight": true},
-        {"distance_nm": 12, "speed": 250, "altitude": "{altCeiling}",
-         "note": "traffic target"}
+        {"distance_nm": 14, "speed": 250, "altitude": "{altCeiling}",
+         "altitude_offset": 500, "note": "traffic target"}
       ],
       "steps": [
-        {"callsign": "{0}", "command": "TRAFFIC/12/3/{alt1}"},
+        {"callsign": "{0}", "command": "TRAFFIC/12/1/{alt1}"},
         {"wait_for": "traffic_in_sight"}
       ]
     },
@@ -273,11 +273,11 @@
       "aircraft": [
         {"distance_nm": 15, "speed": 250, "altitude": "{altCeiling}",
          "traffic_in_sight": true},
-        {"distance_nm": 12, "speed": 250, "altitude": "{altCeiling}",
-         "note": "traffic target"}
+        {"distance_nm": 14, "speed": 250, "altitude": "{altCeiling}",
+         "altitude_offset": 500, "note": "traffic target"}
       ],
       "steps": [
-        {"callsign": "{0}", "command": "TRAFFIC/12/3/{alt1}"},
+        {"callsign": "{0}", "command": "TRAFFIC/12/1/{alt1}"},
         {"wait_for": "traffic_in_sight"},
         {"callsign": "{0}", "command": "VISSEP", "expect_readback": ["visual separation", "maintain visual"]}
       ]

--- a/resources/test_bench_scenarios.json
+++ b/resources/test_bench_scenarios.json
@@ -246,10 +246,10 @@
     {
       "label": "Traffic advisory, in sight",
       "aircraft": [
-        {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000,
+        {"distance_nm": 15, "speed": 250, "altitude": "{altCeiling}",
          "traffic_in_sight": true},
-        {"distance_nm": 12, "relative_to": "{if}", "speed": 250, "altitude": 7000,
-         "bearing_offset": 10, "note": "traffic target"}
+        {"distance_nm": 12, "speed": 250, "altitude": "{altCeiling}",
+         "note": "traffic target"}
       ],
       "steps": [
         {"callsign": "{0}", "command": "TRAFFIC/12/3/{alt1}"},
@@ -259,22 +259,22 @@
     {
       "label": "Traffic advisory, negative contact",
       "aircraft": [
-        {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000},
-        {"distance_nm": 7, "relative_to": "{if}", "speed": 250, "altitude": 5000,
-         "bearing_offset": 30, "note": "traffic target"}
+        {"distance_nm": 15, "speed": 250, "altitude": "{altCeiling}"},
+        {"distance_nm": 18, "speed": 250, "altitude": "{altCeiling}",
+         "note": "traffic target"}
       ],
       "steps": [
-        {"callsign": "{0}", "command": "TRAFFIC/2/8/{alt1}"},
+        {"callsign": "{0}", "command": "TRAFFIC/12/3/{alt1}"},
         {"wait_for": "traffic_response"}
       ]
     },
     {
       "label": "Traffic in sight, visual separation",
       "aircraft": [
-        {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000,
+        {"distance_nm": 15, "speed": 250, "altitude": "{altCeiling}",
          "traffic_in_sight": true},
-        {"distance_nm": 12, "relative_to": "{if}", "speed": 250, "altitude": 7000,
-         "bearing_offset": 10, "note": "traffic target"}
+        {"distance_nm": 12, "speed": 250, "altitude": "{altCeiling}",
+         "note": "traffic target"}
       ],
       "steps": [
         {"callsign": "{0}", "command": "TRAFFIC/12/3/{alt1}"},

--- a/resources/test_bench_scenarios.json
+++ b/resources/test_bench_scenarios.json
@@ -43,7 +43,7 @@
     {
       "label": "Reduce speed",
       "aircraft": [
-        {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000}
+        {"distance_nm": 15, "speed": 250, "altitude": 7000}
       ],
       "steps": [
         {"command": "S210", "expect_readback": "210 knots"}
@@ -52,7 +52,7 @@
     {
       "label": "Cancel speed restrictions",
       "aircraft": [
-        {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000}
+        {"distance_nm": 15, "speed": 250, "altitude": 7000}
       ],
       "steps": [
         {"command": "S210", "expect_readback": "210 knots"},
@@ -62,7 +62,7 @@
     {
       "label": "Slowest practical speed",
       "aircraft": [
-        {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000}
+        {"distance_nm": 15, "speed": 250, "altitude": 7000}
       ],
       "steps": [
         {"command": "SMIN", "expect_readback": ["slowest practical speed", "slowing as much as we can"]}
@@ -71,7 +71,7 @@
     {
       "label": "Maximum forward speed",
       "aircraft": [
-        {"distance_nm": 15, "relative_to": "{if}", "speed": 210, "altitude": 7000}
+        {"distance_nm": 15, "speed": 210, "altitude": 7000}
       ],
       "steps": [
         {"command": "SMAX", "expect_readback": ["maximum forward speed", "maintaining maximum forward speed"]}
@@ -80,7 +80,7 @@
     {
       "label": "Maintain present speed",
       "aircraft": [
-        {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000}
+        {"distance_nm": 15, "speed": 250, "altitude": 7000}
       ],
       "steps": [
         {"command": "SPRES", "expect_readback": ["maintain present speed", "present speed", "maintaining"]}
@@ -89,7 +89,7 @@
     {
       "label": "Speed until fix",
       "aircraft": [
-        {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000}
+        {"distance_nm": 15, "speed": 250, "altitude": 7000}
       ],
       "steps": [
         {"command": "E{approach}", "expect_readback": "{approach_name}"},
@@ -101,7 +101,7 @@
     {
       "label": "Descend, then reduce speed",
       "aircraft": [
-        {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000}
+        {"distance_nm": 15, "speed": 250, "altitude": 7000}
       ],
       "steps": [
         {"command": "D050", "expect_readback": "5,000"},
@@ -111,7 +111,7 @@
     {
       "label": "Reduce speed, then descend",
       "aircraft": [
-        {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000}
+        {"distance_nm": 15, "speed": 250, "altitude": 7000}
       ],
       "steps": [
         {"command": "S210", "expect_readback": "210 knots"},
@@ -123,7 +123,7 @@
     {
       "label": "Cross fix at altitude",
       "aircraft": [
-        {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000}
+        {"distance_nm": 15, "speed": 250, "altitude": 7000}
       ],
       "steps": [
         {"command": "E{approach}", "expect_readback": "{approach_name}"},
@@ -133,7 +133,7 @@
     {
       "label": "Cross fix at speed",
       "aircraft": [
-        {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000}
+        {"distance_nm": 15, "speed": 250, "altitude": 7000}
       ],
       "steps": [
         {"command": "E{approach}", "expect_readback": "{approach_name}"},
@@ -143,7 +143,7 @@
     {
       "label": "Cross fix at altitude and speed",
       "aircraft": [
-        {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000}
+        {"distance_nm": 15, "speed": 250, "altitude": 7000}
       ],
       "steps": [
         {"command": "E{approach}", "expect_readback": "{approach_name}"},
@@ -203,7 +203,7 @@
     {
       "label": "Expedite descent",
       "aircraft": [
-        {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000}
+        {"distance_nm": 15, "speed": 250, "altitude": 7000}
       ],
       "steps": [
         {"command": "D050", "expect_readback": "5,000"},
@@ -248,11 +248,11 @@
       "aircraft": [
         {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000,
          "traffic_in_sight": true},
-        {"distance_nm": 12, "relative_to": "{if}", "speed": 210, "altitude": 7000,
+        {"distance_nm": 12, "relative_to": "{if}", "speed": 250, "altitude": 7000,
          "bearing_offset": 10, "note": "traffic target"}
       ],
       "steps": [
-        {"callsign": "{0}", "command": "TRAFFIC/12/3/70"},
+        {"callsign": "{0}", "command": "TRAFFIC/12/3/{alt1}"},
         {"wait_for": "traffic_in_sight"}
       ]
     },
@@ -260,11 +260,11 @@
       "label": "Traffic advisory, negative contact",
       "aircraft": [
         {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000},
-        {"distance_nm": 7, "relative_to": "{if}", "speed": 210, "altitude": 5000,
+        {"distance_nm": 7, "relative_to": "{if}", "speed": 250, "altitude": 5000,
          "bearing_offset": 30, "note": "traffic target"}
       ],
       "steps": [
-        {"callsign": "{0}", "command": "TRAFFIC/2/8/50"},
+        {"callsign": "{0}", "command": "TRAFFIC/2/8/{alt1}"},
         {"wait_for": "traffic_response"}
       ]
     },
@@ -273,11 +273,11 @@
       "aircraft": [
         {"distance_nm": 15, "relative_to": "{if}", "speed": 250, "altitude": 7000,
          "traffic_in_sight": true},
-        {"distance_nm": 12, "relative_to": "{if}", "speed": 210, "altitude": 7000,
+        {"distance_nm": 12, "relative_to": "{if}", "speed": 250, "altitude": 7000,
          "bearing_offset": 10, "note": "traffic target"}
       ],
       "steps": [
-        {"callsign": "{0}", "command": "TRAFFIC/12/3/70"},
+        {"callsign": "{0}", "command": "TRAFFIC/12/3/{alt1}"},
         {"wait_for": "traffic_in_sight"},
         {"callsign": "{0}", "command": "VISSEP", "expect_readback": ["visual separation", "maintain visual"]}
       ]

--- a/sim/control.go
+++ b/sim/control.go
@@ -218,8 +218,14 @@ func (s *Sim) DeleteAircraftSlice(tcw TCW, aircraft []Aircraft) error {
 	s.mu.Lock(s.lg)
 	defer s.mu.Unlock(s.lg)
 
+	if lctrl := s.State.LaunchConfig.Controller; lctrl != "" && lctrl != tcw {
+		return av.ErrOtherControllerHasTrack
+	}
+
 	for _, ac := range aircraft {
-		s.deleteAircraft(&ac)
+		if serverAc, ok := s.Aircraft[ac.ADSBCallsign]; ok {
+			s.deleteAircraft(serverAc)
+		}
 	}
 
 	return nil

--- a/sim/spawn.go
+++ b/sim/spawn.go
@@ -393,6 +393,20 @@ func (s *Sim) addAircraftNoLock(ac Aircraft) {
 		}
 	}
 
+	// Assign a squawk code and list index if the aircraft has a NAS flight
+	// plan but no squawk (e.g. test bench spawned aircraft). The flight
+	// plan stays on the aircraft (associated); it is NOT added to
+	// STARSComputer.FlightPlans which holds unassociated plans.
+	if ac.NASFlightPlan != nil && ac.Squawk == av.Squawk(0) {
+		if sq, err := s.ERAMComputer.CreateSquawk(); err == nil {
+			ac.Squawk = sq
+			ac.NASFlightPlan.AssignedSquawk = sq
+		}
+		if ac.NASFlightPlan.ListIndex == UnsetSTARSListIndex {
+			ac.NASFlightPlan.ListIndex = s.STARSComputer.getListIndex()
+		}
+	}
+
 	s.Aircraft[ac.ADSBCallsign] = &ac
 
 	ac.Nav.Prespawn = s.prespawn && (ac.FlightPlan.Rules == av.FlightRulesVFR || s.prespawnUncontrolledOnly)

--- a/sim/spawn_test.go
+++ b/sim/spawn_test.go
@@ -42,7 +42,7 @@ func makeTestBenchAircraft(callsign string) Aircraft {
 			Rand: vrand.Make(),
 		},
 		NASFlightPlan: &NASFlightPlan{
-			ACID:          ACID(callsign),
+			ACID:           ACID(callsign),
 			ArrivalAirport: "KJFK",
 			Rules:          av.FlightRulesIFR,
 			TypeOfFlight:   av.FlightTypeArrival,

--- a/sim/spawn_test.go
+++ b/sim/spawn_test.go
@@ -1,0 +1,171 @@
+package sim
+
+import (
+	"testing"
+
+	av "github.com/mmp/vice/aviation"
+	"github.com/mmp/vice/log"
+	"github.com/mmp/vice/nav"
+	vrand "github.com/mmp/vice/rand"
+)
+
+// makeTestSim creates a minimal Sim with the infrastructure needed for
+// addAircraftNoLock and deleteAircraft (squawk pool, STARS computer, etc.).
+func makeTestSim() *Sim {
+	sc := makeSTARSComputer("test")
+	ec := &ERAMComputer{
+		SquawkCodePool: av.MakeEnrouteSquawkCodePool(nil),
+	}
+	lg := log.New(false, "debug", "")
+	return &Sim{
+		Aircraft:          make(map[av.ADSBCallsign]*Aircraft),
+		STARSComputer:     sc,
+		ERAMComputer:      ec,
+		SquawkWarnedACIDs: make(map[ACID]any),
+		State:             &CommonState{},
+		lg:                lg,
+		Rand:              vrand.Make(),
+	}
+}
+
+func makeTestBenchAircraft(callsign string) Aircraft {
+	return Aircraft{
+		ADSBCallsign: av.ADSBCallsign(callsign),
+		TypeOfFlight: av.FlightTypeArrival,
+		Mode:         av.TransponderModeAltitude,
+		FlightPlan: av.FlightPlan{
+			ArrivalAirport: "KJFK",
+			AircraftType:   "B738",
+			Rules:          av.FlightRulesIFR,
+		},
+		Nav: nav.Nav{
+			Rand: vrand.Make(),
+		},
+		NASFlightPlan: &NASFlightPlan{
+			ACID:          ACID(callsign),
+			ArrivalAirport: "KJFK",
+			Rules:          av.FlightRulesIFR,
+			TypeOfFlight:   av.FlightTypeArrival,
+			AircraftCount:  1,
+			AircraftType:   "B738",
+		},
+	}
+}
+
+func TestAddAndDeleteTestBenchAircraft(t *testing.T) {
+	s := makeTestSim()
+	initialAvailable := len(s.STARSComputer.AvailableIndices)
+
+	// Spawn a test bench aircraft (has NASFlightPlan with no squawk).
+	ac := makeTestBenchAircraft("AAL100")
+	s.addAircraftNoLock(ac)
+
+	// Verify squawk and list index were assigned.
+	serverAc := s.Aircraft[av.ADSBCallsign("AAL100")]
+	if serverAc.Squawk == av.Squawk(0) {
+		t.Error("squawk not assigned")
+	}
+	if serverAc.NASFlightPlan.ListIndex == UnsetSTARSListIndex {
+		t.Error("list index not assigned")
+	}
+	if len(s.STARSComputer.AvailableIndices) != initialAvailable-1 {
+		t.Errorf("available indices: got %d, want %d", len(s.STARSComputer.AvailableIndices), initialAvailable-1)
+	}
+	// Flight plan should NOT be in STARSComputer.FlightPlans (it's associated).
+	if len(s.STARSComputer.FlightPlans) != 0 {
+		t.Errorf("unassociated flight plans: got %d, want 0", len(s.STARSComputer.FlightPlans))
+	}
+
+	// Delete the aircraft.
+	s.deleteAircraft(serverAc)
+
+	if len(s.Aircraft) != 0 {
+		t.Errorf("aircraft map not empty after delete")
+	}
+	if len(s.STARSComputer.AvailableIndices) != initialAvailable {
+		t.Errorf("available indices after delete: got %d, want %d", len(s.STARSComputer.AvailableIndices), initialAvailable)
+	}
+}
+
+func TestDeleteAircraftSliceUsesServerCopy(t *testing.T) {
+	s := makeTestSim()
+	initialAvailable := len(s.STARSComputer.AvailableIndices)
+
+	// Spawn a test bench aircraft.
+	ac := makeTestBenchAircraft("AAL200")
+	s.addAircraftNoLock(ac)
+
+	// Simulate what the client has: a stale copy without server-assigned
+	// list index or squawk.
+	clientCopy := makeTestBenchAircraft("AAL200")
+
+	// Delete via the slice path (as the test bench Clear button does).
+	s.DeleteAircraftSlice("", []Aircraft{clientCopy})
+
+	if len(s.Aircraft) != 0 {
+		t.Errorf("aircraft map not empty after DeleteAircraftSlice")
+	}
+	if len(s.STARSComputer.AvailableIndices) != initialAvailable {
+		t.Errorf("available indices after delete: got %d, want %d", len(s.STARSComputer.AvailableIndices), initialAvailable)
+	}
+	if len(s.STARSComputer.FlightPlans) != 0 {
+		t.Errorf("orphaned unassociated flight plans: got %d, want 0", len(s.STARSComputer.FlightPlans))
+	}
+}
+
+func TestSpawnAndClearMultipleTestBenchAircraft(t *testing.T) {
+	s := makeTestSim()
+	initialAvailable := len(s.STARSComputer.AvailableIndices)
+
+	// Spawn 3 aircraft, clear them, spawn 2 more, clear them.
+	callsigns := []string{"AAL301", "AAL302", "AAL303"}
+	var clientCopies []Aircraft
+	for _, cs := range callsigns {
+		ac := makeTestBenchAircraft(cs)
+		clientCopies = append(clientCopies, ac)
+		s.addAircraftNoLock(ac)
+	}
+
+	if len(s.STARSComputer.AvailableIndices) != initialAvailable-3 {
+		t.Errorf("after spawn 3: available indices got %d, want %d",
+			len(s.STARSComputer.AvailableIndices), initialAvailable-3)
+	}
+
+	s.DeleteAircraftSlice("", clientCopies)
+
+	if len(s.Aircraft) != 0 {
+		t.Errorf("aircraft remaining after first clear: %d", len(s.Aircraft))
+	}
+	if len(s.STARSComputer.AvailableIndices) != initialAvailable {
+		t.Errorf("after clear 3: available indices got %d, want %d",
+			len(s.STARSComputer.AvailableIndices), initialAvailable)
+	}
+
+	// Second batch.
+	callsigns2 := []string{"UAL401", "UAL402"}
+	var clientCopies2 []Aircraft
+	for _, cs := range callsigns2 {
+		ac := makeTestBenchAircraft(cs)
+		clientCopies2 = append(clientCopies2, ac)
+		s.addAircraftNoLock(ac)
+	}
+
+	s.DeleteAircraftSlice("", clientCopies2)
+
+	if len(s.STARSComputer.AvailableIndices) != initialAvailable {
+		t.Errorf("after clear all: available indices got %d, want %d",
+			len(s.STARSComputer.AvailableIndices), initialAvailable)
+	}
+	if len(s.STARSComputer.FlightPlans) != 0 {
+		t.Errorf("orphaned unassociated flight plans: %d", len(s.STARSComputer.FlightPlans))
+	}
+
+	// Check for duplicate indices in the available pool.
+	seen := make(map[int]bool)
+	for _, idx := range s.STARSComputer.AvailableIndices {
+		if seen[idx] {
+			t.Errorf("duplicate index %d in AvailableIndices", idx)
+		}
+		seen[idx] = true
+	}
+}

--- a/website/index.html
+++ b/website/index.html
@@ -9026,14 +9026,19 @@ APPLE3.ALL  : RUUTH WNDYL BRAND/a8000 KORRY DEPDY TYKES MINKS JERZY RENUE APPLE 
               <li><strong>Select an approach and departure runway</strong> using the
                 dropdowns at the top of the panel. These determine which
                 runway and approach fixes are used by the test scenarios.</li>
-              <li><strong>Click "Spawn"</strong> next to a test scenario to
-                create the test aircraft on your scope. The aircraft will
-                appear at the position described in the scenario (e.g., 8nm from
-                the intermediate fix at 210 knots).</li>
-              <li><strong>Issue the commands yourself</strong> by typing them
+              <li><strong>Click "Spawn"</strong> (or "Spawn STAR" / "Spawn
+                Departure" for group and departure tests) next to a test
+                scenario to create the test aircraft on your scope. The
+                aircraft will appear at the position described in the scenario
+                (e.g., 8nm from the intermediate fix at 210 knots). Clicking
+                Spawn while aircraft are already active automatically clears
+                the previous test first.</li>
+              <li><strong>Issue the commands</strong> using STT or by typing them
                 into the STARS command line, just as you would during normal
                 controlling. The steps listed in each scenario show you what
-                commands to issue and in what order.</li>
+                commands to issue and in what order. Alternatively, click the
+                <strong>&#9654; (Send)</strong> button next to the active step
+                to auto-execute the command without typing it.</li>
               <li><strong>Observe the results.</strong> The test bench tracks
                 the pilot's readbacks and marks each step with a result:
                 <ul>
@@ -9044,7 +9049,9 @@ APPLE3.ALL  : RUUTH WNDYL BRAND/a8000 KORRY DEPDY TYKES MINKS JERZY RENUE APPLE 
                 Steps with <code>[wait: ...]</code> labels are automatic
                 checkpoints that pass when the pilot transmits a specific
                 message (e.g., checking in, requesting an approach clearance,
-                or reporting the field in sight).
+                or reporting the field in sight). The last pilot readback is
+                shown in yellow below the step list. If the pilot says "say
+                again", the step stays pending so you can re-issue the command.
               </li>
               <li><strong>Click "Clear"</strong> to remove the spawned aircraft
                 when you are done with a test.</li>
@@ -9076,10 +9083,13 @@ APPLE3.ALL  : RUUTH WNDYL BRAND/a8000 KORRY DEPDY TYKES MINKS JERZY RENUE APPLE 
             <table class="table">
               <thead><tr><th>Field</th><th>Description</th></tr></thead>
               <tbody>
+                <tr><td><code>callsign</code></td><td>Pin a specific callsign for this aircraft. If omitted, a callsign is generated automatically.</td></tr>
+                <tr><td><code>aircraft_type</code></td><td>Aircraft type code (e.g., <code>"B738"</code>). If omitted, sampled from the airline or defaults to B738.</td></tr>
                 <tr><td><code>distance_nm</code></td><td>Distance in nautical miles from the reference point.</td></tr>
                 <tr><td><code>speed</code></td><td>Initial airspeed in knots.</td></tr>
-                <tr><td><code>altitude</code></td><td>Altitude in feet. If omitted and <code>relative_to</code> is set, uses the fix's altitude restriction.</td></tr>
-                <tr><td><code>relative_to</code></td><td>Position relative to a fix name or placeholder (e.g., <code>{if}</code>). If omitted, positions relative to the airport.</td></tr>
+                <tr><td><code>altitude</code></td><td>Altitude in feet, or the placeholder string <code>"{altCeiling}"</code> to derive altitude from the METAR ceiling (ceiling minus 500 ft, or 5000 ft if clear). If omitted and <code>relative_to</code> is set, uses the fix's altitude restriction.</td></tr>
+                <tr><td><code>altitude_offset</code></td><td>Feet added after resolving the altitude. Useful for offsetting from <code>{altCeiling}</code> (e.g., <code>500</code> to place traffic 500 ft higher).</td></tr>
+                <tr><td><code>relative_to</code></td><td>Position relative to a fix name or placeholder (<code>{iaf}</code>, <code>{if}</code>, <code>{faf}</code>, <code>{hold_fix}</code>, or <code>{star_fix}</code>). If omitted, positions relative to the airport.</td></tr>
                 <tr><td><code>heading</code></td><td>Absolute aircraft heading. If omitted, defaults to the runway heading.</td></tr>
                 <tr><td><code>heading_offset</code></td><td>Offset added to the default heading (runway heading).</td></tr>
                 <tr><td><code>bearing</code></td><td>Absolute bearing from the reference point to place the aircraft.</td></tr>
@@ -9096,7 +9106,7 @@ APPLE3.ALL  : RUUTH WNDYL BRAND/a8000 KORRY DEPDY TYKES MINKS JERZY RENUE APPLE 
               <thead><tr><th>Field</th><th>Description</th></tr></thead>
               <tbody>
                 <tr><td><code>command</code></td><td>The STARS command string to issue (e.g., <code>E{approach}</code>, <code>S210</code>, <code>H090</code>).</td></tr>
-                <tr><td><code>expect_readback</code></td><td>A string or array of strings. The step passes if any of these appear in the pilot's readback.</td></tr>
+                <tr><td><code>expect_readback</code></td><td>A string or array of strings. The step passes if any of these appear in the pilot's readback. If omitted, the step is "fire-and-forget" and advances immediately without waiting for a readback.</td></tr>
                 <tr><td><code>reject_readback</code></td><td>If this string appears in the readback, the step fails even if an expected string also matched.</td></tr>
                 <tr><td><code>callsign</code></td><td>Target callsign for multi-aircraft tests. Use <code>{0}</code>, <code>{1}</code>, etc. to reference aircraft by index.</td></tr>
                 <tr><td><code>wait_for</code></td><td>Instead of issuing a command, wait for the pilot to transmit a specific type of message.</td></tr>
@@ -9109,8 +9119,8 @@ APPLE3.ALL  : RUUTH WNDYL BRAND/a8000 KORRY DEPDY TYKES MINKS JERZY RENUE APPLE 
               <li><code>approach_clearance_request</code> &mdash; pilot requests approach clearance</li>
               <li><code>field_in_sight</code> &mdash; pilot reports the field/airport in sight</li>
               <li><code>go_around</code> &mdash; pilot announces a go-around</li>
-              <li><code>traffic_response</code> &mdash; any response to a traffic advisory</li>
-              <li><code>traffic_in_sight</code> &mdash; positive traffic response only</li>
+              <li><code>traffic_response</code> &mdash; any response to a traffic advisory (including "looking", "negative contact", and IMC responses)</li>
+              <li><code>traffic_in_sight</code> &mdash; positive traffic response only (e.g., "traffic in sight", "we have the traffic")</li>
             </ul>
 
             <h4>Placeholders</h4>
@@ -9128,6 +9138,8 @@ APPLE3.ALL  : RUUTH WNDYL BRAND/a8000 KORRY DEPDY TYKES MINKS JERZY RENUE APPLE 
                 <tr><td><code>{star_fix}</code></td><td>First fix of a randomly selected active STAR</td></tr>
                 <tr><td><code>{0}</code>, <code>{1}</code></td><td>Generated callsign for aircraft at that index</td></tr>
                 <tr><td><code>{hdg0}</code>, <code>{hdg1}</code></td><td>Three-digit heading of the aircraft at that index</td></tr>
+                <tr><td><code>{alt0}</code>, <code>{alt1}</code></td><td>Altitude of the aircraft at that index in hundreds of feet (e.g., <code>70</code> for 7,000 ft). Useful in TRAFFIC command parameters.</td></tr>
+                <tr><td><code>{altCeiling}</code></td><td>Used in aircraft spec <code>altitude</code> field. Resolves to the METAR ceiling minus 500 ft, or 5,000 ft if clear/unavailable.</td></tr>
               </tbody>
             </table>
 

--- a/website/index.html
+++ b/website/index.html
@@ -231,6 +231,7 @@
 	  <li class="nav-item"><a class="nav-link scrollto" href="#fe-airspace">Controller Airspace</a></li>
 	  <li class="nav-item"><a class="nav-link scrollto" href="#fe-scenarios">Scenarios</a></li>
 	  <li class="nav-item"><a class="nav-link scrollto" href="#fe-emergencies">Emergencies</a></li>
+	  <li class="nav-item"><a class="nav-link scrollto" href="#fe-test-bench">Test Bench</a></li>
 	  <li class="nav-item"><a class="nav-link scrollto" href="#fe-stars-videomaps">STARS and Video Maps</a>
 	    <ul class="submenu">
 	      <li class="submenu-item"><a class="submenu-link scrollto" href="#fe-stars-list-format">List Formatting</a></li>
@@ -8992,6 +8993,143 @@ APPLE3.ALL  : RUUTH WNDYL BRAND/a8000 KORRY DEPDY TYKES MINKS JERZY RENUE APPLE 
   ]
 }
 }</pre>
+
+          </section><!--//section-->
+
+          <section class="docs-section" id="fe-test-bench">
+            <h2 class="section-heading">Test Bench</h2>
+
+            <p>The test bench is a developer tool for interactively testing
+              ATC commands against spawned aircraft. It allows you to
+              quickly verify that approach clearances, speed assignments,
+              altitude instructions, holds, and other commands work
+              correctly with your facility's approaches and procedures.</p>
+
+            <h3>Enabling the Test Bench</h3>
+            <p>The test bench is available in developer mode. There are two ways to enable it:</p>
+            <ul>
+              <li><strong>Settings window:</strong> Check the "Developer mode" checkbox in the Settings window.</li>
+              <li><strong>Command line:</strong> Launch <i>vice</i> with the <code>-dev</code> flag (e.g., <code>vice -dev</code>).</li>
+            </ul>
+            <p>Once developer mode is enabled, a wrench icon
+              (<i class="fas fa-wrench"></i>) appears in the menu bar
+              while connected to a simulation.  Click it to open the
+              test bench panel.</p>
+
+            <h3>Using the Test Bench</h3>
+            <p>The test bench panel displays a list of test scenarios organized by category
+              (e.g., "Approach Clearance Requests", "Speed Assignments", "Hold").
+              Each scenario has one or more aircraft specifications and a sequence of
+              steps describing the commands to issue.</p>
+
+            <ol>
+              <li><strong>Select an approach and departure runway</strong> using the
+                dropdowns at the top of the panel. These determine which
+                runway and approach fixes are used by the test scenarios.</li>
+              <li><strong>Click "Spawn"</strong> next to a test scenario to
+                create the test aircraft on your scope. The aircraft will
+                appear at the position described in the scenario (e.g., 8nm from
+                the intermediate fix at 210 knots).</li>
+              <li><strong>Issue the commands yourself</strong> by typing them
+                into the STARS command line, just as you would during normal
+                controlling. The steps listed in each scenario show you what
+                commands to issue and in what order.</li>
+              <li><strong>Observe the results.</strong> The test bench tracks
+                the pilot's readbacks and marks each step with a result:
+                <ul>
+                  <li><code>></code> &mdash; current step (waiting for you to issue the command)</li>
+                  <li><code>+</code> (green) &mdash; step passed (readback matched expectations)</li>
+                  <li><code>X</code> (red) &mdash; step failed (unexpected readback)</li>
+                </ul>
+                Steps with <code>[wait: ...]</code> labels are automatic
+                checkpoints that pass when the pilot transmits a specific
+                message (e.g., checking in, requesting an approach clearance,
+                or reporting the field in sight).
+              </li>
+              <li><strong>Click "Clear"</strong> to remove the spawned aircraft
+                when you are done with a test.</li>
+            </ol>
+
+            <h3>Test Scenario Format</h3>
+            <p>Test scenarios are defined in
+              <a href="https://github.com/mmp/vice/blob/master/resources/test_bench_scenarios.json"><code>resources/test_bench_scenarios.json</code></a>.
+              The file is a JSON object where each key is a section name
+              and its value is an array of test cases.</p>
+
+            <p>Each test case has the following fields:</p>
+            <table class="table">
+              <thead><tr><th>Field</th><th>Description</th></tr></thead>
+              <tbody>
+                <tr><td><code>label</code></td><td>Display name for the test case.</td></tr>
+                <tr><td><code>aircraft</code></td><td>Array of aircraft specifications to spawn (for approach/arrival tests).</td></tr>
+                <tr><td><code>steps</code></td><td>Array of test steps (commands and expected readbacks).</td></tr>
+                <tr><td><code>departure</code></td><td>If <code>true</code>, spawn a departure using the sim's departure system.</td></tr>
+                <tr><td><code>group</code></td><td>Arrival group name for STAR-based spawning (uses the sim's arrival system).</td></tr>
+                <tr><td><code>airport</code></td><td>Override airport (defaults to the scenario's primary airport).</td></tr>
+                <tr><td><code>runway</code></td><td>Override departure runway.</td></tr>
+                <tr><td><code>category</code></td><td>Departure category filter (e.g., "J" for jets).</td></tr>
+              </tbody>
+            </table>
+
+            <h4>Aircraft Specifications</h4>
+            <p>Each entry in the <code>aircraft</code> array describes how to position a spawned aircraft:</p>
+            <table class="table">
+              <thead><tr><th>Field</th><th>Description</th></tr></thead>
+              <tbody>
+                <tr><td><code>distance_nm</code></td><td>Distance in nautical miles from the reference point.</td></tr>
+                <tr><td><code>speed</code></td><td>Initial airspeed in knots.</td></tr>
+                <tr><td><code>altitude</code></td><td>Altitude in feet. If omitted and <code>relative_to</code> is set, uses the fix's altitude restriction.</td></tr>
+                <tr><td><code>relative_to</code></td><td>Position relative to a fix name or placeholder (e.g., <code>{if}</code>). If omitted, positions relative to the airport.</td></tr>
+                <tr><td><code>heading</code></td><td>Absolute aircraft heading. If omitted, defaults to the runway heading.</td></tr>
+                <tr><td><code>heading_offset</code></td><td>Offset added to the default heading (runway heading).</td></tr>
+                <tr><td><code>bearing</code></td><td>Absolute bearing from the reference point to place the aircraft.</td></tr>
+                <tr><td><code>bearing_offset</code></td><td>Offset added to the default bearing (extended centerline).</td></tr>
+                <tr><td><code>star_waypoints</code></td><td>If <code>true</code>, populate the aircraft's route from a randomly selected STAR.</td></tr>
+                <tr><td><code>traffic_in_sight</code></td><td>If <code>true</code>, the aircraft will respond positively to traffic advisories.</td></tr>
+                <tr><td><code>note</code></td><td>Descriptive note shown in the UI.</td></tr>
+              </tbody>
+            </table>
+
+            <h4>Test Steps</h4>
+            <p>Each step is either a command to issue or a wait condition:</p>
+            <table class="table">
+              <thead><tr><th>Field</th><th>Description</th></tr></thead>
+              <tbody>
+                <tr><td><code>command</code></td><td>The STARS command string to issue (e.g., <code>E{approach}</code>, <code>S210</code>, <code>H090</code>).</td></tr>
+                <tr><td><code>expect_readback</code></td><td>A string or array of strings. The step passes if any of these appear in the pilot's readback.</td></tr>
+                <tr><td><code>reject_readback</code></td><td>If this string appears in the readback, the step fails even if an expected string also matched.</td></tr>
+                <tr><td><code>callsign</code></td><td>Target callsign for multi-aircraft tests. Use <code>{0}</code>, <code>{1}</code>, etc. to reference aircraft by index.</td></tr>
+                <tr><td><code>wait_for</code></td><td>Instead of issuing a command, wait for the pilot to transmit a specific type of message.</td></tr>
+              </tbody>
+            </table>
+
+            <p>Available <code>wait_for</code> conditions:</p>
+            <ul>
+              <li><code>check_in</code> &mdash; pilot checks in on frequency</li>
+              <li><code>approach_clearance_request</code> &mdash; pilot requests approach clearance</li>
+              <li><code>field_in_sight</code> &mdash; pilot reports the field/airport in sight</li>
+              <li><code>go_around</code> &mdash; pilot announces a go-around</li>
+              <li><code>traffic_response</code> &mdash; any response to a traffic advisory</li>
+              <li><code>traffic_in_sight</code> &mdash; positive traffic response only</li>
+            </ul>
+
+            <h4>Placeholders</h4>
+            <p>Commands and readback expectations can use placeholders that are
+              resolved at runtime based on the selected approach:</p>
+            <table class="table">
+              <thead><tr><th>Placeholder</th><th>Description</th></tr></thead>
+              <tbody>
+                <tr><td><code>{approach}</code></td><td>Approach ID (e.g., "I2L")</td></tr>
+                <tr><td><code>{approach_name}</code></td><td>Full approach name (e.g., "ILS Runway 22L")</td></tr>
+                <tr><td><code>{iaf}</code></td><td>Initial Approach Fix name</td></tr>
+                <tr><td><code>{if}</code></td><td>Intermediate Fix name</td></tr>
+                <tr><td><code>{faf}</code></td><td>Final Approach Fix name</td></tr>
+                <tr><td><code>{hold_fix}</code></td><td>A randomly selected fix with a published hold near the airport</td></tr>
+                <tr><td><code>{star_fix}</code></td><td>First fix of a randomly selected active STAR</td></tr>
+                <tr><td><code>{0}</code>, <code>{1}</code></td><td>Generated callsign for aircraft at that index</td></tr>
+                <tr><td><code>{hdg0}</code>, <code>{hdg1}</code></td><td>Three-digit heading of the aircraft at that index</td></tr>
+              </tbody>
+            </table>
 
           </section><!--//section-->
 


### PR DESCRIPTION
As more nuanced logic gets added to the sim, I found it can be difficult to test new flows and commands thoroughly. I created a test bench panel tool to help make that easy and fun. 

Test cases are facility/scenario agnostic: placeholders like {approach}, {iaf}, {if}, {faf} resolve to actual fixes for whichever approach you've selected, so the same tests work across facilities. Initial scenarios cover approach clearance request flows and basic departure commands, but it should be straightforward to build out further. I think this can also be useful for smoke testing new facility scenarios.

The direct-placement spawn mode constructs a specially configured overflight positioned at a specific distance and bearing from a fix via LaunchArrivalOverflight, making it easy to set up precise test scenarios. Departure/arrival spawns reuse the existing CreateDeparture/CreateArrival plumbing. This should also work fine with ERAM as well, but needs a bit more work to support fully support overflights.

To try this, launch vice with the --dev flag to enable developer tools. A wrench icon appears in the toolbar - click it to open the Test Bench panel. See the attached demo for a walkthrough (commands are issued via STT so there's no audio).

I used an extended version of this to thoroughly smoke test the visual approach logic in #807, and it was quite useful. Those extra scenarios are separate for now since they depend on the visual approach logic, but you can see them here: https://github.com/jordw/vice/commit/ee904d8c3246341e638a34994376395596cc4578

https://github.com/user-attachments/assets/593c9996-924f-4c91-9c41-19b9af3fdea8


