### PR TITLE
nav/wx: use arrival airport METAR for approach speed wind additive

### DIFF
--- a/nav/alt_test.go
+++ b/nav/alt_test.go
@@ -36,12 +36,12 @@ func TestAssignAltitudeDelaysVerticalGuidance(t *testing.T) {
 	}
 
 	wxs := f.weather(f.nav.FlightState.Altitude)
-	f.nav.UpdateWithWeather(f.callsign, wxs, &f.fp, f.simTime, nil)
+	f.nav.UpdateWithWeather(f.callsign, wxs, nil, &f.fp, f.simTime, nil)
 	f.AssertLevelFlight()
 
 	f.simTime = f.nav.Altitude.ActivateAt
 	wxs = f.weather(f.nav.FlightState.Altitude)
-	f.nav.UpdateWithWeather(f.callsign, wxs, &f.fp, f.simTime, nil)
+	f.nav.UpdateWithWeather(f.callsign, wxs, nil, &f.fp, f.simTime, nil)
 
 	if f.nav.Altitude.ActiveAssigned == nil || *f.nav.Altitude.ActiveAssigned != 3000 {
 		t.Fatalf("expected ActiveAssigned=3000 after delay, got %v", f.nav.Altitude.ActiveAssigned)
@@ -70,7 +70,7 @@ func TestAssignAltitudeKeepsPreviousActiveAltitudeDuringDelay(t *testing.T) {
 	}
 
 	f.simTime = f.nav.Altitude.ActivateAt
-	f.nav.UpdateWithWeather(f.callsign, f.weather(f.nav.FlightState.Altitude), &f.fp, f.simTime, nil)
+	f.nav.UpdateWithWeather(f.callsign, f.weather(f.nav.FlightState.Altitude), nil, &f.fp, f.simTime, nil)
 	target, _, _ = f.nav.TargetAltitude()
 	if target != 3000 {
 		t.Fatalf("expected new assigned altitude 3000 after delay, got %.0f", target)
@@ -89,7 +89,7 @@ func TestAssignAltitudeKeepsSTARDescentDuringDelay(t *testing.T) {
 
 	for range 300 {
 		wxs := f.weather(f.nav.FlightState.Altitude)
-		f.nav.UpdateWithWeather(f.callsign, wxs, &f.fp, f.simTime, nil)
+		f.nav.UpdateWithWeather(f.callsign, wxs, nil, &f.fp, f.simTime, nil)
 		f.simTime = f.simTime.Add(time.Second)
 		if f.nav.FlightState.AltitudeRate < -50 {
 			break
@@ -153,7 +153,7 @@ func TestExpediteDuringAssignedAltitudeDelay(t *testing.T) {
 	}
 
 	f.simTime = f.nav.Altitude.ActivateAt.Add(time.Second)
-	f.nav.UpdateWithWeather(f.callsign, f.weather(f.nav.FlightState.Altitude), &f.fp, f.simTime, nil)
+	f.nav.UpdateWithWeather(f.callsign, f.weather(f.nav.FlightState.Altitude), nil, &f.fp, f.simTime, nil)
 	if f.nav.Altitude.Rate != RateExpedite {
 		t.Fatalf("expected expedite rate after delayed activation, got %v", f.nav.Altitude.Rate)
 	}
@@ -616,7 +616,7 @@ func TestAltitudeAfterSpeedDelaysAfterSpeedReached(t *testing.T) {
 
 	for range 300 {
 		wxs := f.weather(f.nav.FlightState.Altitude)
-		f.nav.UpdateWithWeather(f.callsign, wxs, &f.fp, f.simTime, nil)
+		f.nav.UpdateWithWeather(f.callsign, wxs, nil, &f.fp, f.simTime, nil)
 		f.simTime = f.simTime.Add(time.Second)
 		if f.nav.Altitude.AfterSpeed == nil {
 			break
@@ -637,7 +637,7 @@ func TestAltitudeAfterSpeedDelaysAfterSpeedReached(t *testing.T) {
 	f.AssertLevelFlight()
 
 	f.simTime = f.nav.Altitude.ActivateAt.Add(time.Second)
-	f.nav.UpdateWithWeather(f.callsign, f.weather(f.nav.FlightState.Altitude), &f.fp, f.simTime, nil)
+	f.nav.UpdateWithWeather(f.callsign, f.weather(f.nav.FlightState.Altitude), nil, &f.fp, f.simTime, nil)
 	if f.nav.Altitude.ActiveAssigned == nil || *f.nav.Altitude.ActiveAssigned != 3000 {
 		t.Fatalf("expected ActiveAssigned=3000 after delayed activation, got %v", f.nav.Altitude.ActiveAssigned)
 	}
@@ -747,7 +747,7 @@ func TestGoodRateDescentFasterThanNormal(t *testing.T) {
 	runForTicks := func(f *FlightTest, ticks int) {
 		for range ticks {
 			wxs := f.weather(f.nav.FlightState.Altitude)
-			f.nav.UpdateWithWeather(f.callsign, wxs, &f.fp, f.simTime, nil)
+			f.nav.UpdateWithWeather(f.callsign, wxs, nil, &f.fp, f.simTime, nil)
 			f.simTime = f.simTime.Add(1e9)
 		}
 	}

--- a/nav/commands_test.go
+++ b/nav/commands_test.go
@@ -180,7 +180,7 @@ func TestExpectDirectReducesDelay(t *testing.T) {
 	// Wait for heading to take effect
 	for i := 0; i < 10; i++ {
 		wxs := fNoExpect.weather(fNoExpect.nav.FlightState.Altitude)
-		fNoExpect.nav.UpdateWithWeather(fNoExpect.callsign, wxs, &fNoExpect.fp, fNoExpect.simTime, nil)
+		fNoExpect.nav.UpdateWithWeather(fNoExpect.callsign, wxs, nil, &fNoExpect.fp, fNoExpect.simTime, nil)
 		fNoExpect.simTime = fNoExpect.simTime.Add(1e9) // 1 second
 	}
 	fNoExpect.nav.DirectFix("DETGY", av.TurnClosest, fNoExpect.simTime, 0)
@@ -191,7 +191,7 @@ func TestExpectDirectReducesDelay(t *testing.T) {
 	fExpect.nav.AssignHeading(math.MagneticHeading(360), av.TurnClosest, fExpect.simTime, 0)
 	for i := 0; i < 10; i++ {
 		wxs := fExpect.weather(fExpect.nav.FlightState.Altitude)
-		fExpect.nav.UpdateWithWeather(fExpect.callsign, wxs, &fExpect.fp, fExpect.simTime, nil)
+		fExpect.nav.UpdateWithWeather(fExpect.callsign, wxs, nil, &fExpect.fp, fExpect.simTime, nil)
 		fExpect.simTime = fExpect.simTime.Add(1e9)
 	}
 	fExpect.nav.ExpectDirect("DETGY")

--- a/nav/hold_test.go
+++ b/nav/hold_test.go
@@ -52,7 +52,7 @@ func TestHoldTurningInboundDoesNotFlyAwayAfterOvershoot(t *testing.T) {
 	}}
 
 	f.nav.UpdateWithWeather(f.callsign, wx.MakeStandardSampleForAltitude(f.nav.FlightState.Altitude),
-		&f.fp, f.simTime, nil)
+		nil, &f.fp, f.simTime, nil)
 	f.simTime = f.simTime.Add(time.Second)
 	if f.nav.Heading.Hold == nil {
 		t.Fatal("hold unexpectedly ended")
@@ -65,7 +65,7 @@ func TestHoldTurningInboundDoesNotFlyAwayAfterOvershoot(t *testing.T) {
 
 	for range 90 {
 		f.nav.UpdateWithWeather(f.callsign, wx.MakeStandardSampleForAltitude(f.nav.FlightState.Altitude),
-			&f.fp, f.simTime, nil)
+			nil, &f.fp, f.simTime, nil)
 		f.simTime = f.simTime.Add(time.Second)
 	}
 
@@ -124,7 +124,7 @@ func TestHoldInboundTurnDistanceMatchesOutboundTurn(t *testing.T) {
 	previousStep := hold.currentStep()
 
 	for tick := range 300 {
-		f.nav.UpdateWithWeather(f.callsign, f.weather(f.nav.FlightState.Altitude), &f.fp, f.simTime, nil)
+		f.nav.UpdateWithWeather(f.callsign, f.weather(f.nav.FlightState.Altitude), nil, &f.fp, f.simTime, nil)
 		f.simTime = f.simTime.Add(time.Second)
 
 		step := hold.currentStep()
@@ -191,7 +191,7 @@ func TestFQM3HoldInboundTurnCompletesNearExpectedTrack(t *testing.T) {
 	flyFixStep := "fly toward fix until fix"
 
 	for tick := range 2000 {
-		f.nav.UpdateWithWeather(f.callsign, f.weather(f.nav.FlightState.Altitude), &f.fp, f.simTime, nil)
+		f.nav.UpdateWithWeather(f.callsign, f.weather(f.nav.FlightState.Altitude), nil, &f.fp, f.simTime, nil)
 		f.simTime = f.simTime.Add(time.Second)
 
 		if f.nav.Heading.Hold != nil && hold == nil {
@@ -311,7 +311,7 @@ func TestHoldInboundTurnCompletesAfterHalfCircuitWithStrongWind(t *testing.T) {
 	inboundTurnStartTick := -1
 
 	for tick := range 240 {
-		f.nav.UpdateWithWeather(f.callsign, f.weather(f.nav.FlightState.Altitude), &f.fp, f.simTime, nil)
+		f.nav.UpdateWithWeather(f.callsign, f.weather(f.nav.FlightState.Altitude), nil, &f.fp, f.simTime, nil)
 		f.simTime = f.simTime.Add(time.Second)
 
 		step := hold.currentStep()

--- a/nav/lateral.go
+++ b/nav/lateral.go
@@ -121,13 +121,17 @@ func (nav *Nav) Check(lg *log.Logger) {
 }
 
 func (nav *Nav) Update(callsign string, model *wx.Model, fp *av.FlightPlan, simTime Time, bravo *av.AirspaceGrid) UpdateResult {
-	// Perform single weather lookup at the start
 	wxs := model.Lookup(nav.FlightState.Position, nav.FlightState.Altitude, simTime.Time())
-	return nav.UpdateWithWeather(callsign, wxs, fp, simTime, bravo)
+	var arrivalMETAR *wx.METAR
+	if fp != nil && fp.ArrivalAirport != "" {
+		arrivalMETAR = model.AirportMETARForTime(fp.ArrivalAirport, simTime.Time())
+	}
+	return nav.UpdateWithWeather(callsign, wxs, arrivalMETAR, fp, simTime, bravo)
 }
 
-// UpdateWithWeather is a helper for simulations that use pre-fetched weather
-func (nav *Nav) UpdateWithWeather(callsign string, wxs wx.Sample, fp *av.FlightPlan, simTime Time, bravo *av.AirspaceGrid) UpdateResult {
+// UpdateWithWeather is a helper for simulations that use pre-fetched weather.
+// arrivalMETAR, if non-nil, is used for the approach speed wind additive.
+func (nav *Nav) UpdateWithWeather(callsign string, wxs wx.Sample, arrivalMETAR *wx.METAR, fp *av.FlightPlan, simTime Time, bravo *av.AirspaceGrid) UpdateResult {
 	nav.PendingWaypointActionEvents = nil
 	nav.activatePendingAltitude(simTime)
 
@@ -139,7 +143,7 @@ func (nav *Nav) UpdateWithWeather(callsign string, wxs wx.Sample, fp *av.FlightP
 		nav.FlightState.BankAngle, nav.FlightState.AltitudeRate)
 
 	targetAltitude, altitudeRate, geometricDescent := nav.TargetAltitude()
-	deltaKts, slowingTo250 := nav.updateAirspeed(callsign, targetAltitude, geometricDescent, fp, wxs, simTime, bravo)
+	deltaKts, slowingTo250 := nav.updateAirspeed(callsign, targetAltitude, geometricDescent, fp, wxs, arrivalMETAR, simTime, bravo)
 	nav.updateAltitude(callsign, targetAltitude, altitudeRate, geometricDescent, deltaKts, slowingTo250, wxs, simTime)
 	nav.updateHeading(callsign, wxs, simTime)
 	nav.updatePositionAndGS(wxs)
@@ -722,7 +726,7 @@ func (nav *Nav) shouldTurnForOutbound(p math.Point2LL, hdg math.MagneticHeading,
 	// Don't simulate the turn longer than it will take to do it.
 	n := int(1 + turnAngle/3)
 	for range n {
-		nav2.UpdateWithWeather("", wxs, nil, Time{}, nil)
+		nav2.UpdateWithWeather("", wxs, nil, nil, Time{}, nil)
 		curDist := math.SignedPointLineDistance(math.LL2NM(nav2.FlightState.Position,
 			nav2.FlightState.NmPerLongitude),
 			p0, p1)
@@ -778,7 +782,7 @@ func (nav *Nav) shouldTurnToIntercept(p0 math.Point2LL, hdg math.MagneticHeading
 	n := int(1 + turnAngle)
 	lastDist := initialDist
 	for range n {
-		nav2.UpdateWithWeather("", wxs, nil, Time{}, nil)
+		nav2.UpdateWithWeather("", wxs, nil, nil, Time{}, nil)
 		curDist := math.SignedPointLineDistance(math.LL2NM(nav2.FlightState.Position, nav2.FlightState.NmPerLongitude), p0nm, p1)
 
 		intercepted := math.Abs(curDist) < 0.02

--- a/nav/nav.go
+++ b/nav/nav.go
@@ -750,7 +750,7 @@ func (nav *Nav) Summary(fp av.FlightPlan, model *wx.Model, simTime Time, lg *log
 	targetAltitude, _, _ := nav.TargetAltitude()
 	lines = append(lines, fmt.Sprintf("IAS %d GS %d TAS %d", int(nav.FlightState.IAS),
 		int(nav.FlightState.GS), int(nav.TAS(wxs.Temperature()))))
-	ias, _ := nav.TargetSpeed(targetAltitude, &fp, wxs, nil)
+	ias, _ := nav.TargetSpeed(targetAltitude, &fp, wxs, nil, nil)
 	if nav.Speed.MaintainSlowestPractical {
 		lines = append(lines, fmt.Sprintf("Maintain slowest practical speed: %.0f kts", ias))
 	} else if nav.Speed.MaintainMaximumForward {

--- a/nav/nav_test.go
+++ b/nav/nav_test.go
@@ -311,7 +311,7 @@ func (f *FlightTest) Run() {
 
 	for f.tick = 0; f.tick < f.maxTicks; f.tick++ {
 		wxs := f.weather(f.nav.FlightState.Altitude)
-		passedWp := f.nav.UpdateWithWeather(f.callsign, wxs, &f.fp, f.simTime, nil).PassedWaypoint
+		passedWp := f.nav.UpdateWithWeather(f.callsign, wxs, nil, &f.fp, f.simTime, nil).PassedWaypoint
 
 		if passedWp != nil {
 			f.passed = append(f.passed, passedWp.Fix)

--- a/nav/pt_test.go
+++ b/nav/pt_test.go
@@ -146,7 +146,7 @@ func TestStandard45ProcedureTurnCompletes(t *testing.T) {
 	f := makePTFlight(t, "FORMU/pt45/flyover ZIVUX WENGA", 3000, 180)
 
 	wxs := f.weather(f.nav.FlightState.Altitude)
-	f.nav.UpdateWithWeather(f.callsign, wxs, &f.fp, f.simTime, nil)
+	f.nav.UpdateWithWeather(f.callsign, wxs, nil, &f.fp, f.simTime, nil)
 	f.simTime = f.simTime.Add(time.Second)
 
 	f.nav.flyProcedureTurnIfNecessary()
@@ -180,7 +180,7 @@ func TestRacetrackPTCreatesManeuvers(t *testing.T) {
 	f := makePTFlight(t, "FORMU/hilpt4.0nm/flyover ZIVUX WENGA", 3000, 180)
 
 	wxs := f.weather(f.nav.FlightState.Altitude)
-	f.nav.UpdateWithWeather(f.callsign, wxs, &f.fp, f.simTime, nil)
+	f.nav.UpdateWithWeather(f.callsign, wxs, nil, &f.fp, f.simTime, nil)
 	f.simTime = f.simTime.Add(time.Second)
 
 	f.nav.flyProcedureTurnIfNecessary()
@@ -231,7 +231,7 @@ func TestProcedureTurnDescendsToExitAltitude(t *testing.T) {
 	f := makePTFlight(t, "FORMU/pt45/pta2000/flyover ZIVUX WENGA", 3000, 180)
 
 	wxs := f.weather(f.nav.FlightState.Altitude)
-	f.nav.UpdateWithWeather(f.callsign, wxs, &f.fp, f.simTime, nil)
+	f.nav.UpdateWithWeather(f.callsign, wxs, nil, &f.fp, f.simTime, nil)
 	f.simTime = f.simTime.Add(time.Second)
 
 	f.nav.flyProcedureTurnIfNecessary()

--- a/nav/speed.go
+++ b/nav/speed.go
@@ -10,11 +10,11 @@ import (
 	"github.com/mmp/vice/wx"
 )
 
-func (nav *Nav) updateAirspeed(callsign string, alt float32, geometricDescent bool, fp *av.FlightPlan, wxs wx.Sample, simTime Time, bravo *av.AirspaceGrid) (float32, bool) {
+func (nav *Nav) updateAirspeed(callsign string, alt float32, geometricDescent bool, fp *av.FlightPlan, wxs wx.Sample, arrivalMETAR *wx.METAR, simTime Time, bravo *av.AirspaceGrid) (float32, bool) {
 	// Figure out what speed we're supposed to be going. The following is
 	// prioritized, so once targetSpeed has been set, nothing should
 	// override it.
-	targetSpeed, targetRate := nav.TargetSpeed(alt, fp, wxs, bravo)
+	targetSpeed, targetRate := nav.TargetSpeed(alt, fp, wxs, arrivalMETAR, bravo)
 
 	// Stay within the aircraft's capabilities
 	targetSpeed = math.Clamp(targetSpeed, nav.Perf.Speed.Min, MaxIAS)
@@ -100,7 +100,7 @@ func (nav *Nav) updateAirspeed(callsign string, alt float32, geometricDescent bo
 		return 0, false
 	}
 }
-func (nav *Nav) TargetSpeed(targetAltitude float32, fp *av.FlightPlan, wxs wx.Sample, bravo *av.AirspaceGrid) (float32, float32) {
+func (nav *Nav) TargetSpeed(targetAltitude float32, fp *av.FlightPlan, wxs wx.Sample, arrivalMETAR *wx.METAR, bravo *av.AirspaceGrid) (float32, float32) {
 	if nav.Airwork != nil {
 		if spd, rate, ok := nav.Airwork.TargetSpeed(); ok {
 			return spd, rate
@@ -253,7 +253,21 @@ func (nav *Nav) TargetSpeed(targetAltitude float32, fp *av.FlightPlan, wxs wx.Sa
 	// last half mile before touchdown.
 	if nav.Speed.Assigned == nil && fd != 0 && fd < 10 {
 		hdg := nav.Approach.Assigned.RunwayHeading(nav.FlightState.NmPerLongitude)
-		approachSpeed := nav.Perf.ApproachSpeed(float32(wxs.WindDirection()), wxs.WindSpeed(), 0 /* FIXME: GUST */, float32(hdg))
+		var approachSpeed float32
+		if arrivalMETAR != nil {
+			windDir := float32(0) // treat variable winds as unknown direction (zero headwind component)
+			if arrivalMETAR.WindDir != nil {
+				windDir = float32(*arrivalMETAR.WindDir)
+			}
+			windSpeed := float32(arrivalMETAR.WindSpeed)
+			windGust := windSpeed // default: no gust above steady wind
+			if arrivalMETAR.WindGust != nil && *arrivalMETAR.WindGust > arrivalMETAR.WindSpeed {
+				windGust = float32(*arrivalMETAR.WindGust)
+			}
+			approachSpeed = nav.Perf.ApproachSpeed(windDir, windSpeed, windGust, float32(hdg))
+		} else {
+			approachSpeed = nav.Perf.ApproachSpeed(float32(wxs.WindDirection()), wxs.WindSpeed(), 0, float32(hdg))
+		}
 
 		if fd < 0.5 {
 			// Short final: slow down to landing speed.

--- a/nav/speed_test.go
+++ b/nav/speed_test.go
@@ -135,7 +135,7 @@ func TestAssignedAtOrAboveSpeedDoesNotAccelerateWhenAlreadyCompliant(t *testing.
 	f.nav.AssignSpeed(&sr, false)
 
 	targetAltitude, _, _ := f.nav.TargetAltitude()
-	targetSpeed, _ := f.nav.TargetSpeed(targetAltitude, &f.fp, f.weather(f.nav.FlightState.Altitude), nil)
+	targetSpeed, _ := f.nav.TargetSpeed(targetAltitude, &f.fp, f.weather(f.nav.FlightState.Altitude), nil, nil)
 	if targetSpeed != f.nav.FlightState.IAS {
 		t.Fatalf("target speed = %.0f, want current compliant speed %.0f", targetSpeed, f.nav.FlightState.IAS)
 	}
@@ -156,7 +156,7 @@ func TestAssignedAtOrBelowSpeedDoesNotAccelerateWhenAlreadyCompliant(t *testing.
 	f.nav.AssignSpeed(&sr, false)
 
 	targetAltitude, _, _ := f.nav.TargetAltitude()
-	targetSpeed, _ := f.nav.TargetSpeed(targetAltitude, &f.fp, f.weather(f.nav.FlightState.Altitude), nil)
+	targetSpeed, _ := f.nav.TargetSpeed(targetAltitude, &f.fp, f.weather(f.nav.FlightState.Altitude), nil, nil)
 	if targetSpeed != f.nav.FlightState.IAS {
 		t.Fatalf("target speed = %.0f, want current compliant speed %.0f", targetSpeed, f.nav.FlightState.IAS)
 	}
@@ -197,7 +197,7 @@ func TestVisualApproachSpeedUntilFiveMileFinal(t *testing.T) {
 	}
 
 	targetAltitude, _, _ := f.nav.TargetAltitude()
-	spd, _ := f.nav.TargetSpeed(targetAltitude, &f.fp, f.weather(f.nav.FlightState.Altitude), nil)
+	spd, _ := f.nav.TargetSpeed(targetAltitude, &f.fp, f.weather(f.nav.FlightState.Altitude), nil, nil)
 	if f.nav.Speed.Assigned == nil {
 		t.Fatal("speed restriction cleared too early at 7 NM from threshold")
 	}
@@ -215,7 +215,7 @@ func TestVisualApproachSpeedUntilFiveMileFinal(t *testing.T) {
 		t.Fatalf("at 4 NM final: DistanceToEndOfApproach = %.2f, want ~4", d)
 	}
 
-	f.nav.TargetSpeed(targetAltitude, &f.fp, f.weather(f.nav.FlightState.Altitude), nil)
+	f.nav.TargetSpeed(targetAltitude, &f.fp, f.weather(f.nav.FlightState.Altitude), nil, nil)
 	if f.nav.Speed.Assigned != nil {
 		t.Errorf("speed restriction should be cleared inside 5 NM final, still set to %v", f.nav.Speed.Assigned)
 	}

--- a/sim/spawn_departures.go
+++ b/sim/spawn_departures.go
@@ -885,7 +885,7 @@ func (s *Sim) createUncontrolledVFRDeparture(depart, arrive, fleet string, route
 	prespawnWxs := s.wxModel.Lookup(simNav.FlightState.Position,
 		simNav.FlightState.Altitude, simTime.Time())
 	for i := range 3 * 60 * 60 { // limit to 3 hours of sim time, just in case
-		if wp := simNav.UpdateWithWeather("", prespawnWxs, &simFP,
+		if wp := simNav.UpdateWithWeather("", prespawnWxs, nil, &simFP,
 			simTime.NavTime(), nil).PassedWaypoint; wp != nil {
 			if wp.Delete() {
 				return ac, rwy.Id, nil

--- a/wx/model.go
+++ b/wx/model.go
@@ -25,6 +25,9 @@ type Model struct {
 
 	mu sync.Mutex
 	lg *log.Logger
+
+	metarCache   map[string][]METAR
+	metarCacheMu sync.Mutex
 }
 
 type AtmosResult struct {
@@ -152,4 +155,31 @@ func (m *Model) GetAtmosGrid() *AtmosGrid {
 	}
 
 	return m.grids[0]
+}
+
+// AirportMETARForTime returns the METAR closest to t for the given airport
+// ICAO. Returns nil if no METAR data is available. The decoded METAR slice
+// is cached per airport after the first lookup.
+func (m *Model) AirportMETARForTime(icao string, t time.Time) *METAR {
+	m.metarCacheMu.Lock()
+	if m.metarCache == nil {
+		m.metarCache = make(map[string][]METAR)
+	}
+	metars, cached := m.metarCache[icao]
+	if !cached {
+		metarMap, err := GetMETAR([]string{icao})
+		if err == nil {
+			if soa, ok := metarMap[icao]; ok {
+				metars = soa.Decode(icao)
+			}
+		}
+		m.metarCache[icao] = metars
+	}
+	m.metarCacheMu.Unlock()
+
+	if len(metars) == 0 {
+		return nil
+	}
+	metar := METARForTime(metars, t)
+	return &metar
 }


### PR DESCRIPTION
Use METAR wind data (including gusts) from the arrival airport when computing approach speed, instead of the weather sample at the aircraft's current position. Caches decoded METARs per airport in the wx.Model to avoid repeated fetches.