### PR TITLE
Added DPI-Only DCB Scaling. Scrolling added if the DCB overflows. 

### DIFF
--- a/stars/dcb.go
+++ b/stars/dcb.go
@@ -77,20 +77,48 @@ type dcbSpinner interface {
 }
 
 func (sp *STARSPane) dcbButtonScale(ctx *panes.Context) float32 {
+	// Buttons are always drawn at the platform's DPI scale so a button is
+	// the same physical size on every monitor. If the pane is too narrow
+	// to fit every button, the overflow is handled by scrolling (see
+	// sp.dcbScroll) rather than by shrinking the buttons.
+	return ctx.DrawPixelScale
+}
+
+// dcbBarExtent returns the rectangle (in pane-local coordinates) that the
+// DCB bar occupies for the current preference's DCB position. The scroll
+// offset does not shift the bar itself — only the buttons inside it — so
+// this always returns the full, non-scrolled rectangle.
+func (sp *STARSPane) dcbBarExtent(ctx *panes.Context) math.Extent2D {
 	ps := sp.currentPrefs()
-	// Sigh; on windows we want the button size in pixels on high DPI displays
-	ds := ctx.DrawPixelScale
-	width := ds*ctx.PaneExtent.Width() - 4
-	height := ds*ctx.PaneExtent.Height() - 4
-	if ps.DCBPosition == dcbPositionTop || ps.DCBPosition == dcbPositionBottom {
-		mainScale := width / (numDCBSlots * dcbButtonSize)
-		crossScale := height / dcbButtonSize
-		return min(ds, mainScale, crossScale)
-	} else {
-		mainScale := height / (numDCBSlots * dcbButtonSize)
-		crossScale := width / dcbButtonSize
-		return min(ds, mainScale, crossScale)
+	bs := float32(int(sp.dcbButtonScale(ctx)*dcbButtonSize + 0.5))
+	w, h := ctx.PaneExtent.Width(), ctx.PaneExtent.Height()
+	switch ps.DCBPosition {
+	case dcbPositionTop:
+		return math.Extent2D{P0: [2]float32{0, h - bs}, P1: [2]float32{w, h}}
+	case dcbPositionBottom:
+		return math.Extent2D{P0: [2]float32{0, 0}, P1: [2]float32{w, bs}}
+	case dcbPositionLeft:
+		return math.Extent2D{P0: [2]float32{0, 0}, P1: [2]float32{bs, h}}
+	case dcbPositionRight:
+		return math.Extent2D{P0: [2]float32{w - bs, 0}, P1: [2]float32{w, h}}
 	}
+	return math.Extent2D{}
+}
+
+// dcbMaxScroll returns the maximum scroll offset needed to reach the end
+// of the DCB content (buttons past the visible region). Clamping the
+// stored scroll to [0, max] prevents scrolling past useful content.
+func (sp *STARSPane) dcbMaxScroll(ctx *panes.Context) float32 {
+	ps := sp.currentPrefs()
+	bs := sp.dcbButtonScale(ctx) * dcbButtonSize
+	content := float32(numDCBSlots) * bs
+	var visible float32
+	if ps.DCBPosition == dcbPositionTop || ps.DCBPosition == dcbPositionBottom {
+		visible = ctx.PaneExtent.Width()
+	} else {
+		visible = ctx.PaneExtent.Height()
+	}
+	return max(0, content-visible)
 }
 
 func (sp *STARSPane) drawDCB(ctx *panes.Context, transforms radar.ScopeTransformations, cb *renderer.CommandBuffer) (paneExtent math.Extent2D) {
@@ -98,6 +126,19 @@ func (sp *STARSPane) drawDCB(ctx *panes.Context, transforms radar.ScopeTransform
 
 	// Find a scale factor so that the buttons all fit in the window, if necessary
 	buttonScale := sp.dcbButtonScale(ctx)
+
+	// Clamp any stale scroll offset and absorb mouse-wheel input that
+	// occurs over the DCB bar (but not while a spinner is active, since
+	// those consume the wheel themselves). One notch of the wheel scrolls
+	// by one button width so wheel feel matches button cadence.
+	maxScroll := sp.dcbMaxScroll(ctx)
+	barExtent := sp.dcbBarExtent(ctx)
+	if ctx.Mouse != nil && sp.activeSpinner == nil && ctx.Mouse.Wheel[1] != 0 && barExtent.Inside(ctx.Mouse.Pos) {
+		bs := sp.dcbButtonScale(ctx) * dcbButtonSize
+		// Positive wheel -> scroll to reveal later buttons (increase offset).
+		sp.dcbScroll -= ctx.Mouse.Wheel[1] * bs
+	}
+	sp.dcbScroll = math.Clamp(sp.dcbScroll, 0, maxScroll)
 
 	sp.startDrawDCB(ctx, buttonScale, transforms, cb)
 
@@ -769,6 +810,10 @@ var dcbDrawState struct {
 	style        renderer.TextStyle
 	brightness   radar.Brightness
 	position     int
+	// barExtent is the DCB bar rectangle in pane-local coordinates. Per-button
+	// scissors are intersected with this so buttons scrolled past the edge
+	// don't bleed into the radar area.
+	barExtent math.Extent2D
 }
 
 func (sp *STARSPane) startDrawDCB(ctx *panes.Context, buttonScale float32, transforms radar.ScopeTransformations,
@@ -779,6 +824,7 @@ func (sp *STARSPane) startDrawDCB(ctx *panes.Context, buttonScale float32, trans
 	ps := sp.currentPrefs()
 	dcbDrawState.brightness = ps.Brightness.DCB
 	dcbDrawState.position = ps.DCBPosition
+	dcbDrawState.barExtent = sp.dcbBarExtent(ctx)
 	buttonSize := float32(int(sp.dcbButtonScale(ctx)*dcbButtonSize + 0.5))
 	var drawEndPos [2]float32
 	switch dcbDrawState.position {
@@ -799,8 +845,6 @@ func (sp *STARSPane) startDrawDCB(ctx *panes.Context, buttonScale float32, trans
 		drawEndPos = [2]float32{ctx.PaneExtent.Width(), 0}
 	}
 
-	dcbDrawState.cursor = dcbDrawState.drawStartPos
-
 	dcbDrawState.style = renderer.TextStyle{
 		Font:        sp.dcbFont(ctx, ps.CharSize.DCB),
 		Color:       sp.Colors.DCBText,
@@ -810,13 +854,26 @@ func (sp *STARSPane) startDrawDCB(ctx *panes.Context, buttonScale float32, trans
 	transforms.LoadWindowViewingMatrices(cb)
 	cb.LineWidth(1, ctx.DPIScale)
 
-	// Draw background color quad
+	// Draw background color quad (covers the full bar — always the non-scrolled region)
 	trid := renderer.GetColoredTrianglesDrawBuilder()
 	defer renderer.ReturnColoredTrianglesDrawBuilder(trid)
 	trid.AddQuad(dcbDrawState.drawStartPos, [2]float32{drawEndPos[0], dcbDrawState.drawStartPos[1]},
 		drawEndPos, [2]float32{dcbDrawState.drawStartPos[0], drawEndPos[1]},
 		sp.Colors.DCBBackground)
 	trid.GenerateCommands(cb)
+
+	// Apply the horizontal/vertical scroll offset so that buttons drawn
+	// relative to drawStartPos shift with sp.dcbScroll. The bar background
+	// above is not shifted — only the button cursor.
+	if sp.dcbScroll != 0 {
+		switch dcbDrawState.position {
+		case dcbPositionTop, dcbPositionBottom:
+			dcbDrawState.drawStartPos[0] -= sp.dcbScroll
+		case dcbPositionLeft, dcbPositionRight:
+			dcbDrawState.drawStartPos[1] += sp.dcbScroll
+		}
+	}
+	dcbDrawState.cursor = dcbDrawState.drawStartPos
 
 	if ctx.Mouse != nil && ctx.Mouse.Clicked[platform.MouseButtonPrimary] {
 		dcbDrawState.mouseDownPos = ctx.Mouse.Pos[:]
@@ -876,10 +933,19 @@ func (sp *STARSPane) drawDCBButton(ctx *panes.Context, text string, flags dcbFla
 	p3 := math.Add2f(p2, [2]float32{-sz[0], 0})
 
 	ext := math.Extent2DFromPoints([][2]float32{p0, p2})
+	// Clip the hit-test extent to the DCB bar so scrolled-off portions of a
+	// partially visible button don't steal clicks from the radar area.
+	hitExt := math.Extent2D{
+		P0: [2]float32{max(ext.P0[0], dcbDrawState.barExtent.P0[0]),
+			max(ext.P0[1], dcbDrawState.barExtent.P0[1])},
+		P1: [2]float32{min(ext.P1[0], dcbDrawState.barExtent.P1[0]),
+			min(ext.P1[1], dcbDrawState.barExtent.P1[1])},
+	}
+	hitVisible := hitExt.P1[0] > hitExt.P0[0] && hitExt.P1[1] > hitExt.P0[1]
 	mouse := dcbDrawState.mouse
-	mouseInside := mouse != nil && ext.Inside(mouse.Pos)
-	mouseDownInside := dcbDrawState.mouseDownPos != nil &&
-		ext.Inside([2]float32{dcbDrawState.mouseDownPos[0], dcbDrawState.mouseDownPos[1]}) &&
+	mouseInside := hitVisible && mouse != nil && hitExt.Inside(mouse.Pos)
+	mouseDownInside := hitVisible && dcbDrawState.mouseDownPos != nil &&
+		hitExt.Inside([2]float32{dcbDrawState.mouseDownPos[0], dcbDrawState.mouseDownPos[1]}) &&
 		flags&buttonDisabled == 0
 
 	var buttonColor, textColor renderer.RGB
@@ -937,14 +1003,26 @@ func (sp *STARSPane) drawDCBButton(ctx *panes.Context, text string, flags dcbFla
 		ld.AddLine(shiftp(p2, 0, fi), shiftp(p3, fi, fi), bottomRightBevelColor)
 	}
 
-	// Scissor to just the extent of the button. Note that we need to give
-	// this in window coordinates, not our local pane coordinates, so
-	// translating by ctx.PaneExtent.p0 is needed...
-	winBase := math.Add2f(dcbDrawState.cursor, ctx.PaneExtent.P0)
-	dcbDrawState.cb.SetScissorBounds(math.Extent2D{
-		P0: [2]float32{winBase[0], winBase[1] - sz[1]},
-		P1: [2]float32{winBase[0] + sz[0], winBase[1]},
-	}, ctx.Platform.FramebufferSize()[1]/ctx.Platform.DisplaySize()[1])
+	// Scissor to just the extent of the button — clipped to the DCB bar so
+	// buttons scrolled past the edge don't bleed into the radar area. Note
+	// that we need to give this in window coordinates, not our local pane
+	// coordinates, so translating by ctx.PaneExtent.p0 is needed...
+	btnLocal := math.Extent2D{
+		P0: [2]float32{dcbDrawState.cursor[0], dcbDrawState.cursor[1] - sz[1]},
+		P1: [2]float32{dcbDrawState.cursor[0] + sz[0], dcbDrawState.cursor[1]},
+	}
+	clipped := math.Extent2D{
+		P0: [2]float32{max(btnLocal.P0[0], dcbDrawState.barExtent.P0[0]),
+			max(btnLocal.P0[1], dcbDrawState.barExtent.P0[1])},
+		P1: [2]float32{min(btnLocal.P1[0], dcbDrawState.barExtent.P1[0]),
+			min(btnLocal.P1[1], dcbDrawState.barExtent.P1[1])},
+	}
+	winScissor := math.Extent2D{
+		P0: math.Add2f(clipped.P0, ctx.PaneExtent.P0),
+		P1: math.Add2f(clipped.P1, ctx.PaneExtent.P0),
+	}
+	dcbDrawState.cb.SetScissorBounds(winScissor,
+		ctx.Platform.FramebufferSize()[1]/ctx.Platform.DisplaySize()[1])
 	moveDCBCursor(flags, sz, ctx)
 
 	trid.GenerateCommands(dcbDrawState.cb)
@@ -1079,7 +1157,19 @@ func dcbCaptureMouseFromRegion(ctx *panes.Context, buttonScale float32) {
 	} else {
 		p1[0] += sz[0]
 	}
-	dcbCaptureMouse(ctx, math.Extent2DFromPoints([][2]float32{dcbCaptureMouseP0, p1}))
+	region := math.Extent2DFromPoints([][2]float32{dcbCaptureMouseP0, p1})
+	// Clip to the visible DCB bar so mouse lock follows the DCB rather than
+	// extending into the radar area when content is scrolled off-screen.
+	clipped := math.Extent2D{
+		P0: [2]float32{max(region.P0[0], dcbDrawState.barExtent.P0[0]),
+			max(region.P0[1], dcbDrawState.barExtent.P0[1])},
+		P1: [2]float32{min(region.P1[0], dcbDrawState.barExtent.P1[0]),
+			min(region.P1[1], dcbDrawState.barExtent.P1[1])},
+	}
+	if clipped.P1[0] <= clipped.P0[0] || clipped.P1[1] <= clipped.P0[1] {
+		return
+	}
+	dcbCaptureMouse(ctx, clipped)
 }
 
 func dcbCaptureMouse(ctx *panes.Context, bounds math.Extent2D) {

--- a/stars/dcb.go
+++ b/stars/dcb.go
@@ -106,19 +106,19 @@ func (sp *STARSPane) dcbBarExtent(ctx *panes.Context) math.Extent2D {
 }
 
 // dcbMaxScroll returns the maximum scroll offset needed to reach the end
-// of the DCB content (buttons past the visible region). Clamping the
-// stored scroll to [0, max] prevents scrolling past useful content.
+// of the DCB content (buttons past the visible region). Uses the actual
+// content size measured by the previous frame's draw so submenus with
+// fewer slots don't allow scrolling past their last button into empty
+// bar area.
 func (sp *STARSPane) dcbMaxScroll(ctx *panes.Context) float32 {
 	ps := sp.currentPrefs()
-	bs := sp.dcbButtonScale(ctx) * dcbButtonSize
-	content := float32(numDCBSlots) * bs
 	var visible float32
 	if ps.DCBPosition == dcbPositionTop || ps.DCBPosition == dcbPositionBottom {
 		visible = ctx.PaneExtent.Width()
 	} else {
 		visible = ctx.PaneExtent.Height()
 	}
-	return max(0, content-visible)
+	return max(0, sp.dcbContentSize-visible)
 }
 
 func (sp *STARSPane) drawDCB(ctx *panes.Context, transforms radar.ScopeTransformations, cb *renderer.CommandBuffer) (paneExtent math.Extent2D) {
@@ -813,6 +813,10 @@ var dcbDrawState struct {
 	// scissors are intersected with this so buttons scrolled past the edge
 	// don't bleed into the radar area.
 	barExtent math.Extent2D
+	// contentMain accumulates the maximum main-axis extent reached by any
+	// drawn button this frame, measured relative to the unscrolled bar
+	// origin. endDrawDCB commits this to sp.dcbContentSize.
+	contentMain float32
 }
 
 func (sp *STARSPane) startDrawDCB(ctx *panes.Context, buttonScale float32, transforms radar.ScopeTransformations,
@@ -824,6 +828,7 @@ func (sp *STARSPane) startDrawDCB(ctx *panes.Context, buttonScale float32, trans
 	dcbDrawState.brightness = ps.Brightness.DCB
 	dcbDrawState.position = ps.DCBPosition
 	dcbDrawState.barExtent = sp.dcbBarExtent(ctx)
+	dcbDrawState.contentMain = 0
 	buttonSize := float32(int(sp.dcbButtonScale(ctx)*dcbButtonSize + 0.5))
 	var drawEndPos [2]float32
 	switch dcbDrawState.position {
@@ -888,6 +893,8 @@ func (sp *STARSPane) endDrawDCB() {
 			dcbDrawState.mouseDownPos = nil
 		}
 	}
+
+	sp.dcbContentSize = dcbDrawState.contentMain
 }
 
 func drawDCBText(text string, td *renderer.TextDrawBuilder, buttonSize [2]float32, color renderer.RGB) {
@@ -1022,6 +1029,21 @@ func (sp *STARSPane) drawDCBButton(ctx *panes.Context, text string, flags dcbFla
 	}
 	dcbDrawState.cb.SetScissorBounds(winScissor,
 		ctx.Platform.FramebufferSize()[1]/ctx.Platform.DisplaySize()[1])
+
+	// Track the furthest main-axis extent reached by any drawn button so
+	// dcbMaxScroll can stop exactly at the last button of the current menu
+	// rather than at a fixed 22-slot assumption.
+	var reached float32
+	switch dcbDrawState.position {
+	case dcbPositionTop, dcbPositionBottom:
+		reached = btnLocal.P1[0] - dcbDrawState.drawStartPos[0]
+	case dcbPositionLeft, dcbPositionRight:
+		reached = dcbDrawState.drawStartPos[1] - btnLocal.P0[1]
+	}
+	if reached > dcbDrawState.contentMain {
+		dcbDrawState.contentMain = reached
+	}
+
 	moveDCBCursor(flags, sz, ctx)
 
 	trid.GenerateCommands(dcbDrawState.cb)

--- a/stars/dcb.go
+++ b/stars/dcb.go
@@ -135,8 +135,7 @@ func (sp *STARSPane) drawDCB(ctx *panes.Context, transforms radar.ScopeTransform
 	barExtent := sp.dcbBarExtent(ctx)
 	if ctx.Mouse != nil && sp.activeSpinner == nil && ctx.Mouse.Wheel[1] != 0 && barExtent.Inside(ctx.Mouse.Pos) {
 		bs := sp.dcbButtonScale(ctx) * dcbButtonSize
-		// Positive wheel -> scroll to reveal later buttons (increase offset).
-		sp.dcbScroll -= ctx.Mouse.Wheel[1] * bs
+		sp.dcbScroll += ctx.Mouse.Wheel[1] * bs
 	}
 	sp.dcbScroll = math.Clamp(sp.dcbScroll, 0, maxScroll)
 

--- a/stars/stars.go
+++ b/stars/stars.go
@@ -160,6 +160,12 @@ type STARSPane struct {
 	previewAreaInput  string
 	dcbShowAux        bool
 
+	// dcbScroll is the horizontal/vertical scroll offset (in pane-local
+	// pixels) applied to the DCB when the pane is too narrow to show every
+	// button at the fixed button size. Clamped to [0, content - visible]
+	// each frame; mouse wheel over the DCB bar adjusts it.
+	dcbScroll float32
+
 	lastTrackUpdate        sim.Time
 	lastHistoryTrackUpdate sim.Time
 	discardTracks          bool

--- a/stars/stars.go
+++ b/stars/stars.go
@@ -166,6 +166,11 @@ type STARSPane struct {
 	// each frame; mouse wheel over the DCB bar adjusts it.
 	dcbScroll float32
 
+	// dcbContentSize is the main-axis extent (in pane-local pixels) that
+	// the previous frame's DCB drawing actually used. Lets dcbMaxScroll
+	// stop at the last real button so the user can't scroll into empty bar.
+	dcbContentSize float32
+
 	lastTrackUpdate        sim.Time
 	lastHistoryTrackUpdate sim.Time
 	discardTracks          bool


### PR DESCRIPTION
  - DCB button scale is now DPI-only, so every button is the same physical size regardless of monitor or pane width
  - When the pane is too narrow to show every slot, a mouse-wheel-driven scroll shifts the button cursor while the bar background stays pinned
  - Per-button scissoring + clipped hit-test + clipped mouse-capture regions keep scrolled-off buttons from bleeding into the radar area
  - Scroll wheel reversed to match the natural "push buttons into view" direction
  - Scroll extent clamped to the measured content size so menus with fewer than 22 slots don't scroll past their last button