### PR TITLE
Add ZTL Area 2 low sectors (29+30) scenarios

### DIFF
--- a/resources/configurations/ZTL/ZTL.json
+++ b/resources/configurations/ZTL/ZTL.json
@@ -714,6 +714,37 @@
           "BANKR7-N": "31",
           "JONZE7-N": "31"
         }
+      },
+      "L30": {
+        "default_consolidation": {
+          "30": []
+        },
+        "departure_assignments": {
+          "KCLT/BEAVY8": "30",
+          "KCLT/ICONS7": "30",
+          "KCLT/KWEEN7": "30",
+          "KCLT/LILLS5": "30",
+          "KCLT/BARMY7": "30",
+          "KCLT/KILNS7": "30"
+        },
+        "inbound_assignments": {}
+      },
+      "L29": {
+        "default_consolidation": {
+          "29": []
+        },
+        "departure_assignments": {
+          "KGSO/TRI9": "29",
+          "KGSO/TRSHA1": "29",
+          "KGSO/QUAK8": "29"
+        },
+        "inbound_assignments": {
+          "CHSLY8-AIROW": "29",
+          "CHSLY8-RDU": "29",
+          "CHSLY8-AIROW-N": "29",
+          "CHSLY8-RDU-N": "29",
+          "GSP-JUNNR": "29"
+        }
       }
     },
     "center": "N036.15.25.378,W081.54.35.546",

