### PR TITLE
Fix PHL scenario PHL_N_HIGH27 Pottstown sector altitude range

### DIFF
--- a/resources/scenarios/phl.json
+++ b/resources/scenarios/phl.json
@@ -3643,7 +3643,7 @@
         },
         {
           "boundaries": ["PHL_NH27_6_W"],
-          "lower": 13000,
+          "lower": 9000,
           "upper": 13000
         },
         {


### PR DESCRIPTION
Hi, I think there was a tiny error in the Philadelphia scenario.

The previous boundary contained only 13000 feet. The correct range is from 9000 to 13000, just above the PHL_N_APP27 sector that goes up to 8000.

The segment that is to the south of this one is correct with only 13000, as the airspace up to 1200 is covered by the departure sectors.