### PR TITLE
Fix Aircraft Randomly Leaving The Hold

### DIFF
--- a/nav/procedures.go
+++ b/nav/procedures.go
@@ -538,18 +538,10 @@ func init() {
 		HoldStateTurningInbound: func(nav *Nav, fh *FlyHold, wxs wx.Sample, simTime Time) (math.MagneticHeading, av.TurnDirection, HoldState) {
 			turn := util.Select(fh.Hold.TurnDirection == av.TurnRight, av.TurnRight, av.TurnLeft)
 
-			if math.HeadingDifference(nav.FlightState.Heading, fh.Hold.InboundCourse) > 60 {
-				// Initial turn off the outbound leg
+			if math.HeadingDifference(nav.FlightState.Heading, fh.Hold.InboundCourse) > 5 {
 				return fh.Hold.InboundCourse, turn, HoldStateTurningInbound
 			}
 
-			if nav.shouldTurnToIntercept(fh.FixLocation, fh.Hold.InboundCourse, turn, wxs) != turnToInterceptTurn {
-				// Don't finish the turn and instead fly present heading a bit until the point at
-				// which finishing the turn would have us roll out to the inbound course.
-				return nav.FlightState.Heading, turn, HoldStateTurningInbound
-			}
-
-			// Wrap up the turn and start flying the inbound leg.
 			return fh.Hold.InboundCourse, av.TurnClosest, HoldStateFlyingInbound
 		},
 


### PR DESCRIPTION
Closes #876 

HoldStateTurningInbound bailed out of the inbound turn at 60 degrees and fell back to ShouldTurnToIntercept which is written for localizer intercepts. When the turn was more than 10 degrees it returned MajorOvershoot, which falls back to "fly present heading" which leads to the behaviour of the aircraft randomly leaving the hold as stated in the issue Now it just completes the 180 degree turn through the inbound and and has FlyingInbound turn direct-to-fix as it already does. 

The tradeoff with this fix is that the aircraft will overshoot just a bit on the inbound turn. It shouldn't be that big of a deal though as its barely noticeable. 

Tested on BOS FV 4L/R with the same conditions stated in the bug report and it works flawlessly now.