--- a/resources/scenarios/ztl_leeon29.json
+++ b/resources/scenarios/ztl_leeon29.json
@@ -1,0 +1,389 @@
+{
+  "artcc": "ZTL",
+  "area": "ZTL Area 2",
+  "name": "ZTL Leeon 29",
+  "default_scenario": "ZTL 29 Leeon Low - CLT South",
+  "magnetic_adjustment": -7.0,
+  "airports": {
+    "KCLT": {
+      "approaches": {
+        "I8L": {
+          "cifp_id": "I18L"
+        },
+        "I9R": {
+          "cifp_id": "I19R"
+        },
+        "I1L": {
+          "cifp_id": "I1L"
+        },
+        "I1R": {
+          "cifp_id": "I1R"
+        },
+        "I6R": {
+          "cifp_id": "I36R"
+        }
+      }
+    },
+    "KGSO": {
+      "departure_controller": "G1W",
+      "departure_routes": {
+        "23L": {
+          "CARWN": {
+            "cleared_altitude": 12000,
+            "sid": "TRI9",
+            "waypoints": "GSO/ho BOLTT CARWN/c270 LEAVI/delete",
+            "handoff_controller": "29"
+          },
+          "BAWDS": {
+            "cleared_altitude": 12000,
+            "sid": "TRSHA1",
+            "waypoints": "GSO/ho WHAYN TRSHA BAWDS/c270 VXV/delete",
+            "handoff_controller": "29"
+          },
+          "SBV": {
+            "cleared_altitude": 12000,
+            "sid": "QUAK8",
+            "waypoints": "GSO/ho JEANY SBV/c270/delete",
+            "handoff_controller": "29"
+          }
+        },
+        "5R": {
+          "CARWN": {
+            "cleared_altitude": 12000,
+            "sid": "TRI9",
+            "waypoints": "GSO/ho BOLTT CARWN/c270 LEAVI/delete",
+            "handoff_controller": "29"
+          },
+          "BAWDS": {
+            "cleared_altitude": 12000,
+            "sid": "TRSHA1",
+            "waypoints": "GSO/ho WHAYN TRSHA BAWDS/c270 VXV/delete",
+            "handoff_controller": "29"
+          },
+          "SBV": {
+            "cleared_altitude": 12000,
+            "sid": "QUAK8",
+            "waypoints": "GSO/ho JEANY SBV/c270/delete",
+            "handoff_controller": "29"
+          }
+        }
+      },
+      "departures": [
+        {
+          "airlines": [
+            {
+              "icao": "DAL"
+            },
+            {
+              "icao": "FDX"
+            }
+          ],
+          "altitude": [
+            24000,
+            26000,
+            28000,
+            30000
+          ],
+          "destination": "KATL",
+          "exit": "CARWN",
+          "route": "CARWN LEAVI OZZZI2"
+        },
+        {
+          "airlines": [
+            {
+              "icao": "AAL"
+            },
+            {
+              "icao": "ENY"
+            }
+          ],
+          "altitude": [
+            29000,
+            31000,
+            33000
+          ],
+          "destination": "KORD",
+          "exit": "BAWDS",
+          "route": "BAWDS VXV FOUNT CVG VHP WWODD HANBL3"
+        },
+        {
+          "airlines": [
+            {
+              "icao": "DAL"
+            },
+            {
+              "icao": "RPA"
+            }
+          ],
+          "altitude": [
+            29000,
+            31000,
+            33000
+          ],
+          "destination": "KDTW",
+          "exit": "BAWDS",
+          "route": "BAWDS VXV FOUNT CVG VHP WWODD HANBL3"
+        },
+        {
+          "airlines": [
+            {
+              "icao": "PDT"
+            },
+            {
+              "icao": "JIA"
+            }
+          ],
+          "altitude": [
+            25000,
+            27000,
+            29000
+          ],
+          "destination": "KPHL",
+          "exit": "SBV",
+          "route": "SBV BBDOL PAATS4"
+        },
+        {
+          "airlines": [
+            {
+              "icao": "RPA"
+            },
+            {
+              "icao": "JIA"
+            }
+          ],
+          "altitude": [
+            25000,
+            27000,
+            29000
+          ],
+          "destination": "KLGA",
+          "exit": "SBV",
+          "route": "SBV"
+        }
+      ]
+    },
+    "KGSP": {
+      "approaches": {
+        "I22": {
+          "cifp_id": "I22"
+        }
+      }
+    }
+  },
+  "fixes": {
+    "_CLT_CHSLY_S_OUT": "HEELZ@270/25",
+    "_CLT_CHSLY_N_OUT": "EPAYE@183/25"
+  },
+  "inbound_flows": {
+    "CHSLY8-AIROW": {
+      "arrivals": [
+        {
+          "airlines": {
+            "KCLT": [
+              {
+                "icao": "AAL",
+                "airport": "KIAD"
+              },
+              {
+                "icao": "JIA",
+                "airport": "KIAD"
+              },
+              {
+                "icao": "ASH",
+                "airport": "KIAD"
+              }
+            ]
+          },
+          "initial_controller": "W36",
+          "initial_altitude": 27000,
+          "initial_speed": 280,
+          "cleared_altitude": 6000,
+          "cruise_altitude": 33000,
+          "star": "CHSLY8",
+          "route": "/. CHSLY8",
+          "is_rnav": true,
+          "waypoints": "BLUEJ/ho BURRZ/a24000-27000/s280 SKLES/a22000+ DENTT/a16000+/s270 BOOTS/a13000-23000 CHSLY/a13000-22000/s250 KRISS/a11000-12000 NODEW/a8000-9000/s230 HEELZ/a6000/s210/d40 _CLT_CHSLY_S_OUT/delete"
+        }
+      ]
+    },
+    "CHSLY8-RDU": {
+      "arrivals": [
+        {
+          "airlines": {
+            "KCLT": [
+              {
+                "icao": "AAL",
+                "airport": "KRDU"
+              },
+              {
+                "icao": "FFT",
+                "airport": "KRDU"
+              }
+            ]
+          },
+          "initial_controller": "W27",
+          "initial_altitude": 24000,
+          "initial_speed": 280,
+          "assigned_altitude": 23000,
+          "waypoints": "CATAR/ho SDAIL/a17000-23000/s280 WLLSH/a16000+/s270 CHSLY/a13000-22000/s250 KRISS/a11000-12000 NODEW/a8000-9000/s230 HEELZ/a6000/s210/d40 _CLT_CHSLY_S_OUT/delete",
+          "cruise_altitude": 24000,
+          "star": "CHSLY8",
+          "route": "/. CHSLY8",
+          "is_rnav": true
+        }
+      ]
+    },
+    "CHSLY8-AIROW-N": {
+      "arrivals": [
+        {
+          "airlines": {
+            "KCLT": [
+              {
+                "icao": "AAL",
+                "airport": "KIAD"
+              },
+              {
+                "icao": "JIA",
+                "airport": "KIAD"
+              },
+              {
+                "icao": "ASH",
+                "airport": "KIAD"
+              }
+            ]
+          },
+          "initial_controller": "W36",
+          "initial_altitude": 27000,
+          "initial_speed": 280,
+          "cleared_altitude": 10000,
+          "cruise_altitude": 33000,
+          "star": "CHSLY8",
+          "route": "/. CHSLY8",
+          "is_rnav": true,
+          "waypoints": "BLUEJ/ho BURRZ/a24000-27000/s280 SKLES/a22000+ DENTT/a16000+/s270 BOOTS/a13000-23000 CHSLY/a13000-22000/s250 SLPOH/a11000-21000 JAMGO/a10000-16000 WHIZE/a10000-12000 CAATT/a10000/s210 EPAYE/d50 _CLT_CHSLY_N_OUT/delete"
+        }
+      ]
+    },
+    "CHSLY8-RDU-N": {
+      "arrivals": [
+        {
+          "airlines": {
+            "KCLT": [
+              {
+                "icao": "AAL",
+                "airport": "KRDU"
+              },
+              {
+                "icao": "FFT",
+                "airport": "KRDU"
+              }
+            ]
+          },
+          "initial_controller": "W27",
+          "initial_altitude": 24000,
+          "initial_speed": 280,
+          "assigned_altitude": 23000,
+          "waypoints": "CATAR/ho SDAIL/a17000-23000/s280 WLLSH/a16000+/s270 CHSLY/a13000-22000/s250 SLPOH/a11000-21000 JAMGO/a10000-16000 WHIZE/a10000-12000 CAATT/a10000/s210 EPAYE/d50 _CLT_CHSLY_N_OUT/delete",
+          "cruise_altitude": 24000,
+          "star": "CHSLY8",
+          "route": "/. CHSLY8",
+          "is_rnav": true
+        }
+      ]
+    },
+    "GSP-JUNNR": {
+      "arrivals": [
+        {
+          "airlines": {
+            "KGSP": [
+              {
+                "icao": "RPA",
+                "airport": "KEWR"
+              },
+              {
+                "icao": "PDT",
+                "airport": "KPHL"
+              }
+            ]
+          },
+          "initial_controller": "45",
+          "initial_altitude": 23000,
+          "assigned_altitude": 23000,
+          "initial_speed": 290,
+          "cruise_altitude": 23000,
+          "route": "GMONY WAMUR JUNNR YELKS SPA",
+          "waypoints": "GMONY/ho WAMUR JUNNR YELKS SPA/delete",
+          "airports": [
+            "KGSP"
+          ]
+        }
+      ]
+    }
+  },
+  "scenarios": {
+    "ZTL 29 Leeon Low - CLT South": {
+      "configuration": "L29",
+      "default_map_group": "ZTL",
+      "departure_runways": [
+        {
+          "airport": "KGSO",
+          "rate": 12,
+          "runway": "23L"
+        }
+      ],
+      "arrival_runways": [
+        {
+          "airport": "KCLT",
+          "runway": "18L"
+        },
+        {
+          "airport": "KGSP",
+          "runway": "22"
+        }
+      ],
+      "inbound_rates": {
+        "CHSLY8-AIROW": {
+          "KCLT": 6
+        },
+        "CHSLY8-RDU": {
+          "KCLT": 4
+        },
+        "GSP-JUNNR": {
+          "KGSP": 3
+        }
+      }
+    },
+    "ZTL 29 Leeon Low - CLT North": {
+      "configuration": "L29",
+      "default_map_group": "ZTL",
+      "departure_runways": [
+        {
+          "airport": "KGSO",
+          "rate": 12,
+          "runway": "5R"
+        }
+      ],
+      "arrival_runways": [
+        {
+          "airport": "KCLT",
+          "runway": "1L"
+        },
+        {
+          "airport": "KGSP",
+          "runway": "22"
+        }
+      ],
+      "inbound_rates": {
+        "CHSLY8-AIROW-N": {
+          "KCLT": 6
+        },
+        "CHSLY8-RDU-N": {
+          "KCLT": 4
+        },
+        "GSP-JUNNR": {
+          "KGSP": 3
+        }
+      }
+    }
+  }
+}

