### PR TITLE
Added PHL_S_HIGH27 missing sector from 11000 to 12000.

### DIFF
--- a/resources/scenarios/phl.json
+++ b/resources/scenarios/phl.json
@@ -4173,6 +4173,11 @@
           "upper": 12000
         },
         {
+          "boundaries": ["PHL_SD27_50_45"],
+          "lower": 11000,
+          "upper": 12000
+        },
+        {
           "boundaries": ["PHL_SD27_50_N"],
           "lower": 11000,
           "upper": 12000


### PR DESCRIPTION
There is a sector missing just after westbound departure at from 10000 to 12000 feet. It is present for the _low_ departure but missing for the _high_ departure. However, Philadelphia TRACON airspace goes up to 12000 feet and this sector is missing.