### PR TITLE
sim: add optional scenario description displayed in new sim window

### DIFF
--- a/cmd/vice/simconfig.go
+++ b/cmd/vice/simconfig.go
@@ -941,6 +941,15 @@ func (c *NewSimConfiguration) DrawScenarioSelectionUI(p platform.Platform, confi
 				}
 			}
 		}
+		if desc := c.ScenarioSpec.Description; desc != "" {
+			imgui.Spacing()
+			imgui.Separator()
+			imgui.Spacing()
+			if imgui.BeginChildStrV("scenario_desc", imgui.Vec2{0, 0}, imgui.ChildFlagsBorders|imgui.ChildFlagsAutoResizeY, 0) {
+				imgui.TextWrapped(desc)
+			}
+			imgui.EndChild()
+		}
 		// Configuration options (initials, checkboxes, METAR) are now on Screen 2
 	} else {
 		// Join remote

--- a/resources/scenarios/bos.json
+++ b/resources/scenarios/bos.json
@@ -78217,6 +78217,7 @@
       }
     },
     "FV BOS 27 ": {
+      "description": "Give the tower either 2.5NM in-trail at the threshold or 6NM+ at the threshold.\n\nKeep an eye on how the wind affects each final (33L vs 27). It will be important to get proper spacing with arrivals requesting 33L",
       "arrival_runways": [
         {
           "airport": "KBOS",

--- a/server/manager.go
+++ b/server/manager.go
@@ -66,6 +66,7 @@ type ScenarioSpec struct {
 
 	LaunchConfig sim.LaunchConfig
 
+	Description      string
 	DepartureRunways []sim.DepartureRunway
 	ArrivalRunways   []sim.ArrivalRunway
 }

--- a/server/scenario.go
+++ b/server/scenario.go
@@ -81,6 +81,7 @@ type scenario struct {
 
 	Airspace map[sim.TCP][]string `json:"airspace"`
 
+	Description      string                `json:"description,omitempty"`
 	DepartureRunways []sim.DepartureRunway `json:"departure_runways,omitempty"`
 	ArrivalRunways   []sim.ArrivalRunway   `json:"arrival_runways,omitempty"`
 
@@ -1742,6 +1743,7 @@ func initializeSimConfigurations(sg *scenarioGroup, catalogs map[string]map[stri
 		spec := &ScenarioSpec{
 			ControllerConfiguration: &scenario.ControllerConfiguration,
 			LaunchConfig:            lc,
+			Description:             scenario.Description,
 			DepartureRunways:        scenario.DepartureRunways,
 			ArrivalRunways:          scenario.ArrivalRunways,
 			PrimaryAirport:          sg.PrimaryAirport,


### PR DESCRIPTION
Adds a "description" field to scenario JSON that scenario developers can use to describe goals, tips, or context for the scenario. When present, it is shown in the new simulation selection window below the landing runways section in its own auto-sized bordered box. 