--- a/resources/scenarios/ztl_locas30.json
+++ b/resources/scenarios/ztl_locas30.json
@@ -1,0 +1,253 @@
+{
+  "artcc": "ZTL",
+  "area": "ZTL Area 2",
+  "name": "ZTL Locas 30",
+  "default_scenario": "ZTL 30 Locas Low - CLT South",
+  "magnetic_adjustment": -7.0,
+  "airports": {
+    "KCLT": {
+      "departure_controller": "C1W",
+      "departure_routes": {
+        "18L": {
+          "BEAVY": {
+            "cleared_altitude": 16000,
+            "sid": "BEAVY8",
+            "waypoints": "UGANG/ho",
+            "handoff_controller": "30"
+          },
+          "ICONS": {
+            "cleared_altitude": 16000,
+            "sid": "ICONS7",
+            "waypoints": "GILFN/ho",
+            "handoff_controller": "30"
+          },
+          "KWEEN": {
+            "cleared_altitude": 16000,
+            "sid": "KWEEN7",
+            "waypoints": "HMMPY/ho",
+            "handoff_controller": "30"
+          },
+          "LILLS": {
+            "cleared_altitude": 13000,
+            "sid": "LILLS5",
+            "waypoints": "N035.08.40.504,W080.54.03.850/ho LAMDE",
+            "handoff_controller": "30"
+          },
+          "BARMY": {
+            "cleared_altitude": 16000,
+            "sid": "BARMY7",
+            "waypoints": "MESHY/ho GULFY",
+            "handoff_controller": "30"
+          },
+          "KILNS": {
+            "cleared_altitude": 16000,
+            "sid": "KILNS7",
+            "waypoints": "MUNBE/ho LILIC",
+            "handoff_controller": "30"
+          }
+        },
+        "1R": {
+          "BEAVY": {
+            "cleared_altitude": 16000,
+            "sid": "BEAVY8",
+            "waypoints": "UGANG/ho",
+            "handoff_controller": "30"
+          },
+          "ICONS": {
+            "cleared_altitude": 16000,
+            "sid": "ICONS7",
+            "waypoints": "GILFN/ho",
+            "handoff_controller": "30"
+          },
+          "KWEEN": {
+            "cleared_altitude": 16000,
+            "sid": "KWEEN7",
+            "waypoints": "HMMPY/ho",
+            "handoff_controller": "30"
+          },
+          "LILLS": {
+            "cleared_altitude": 13000,
+            "sid": "LILLS5",
+            "waypoints": "N035.16.16.300,W080.55.00.265/ho LAMDE",
+            "handoff_controller": "30"
+          },
+          "BARMY": {
+            "cleared_altitude": 16000,
+            "sid": "BARMY7",
+            "waypoints": "MESHY/ho GULFY",
+            "handoff_controller": "30"
+          },
+          "KILNS": {
+            "cleared_altitude": 16000,
+            "sid": "KILNS7",
+            "waypoints": "MUNBE/ho LILIC",
+            "handoff_controller": "30"
+          }
+        }
+      },
+      "departures": [
+        {
+          "airlines": [
+            {
+              "icao": "AAL"
+            }
+          ],
+          "altitude": [
+            36000
+          ],
+          "destination": "KMIA",
+          "exit": "ICONS",
+          "route": "ICONS NOOKS WURFL/c360 Q83 JEVED Q97 DEBRL/delete CSTAL3"
+        },
+        {
+          "airlines": [
+            {
+              "icao": "AAL"
+            },
+            {
+              "icao": "FFT"
+            }
+          ],
+          "altitude": [
+            38000
+          ],
+          "destination": "KMIA",
+          "exit": "ICONS",
+          "route": "ICONS NOOKS WURFL/c380 Q83 JEVED Q97 DEBRL/delete CSTAL3"
+        },
+        {
+          "airlines": [
+            {
+              "icao": "AAL"
+            }
+          ],
+          "altitude": [
+            23000
+          ],
+          "destination": "KMYR",
+          "exit": "KWEEN",
+          "route": "KWEEN UNJAM/c230 KMYR/delete"
+        },
+        {
+          "airlines": [
+            {
+              "icao": "AAL"
+            },
+            {
+              "icao": "FFT"
+            }
+          ],
+          "altitude": [
+            37000
+          ],
+          "destination": "KMIA",
+          "exit": "KWEEN",
+          "route": "KWEEN PITRW/c370 Y436 OGGRE DUUNK Y313 HOAGG/delete BNFSH3"
+        },
+        {
+          "airlines": [
+            {
+              "icao": "AAL"
+            }
+          ],
+          "altitude": [
+            36000
+          ],
+          "destination": "KMSY",
+          "exit": "BEAVY",
+          "route": "BEAVY JENDO/c360 MAVRC ALLMA CEW J2 SJI/delete MNSTR2"
+        },
+        {
+          "airlines": [
+            {
+              "icao": "AAL"
+            },
+            {
+              "icao": "EDV"
+            }
+          ],
+          "altitude": [
+            35000
+          ],
+          "destination": "KJFK",
+          "exit": "BARMY",
+          "route": "BARMY TYI/c350 Q64 SAWED Q108 SIE/delete CAMRN5"
+        },
+        {
+          "airlines": [
+            {
+              "icao": "AAL"
+            },
+            {
+              "icao": "SWA"
+            },
+            {
+              "icao": "FFT"
+            }
+          ],
+          "altitude": [
+            33000
+          ],
+          "destination": "KBWI",
+          "exit": "BARMY",
+          "route": "BARMY RDU/c330 THHMP/delete RAVNN9"
+        },
+        {
+          "airlines": [
+            {
+              "icao": "AAL"
+            },
+            {
+              "icao": "JIA"
+            }
+          ],
+          "altitude": [
+            31000
+          ],
+          "destination": "KDCA",
+          "exit": "KILNS",
+          "route": "KILNS AUDII/c310 WAVES/delete CAPSS4"
+        },
+        {
+          "airlines": [
+            {
+              "icao": "PDT"
+            }
+          ],
+          "altitude": [
+            13000
+          ],
+          "destination": "KFAY",
+          "exit": "LILLS",
+          "route": "LILLS V296 FAY/delete"
+        }
+      ]
+    }
+  },
+  "scenarios": {
+    "ZTL 30 Locas Low - CLT South": {
+      "default_map_group": "ZTL",
+      "departure_runways": [
+        {
+          "airport": "KCLT",
+          "rate": 34,
+          "runway": "18L"
+        }
+      ],
+      "arrival_runways": [],
+      "configuration": "L30"
+    },
+    "ZTL 30 Locas Low - CLT North": {
+      "default_map_group": "ZTL",
+      "departure_runways": [
+        {
+          "airport": "KCLT",
+          "rate": 34,
+          "runway": "1R"
+        }
+      ],
+      "arrival_runways": [],
+      "configuration": "L30"
+    }
+  }
+}


### PR DESCRIPTION
Adds standalone Vice scenarios for ZTL Area 2 low sectors:

L29 LEEON
L30 LOCAS

Includes CLT CHSLY arrivals, GSO departure flows, GSP arrivals, and CLT departure flows into LOCAS, along with the associated ZTL facility configuration updates.

Both scenarios were tested in Vice for routing, handoff timing, and altitude behavior.