### PR TITLE
Add copy from the messages window and paste into the STARS window

### DIFF
--- a/panes/messages.go
+++ b/panes/messages.go
@@ -103,6 +103,17 @@ func (mp *MessagesPane) DrawUI(p platform.Platform, config *platform.Config) {
 	imgui.Checkbox("Play audio alert after pilot readback transmissions", &mp.ReadbackTransmissionsAlert)
 }
 
+func (mp *MessagesPane) joinedMessages() string {
+	var sb strings.Builder
+	for i, msg := range mp.messages {
+		if i > 0 {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(msg.contents)
+	}
+	return sb.String()
+}
+
 func (msg *Message) Color() renderer.RGB {
 	switch {
 	case msg.error:
@@ -137,15 +148,25 @@ func (mp *MessagesPane) DrawWindow(show *bool, c *client.ControlClient, p platfo
 	imgui.BeginV("Messages", show, 0)
 	DrawPinButton("Messages", unpinnedWindows, p)
 	if imgui.BeginChildStrV("##messages_scroll", imgui.Vec2{}, 0, 0) {
-		for _, msg := range mp.messages {
+		for i, msg := range mp.messages {
 			color := msg.ImguiColor()
 			imgui.PushStyleColorVec4(imgui.ColText, color)
 			imgui.PushTextWrapPos()
 			imgui.TextUnformatted(msg.contents)
 			imgui.PopTextWrapPos()
 			imgui.PopStyleColor()
+
+			if imgui.BeginPopupContextItemV(fmt.Sprintf("##msg_ctx_%d", i),
+				imgui.PopupFlagsMouseButtonRight) {
+				if imgui.SelectableBool("Copy message") {
+					imgui.SetClipboardText(msg.contents)
+				}
+				if imgui.SelectableBool("Copy all messages") {
+					imgui.SetClipboardText(mp.joinedMessages())
+				}
+				imgui.EndPopup()
+			}
 		}
-		// Auto-scroll when new messages arrive
 		if mp.shouldAutoScroll {
 			imgui.SetScrollHereYV(1.0)
 			mp.shouldAutoScroll = false

--- a/stars/commands.go
+++ b/stars/commands.go
@@ -256,6 +256,18 @@ func (sp *STARSPane) processKeyboardInput(ctx *panes.Context) {
 				sp.drawRoutePoints = sp.drawRoutePoints[:n-1]
 			}
 
+		case imgui.KeyV:
+			if ctx.Keyboard.KeyControl() {
+				pasted := strings.ToUpper(ctx.Platform.GetClipboard().GetClipboard())
+				var b strings.Builder
+				for _, r := range pasted {
+					if r >= 32 && r < 127 {
+						b.WriteRune(r)
+					}
+				}
+				sp.previewAreaInput += strings.ReplaceAll(b.String(), "`", STARSTriangleCharacter)
+			}
+
 		case imgui.KeyEnd:
 			sp.setCommandMode(ctx, CommandModeMin)
 


### PR DESCRIPTION
Closes #861 

You can now right click in the messages window and copy an individual message that you're hovering over or copy the entire thing. Good for debugging.  

Added pasting messages into the STARS windows. Backtick automatically translates to the triangle if pasted in there.