### PR TITLE
fix: skip tags that contain beta

### DIFF
--- a/cmd/vice/dialogs.go
+++ b/cmd/vice/dialogs.go
@@ -404,7 +404,7 @@ func checkForNewRelease(newReleaseDialogChan chan *NewReleaseModalClient, config
 
 	var newestRelease *Release
 	for i := range releases {
-		if strings.HasSuffix(releases[i].TagName, "-beta") {
+		if strings.Contains(releases[i].TagName, "-beta") {
 			continue
 		}
 		if newestRelease == nil || releases[i].Created.After(newestRelease.Created) {


### PR DESCRIPTION
Fix release checker logic from telling users a beta version is newer

<img width="472" height="184" alt="image" src="https://github.com/user-attachments/assets/23463d64-01d9-4170-8725-fdeb63392f32" />
