### PR TITLE
Adjust ERAM Datablock Leader Line Alignment

### DIFF
--- a/eram/datablock.go
+++ b/eram/datablock.go
@@ -97,29 +97,36 @@ func dbChopTrailing(f []dbChar) []dbChar {
 func dbDrawLines(lines []dbLine, td *renderer.TextDrawBuilder, pt [2]float32,
 	font *renderer.Font, sb *strings.Builder, brightness radar.Brightness,
 	dir math.CardinalOrdinalDirection, halfSeconds int64) {
-	scale := float32(dbLineOffsetScale) // 1.5 for default font
-	if len(lines) >= 5 {
-		if lines[3].ch[0].ch != rune('R') {
-			scale = dbLineOffsetScale
-		}
-	}
 	glyph := font.LookupGlyph(' ')
-	fontWidth := glyph.AdvanceX * scale
+	fontWidth := glyph.AdvanceX * dbLineOffsetScale
 
 	for i, line := range lines {
-		// All lines start at the same position
-		xOffset := float32(0)
-
-		// Special case: line 3 (index 3) starts 1 character to the left
-		if i == 2 || i == 3 {
-			xOffset -= fontWidth
-		}
-		lineSpacing := dbLineSpacing
 		sb.Reset()
-		dbDrawLine(line, td, math.Add2f(pt, [2]float32{xOffset, 0}), font, sb,
-			brightness, halfSeconds)
-		pt[1] -= float32(font.Size) * float32(lineSpacing)
+		if i == dbVCILine || i == dbCIDLine {
+			lead, rest := dbSplitLine(line, dbLeadFieldChars)
+			dbDrawLine(lead, td, math.Add2f(pt, [2]float32{-fontWidth - dbLeadFieldGap*glyph.AdvanceX, 0}),
+				font, sb, brightness, halfSeconds)
+			sb.Reset()
+			dbDrawLine(rest, td, pt, font, sb, brightness, halfSeconds)
+		} else {
+			dbDrawLine(line, td, pt, font, sb, brightness, halfSeconds)
+		}
+		pt[1] -= float32(font.Size) * dbLineSpacing
 	}
+}
+
+func dbSplitLine(l dbLine, n int) (dbLine, dbLine) {
+	var lead, rest dbLine
+	for i := range l.length {
+		if i < n {
+			lead.ch[lead.length] = l.ch[i]
+			lead.length++
+		} else {
+			rest.ch[rest.length] = l.ch[i]
+			rest.length++
+		}
+	}
+	return lead, rest
 }
 
 // dbDrawLine renders a single datablock line.
@@ -225,6 +232,59 @@ func (db fullDatablock) draw(td *renderer.TextDrawBuilder, pt [2]float32,
 	}
 	pt[1] += float32(font.Size)
 	dbDrawLines(lines, td, pt, font, sb, brightness, dir, halfSeconds)
+}
+
+func (db *fullDatablock) ownershipSymbolCol() (int, bool) {
+	for i, ch := range db.col1 {
+		if ch.ch == 'R' {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+func dbOwnershipOverhang(font *renderer.Font, col int) float32 {
+	w := font.LookupGlyph(' ').AdvanceX
+	return w*(dbLineOffsetScale-float32(col)) + w*dbLeadFieldGap
+}
+
+func (db *fullDatablock) leadOverhang(font *renderer.Font) float32 {
+	if col, drawn := db.ownershipSymbolCol(); drawn {
+		return dbOwnershipOverhang(font, col)
+	}
+	return 0
+}
+
+func (db *fullDatablock) mainWidth(font *renderer.Font) float32 {
+	var lines [5]dbLine
+	fullDatablockLines(db, &lines)
+	cols := 0
+	for i := range lines {
+		n := lines[i].Len()
+		if i == dbVCILine || i == dbCIDLine {
+			n -= dbLeadFieldChars
+		}
+		cols = max(cols, n)
+	}
+	if cols == 0 {
+		return 0
+	}
+	return float32(cols-1)*font.LookupGlyph(' ').AdvanceX + font.LookupGlyph('0').Width()
+}
+
+func datablockXOffset(dir math.CardinalOrdinalDirection, db *fullDatablock, font *renderer.Font) float32 {
+	clearance := dbLeaderClearance * font.LookupGlyph(' ').AdvanceX
+	switch dir {
+	case math.West, math.NorthWest, math.SouthWest:
+		return -(db.mainWidth(font) + clearance)
+	case math.North, math.South:
+		if over := db.leadOverhang(font); over > 0 {
+			return over - font.LookupGlyph('0').Width()/2
+		}
+		return clearance
+	default:
+		return clearance
+	}
 }
 
 // dimChars scales the color of every populated character in the field.
@@ -564,7 +624,7 @@ func (ep *ERAMPane) drawDatablocks(tracks []sim.Track, dbs map[av.ADSBCallsign]d
 				sz = ps.LDBSize
 			}
 			font := ep.ERAMFont(sz)
-			end, dir := ep.datablockAnchor(ctx, *trk, dbType, transforms)
+			end, dir := ep.datablockAnchor(ctx, *trk, db, dbType, transforms)
 			brightness := ep.datablockBrightness(state)
 			db.draw(td, end, font, &sb, brightness, dir, halfSeconds)
 		}
@@ -581,7 +641,7 @@ func (ep *ERAMPane) drawDatablocks(tracks []sim.Track, dbs map[av.ADSBCallsign]d
 // datablockAnchor returns the window-space anchor point used by both the
 // datablock renderer and the hover-outline computation. It also returns the
 // (possibly adjusted) direction the datablock was placed in.
-func (ep *ERAMPane) datablockAnchor(ctx *panes.Context, trk sim.Track, dbType DatablockType,
+func (ep *ERAMPane) datablockAnchor(ctx *panes.Context, trk sim.Track, db datablock, dbType DatablockType,
 	transforms radar.ScopeTransformations) ([2]float32, math.CardinalOrdinalDirection) {
 	state := ep.TrackState[trk.ADSBCallsign]
 	start := transforms.WindowFromLatLongP(state.Track.Location)
@@ -595,55 +655,43 @@ func (ep *ERAMPane) datablockAnchor(ctx *panes.Context, trk sim.Track, dbType Da
 		}
 	}
 
-	offset := datablockOffset(*dir)
 	vector := ep.leaderLineVectorWithLength(*dir, lengthMode)
 
-	// For mode 0, adjust positioning based on direction
-	if lengthMode == 0 {
-		if *dir == math.East {
-			offset[0] += 25 // Move right
-			offset[1] -= 10 // Move down
-		}
+	ps := ep.currentPrefs()
+	font := ep.ERAMFont(util.Select(dbType == FullDatablock, ps.FDBSize, ps.LDBSize))
+	dy := datablockLeaderConnectOffset(*dir, font)
+
+	var offset [2]float32
+	if fdb, ok := db.(*fullDatablock); ok {
+		offset[0] = datablockXOffset(*dir, fdb, font)
 	}
+
+	if lengthMode == 0 && *dir == math.East {
+		offset[0] += 2 * font.LookupGlyph(' ').AdvanceX
+	}
+
 	if dbType == EnhancedLimitedDatablock || dbType == LimitedDatablock {
 		*dir = math.East // TODO: change to state eventually
 		vector = ep.leaderLineVectorNoLength(*dir)
 		offset[1] = -10
+		dy = 0
 	}
 	end := math.Add2f(start, math.Scale2f(vector, ctx.DrawPixelScale))
-	end[0] += float32(offset[0]) * ctx.DrawPixelScale
-	end[1] += float32(offset[1]) * ctx.DrawPixelScale
+	end[0] += offset[0]
+	end[1] += offset[1]*ctx.DrawPixelScale + dy
 	return end, *dir
 }
 
-func datablockOffset(dir math.CardinalOrdinalDirection) [2]float32 {
-	var offset [2]float32
-	switch dir {
-	case math.North:
-		offset[0] = 5
-		offset[1] = 40
-	case math.NorthEast:
-		offset[0] = 10
-		offset[1] = 40
-	case math.NorthWest:
-		offset[0] = -80
-		offset[1] = 25
-	case math.East:
-		offset[1] = 35
-	case math.West:
-		offset[0] = -80
-		offset[1] = 25
-	case math.SouthEast:
-		offset[1] = 15
-		offset[0] = 10
-	case math.South:
-		offset[0] = 4
-		offset[1] = 16
-	case math.SouthWest:
-		offset[0] = -80
-		offset[1] = 15
+func datablockLeaderConnectOffset(dir math.CardinalOrdinalDirection, font *renderer.Font) float32 {
+	inkTop := func(line float32) float32 {
+		return (line*dbLineSpacing - 1 + dbLeaderInkInset) * float32(font.Size)
 	}
-	return offset
+	switch dir {
+	case math.South, math.SouthEast, math.SouthWest:
+		return inkTop(dbCallsignLine) + dbInkHeight*float32(font.Size)
+	default:
+		return inkTop(dbCIDLine)
+	}
 }
 
 // shortFieldERAMID returns the ERAM Field E sector identifier for a

--- a/eram/outlines.go
+++ b/eram/outlines.go
@@ -130,7 +130,7 @@ func (ep *ERAMPane) drawOutlineRectangle(ld *renderer.ColoredLinesDrawBuilder, e
 // LineExtent returns the outline for a full line of the specified width.
 func (l DatablockLayout) LineExtent(line, cols int) math.Extent2D {
 	top := l.lineTop(line)
-	x0 := l.Anchor[0] + l.lineShift(line)
+	x0 := l.Anchor[0] + l.lineShift(line, 0)
 	x1 := x0 + l.CharWidth*float32(cols)
 	y0 := top - l.LineHeight
 	return math.Extent2D{P0: [2]float32{x0, y0}, P1: [2]float32{x1, top}}
@@ -139,7 +139,7 @@ func (l DatablockLayout) LineExtent(line, cols int) math.Extent2D {
 // FieldExtent returns the outline for the specified field.
 func (l DatablockLayout) FieldExtent(spec DatablockFieldSpec) math.Extent2D {
 	top := l.lineTop(spec.Line)
-	x0 := l.Anchor[0] + l.lineShift(spec.Line) + l.CharWidth*float32(spec.Col)
+	x0 := l.Anchor[0] + l.lineShift(spec.Line, spec.Col) + l.CharWidth*float32(spec.Col)
 	x1 := x0 + l.CharWidth*float32(spec.Cols)
 	y0 := top - l.LineHeight
 	return math.Extent2D{P0: [2]float32{x0, y0}, P1: [2]float32{x1, top}}
@@ -149,11 +149,14 @@ func (l DatablockLayout) lineTop(line int) float32 {
 	return l.Anchor[1] + l.LineHeight - float32(line)*l.LineHeight*l.LineSpacing
 }
 
-func (l DatablockLayout) lineShift(line int) float32 {
-	if line == 2 || line == 3 {
-		return -l.CharWidth * dbLineOffsetScale
+func (l DatablockLayout) lineShift(line, col int) float32 {
+	if line != dbVCILine && line != dbCIDLine {
+		return 0
 	}
-	return 0
+	if col < dbLeadFieldChars {
+		return -l.CharWidth * (dbLineOffsetScale + dbLeadFieldGap)
+	}
+	return -l.CharWidth * dbLeadFieldChars
 }
 
 // DatablockOutlines provides field and line outlines for a datablock.
@@ -168,6 +171,16 @@ const (
 	dbLineOffsetScale = 2
 	dbOutlinePadding  = 2
 	dbOutlineYOffset  = -2
+
+	dbCallsignLine   = 1
+	dbVCILine        = 2
+	dbCIDLine        = 3
+	dbLeadFieldChars = 2
+
+	dbLeadFieldGap    = 1.0 / 3.0
+	dbLeaderClearance = 0.5
+	dbInkHeight       = 0.85
+	dbLeaderInkInset  = 0.2
 )
 
 // dbFieldSpan returns the column span [start, start+n) of the visible
@@ -217,11 +230,6 @@ func (ep *ERAMPane) FullDatablockOutlines(ctx *panes.Context, trk sim.Track,
 	if ep.datablockType(ctx, trk) != FullDatablock {
 		return DatablockOutlines{}, false
 	}
-	anchor, ok := ep.fullDatablockAnchor(ctx, trk, transforms)
-	if !ok {
-		return DatablockOutlines{}, false
-	}
-
 	ps := ep.currentPrefs()
 	font := ep.ERAMFont(ps.FDBSize)
 	if font == nil {
@@ -230,6 +238,11 @@ func (ep *ERAMPane) FullDatablockOutlines(ctx *panes.Context, trk sim.Track,
 
 	fdb := ep.buildFullDatablock(ctx, trk)
 	if fdb == nil {
+		return DatablockOutlines{}, false
+	}
+
+	anchor, ok := ep.fullDatablockAnchor(ctx, trk, fdb, transforms)
+	if !ok {
 		return DatablockOutlines{}, false
 	}
 
@@ -327,12 +340,12 @@ func (ep *ERAMPane) FullDatablockOutlines(ctx *panes.Context, trk sim.Track,
 	return outlines, true
 }
 
-func (ep *ERAMPane) fullDatablockAnchor(ctx *panes.Context, trk sim.Track,
+func (ep *ERAMPane) fullDatablockAnchor(ctx *panes.Context, trk sim.Track, db *fullDatablock,
 	transforms radar.ScopeTransformations) ([2]float32, bool) {
 	if ep.TrackState[trk.ADSBCallsign] == nil {
 		return [2]float32{}, false
 	}
-	end, _ := ep.datablockAnchor(ctx, trk, FullDatablock, transforms)
+	end, _ := ep.datablockAnchor(ctx, trk, db, FullDatablock, transforms)
 	return end, true
 }
 

--- a/eram/track.go
+++ b/eram/track.go
@@ -521,6 +521,7 @@ func (ep *ERAMPane) drawLeaderLines(ctx *panes.Context, tracks []sim.Track, dbs 
 	ld := renderer.GetColoredLinesDrawBuilder()
 	defer renderer.ReturnColoredLinesDrawBuilder(ld)
 	cb.LineWidth(2, ctx.DPIScale)
+	font := ep.ERAMFont(ep.currentPrefs().FDBSize)
 	for _, trk := range tracks {
 		db := dbs[trk.ADSBCallsign]
 		if db == nil {
@@ -546,13 +547,27 @@ func (ep *ERAMPane) drawLeaderLines(ctx *panes.Context, tracks []sim.Track, dbs 
 		}
 
 		v := util.Select(dbType == FullDatablock, ep.leaderLineVectorWithLength(*dir, state.LeaderLineLength), ep.leaderLineVectorNoLength(*dir))
-		if dbType == FullDatablock {
-			if !ctx.UserOwnsFlightPlan(trk.FlightPlan) && (*dir == math.NorthEast || *dir == math.East) {
-				v = math.Scale2f(v, 0.7) // shorten the leader line for FDBs that are not tracked by the user
+		pv := math.Scale2f(v, ctx.DrawPixelScale)
+
+		if fdb, ok := db.(*fullDatablock); ok && dbType == FullDatablock {
+			if over, l := fdb.leadOverhang(font), math.Length2f(pv); over > 0 {
+				var pull float32
+				switch *dir {
+				case math.East, math.NorthEast:
+					if pv[0] > 0 {
+						pull = over * l / pv[0]
+					}
+				case math.North:
+					pull = dbInkHeight*float32(font.Size) + dbLeaderClearance*font.LookupGlyph(' ').AdvanceX
+				}
+				if pull > 0 && l > pull {
+					pv = math.Scale2f(pv, (l-pull)/l)
+				}
 			}
 		}
 
-		p1 := math.Add2f(p0, math.Scale2f(v, ctx.DrawPixelScale))
+		p0[1] += 0.5
+		p1 := math.Add2f(p0, pv)
 		if dbType == FullDatablock {
 			ld.AddLine(p0, p1, color)
 		}


### PR DESCRIPTION
I noticed in vice, ERAM data blocks were misaligned with the leader line, causing it to look off, and sometimes clipping with elements of the data block. Below are examples.
<img width="113" height="89" alt="image" src="https://github.com/user-attachments/assets/eb2b6069-ed98-48de-b653-ba1db4c6fce1" /> 
<img width="129" height="173" alt="image" src="https://github.com/user-attachments/assets/11192928-87c6-4688-8576-3129320b86d9" /> 
<img width="110" height="110" alt="image" src="https://github.com/user-attachments/assets/204754c6-c83b-4800-90a8-4935a544a5a1" />



Basically, instead of the geometry needing to be tuned by per-direction pixel constants (which drifted depending on font size), now the placement is derviced from the font metrics, and the data block contents.

I made all my tests in reference to CRC ERAM. They all look pretty accurate now. Here are some comparison screenshots:

East Owned

**Before**
<img width="116" height="107" alt="image" src="https://github.com/user-attachments/assets/c1ea44cb-9abb-4947-8c65-bb9a6e5d607a" />
**After** 
<img width="131" height="128" alt="image" src="https://github.com/user-attachments/assets/51e0753b-7157-495a-af0f-d303bbf95813" />
**CRC**
<img width="242" height="205" alt="Screenshot 2026-08-03 020803" src="https://github.com/user-attachments/assets/ef48f1bf-e2b0-42e1-a70e-ae48250b87ff" />

Northeast Owned

**Before**
<img width="112" height="131" alt="image" src="https://github.com/user-attachments/assets/aeb42901-581d-4665-a536-0266b6822301" />
**After**
<img width="130" height="176" alt="image" src="https://github.com/user-attachments/assets/080a5e09-e6a3-4d99-89cb-d85d5e310d25" />
**CRC**
<img width="101" height="73" alt="image" src="https://github.com/user-attachments/assets/9b8eefb1-c83f-4dc6-9c3d-5c051570c911" />

East Not Owned

**Before**
<img width="119" height="134" alt="image" src="https://github.com/user-attachments/assets/2e11aaed-7a5c-455a-84ac-ea112e51d468" />
**After**
<img width="110" height="108" alt="image" src="https://github.com/user-attachments/assets/cbf0901a-7337-4d34-831e-3d910446e666" />
**CRC**
<img width="134" height="151" alt="image" src="https://github.com/user-attachments/assets/5057a241-4806-4476-af0c-94f3bdaf6e7e" />


Specifics:
  - the line meets the CID row's ink top for N/E/W/NE/NW, and the callsign row's ink bottom for S/SE/SW
  - 6 pixels of clearance between the line and the block, in every direction, produced by offsetting the block rather than shortening the line
  - the VCI and "R" symbols sit a third of a character clear of the main columns, matching CRC's 6-pixel gap rather than the normal 2
  - the "R" shortens the line only when the leader line runs into it (when the data block is set to northeast, and east).
  - vertical leaders meet the block under the "R" rather than beside it
  - leader lines are nudged half a pixel onto a pixel boundary so a 2-wide line covers two rows cleanly instead of smearing across three

Also fixes a mismatch where non-owned FDB leader lines were scaled to 0.7 in drawLeaderLines but not in datablockAnchor, leaving those blocks positioned for a full-length line. 

I tested this on a windows machine, on a 4k monitor. Please let me know what thoughts you have on these changes.