### PR TITLE
Add ZTL Area 1 low sector scenarios

### DIFF
--- a/resources/configurations/ZTL/ZTL.json
+++ b/resources/configurations/ZTL/ZTL.json
@@ -745,6 +745,48 @@
           "CHSLY8-RDU-N": "29",
           "GSP-JUNNR": "29"
         }
+      },
+      "L47": {
+        "default_consolidation": {
+          "47": []
+        },
+        "departure_assignments": {
+          "KCLT/KRITR8": "47",
+          "KCLT/WEAZL7": "47"
+        },
+        "inbound_assignments": {
+          "PARQR6": "47",
+          "PARQR6-N": "47",
+          "GSP-JUNNR-MOPED": "47",
+          "GSO-TRAKS": "47"
+        }
+      },
+      "L44": {
+        "default_consolidation": {
+          "44": []
+        },
+        "departure_assignments": {
+          "KCLT/JOJJO7": "44",
+          "KGSP/BWALL2": "44"
+        },
+        "inbound_assignments": {
+          "FILPZ6": "44",
+          "FILPZ6-N": "44",
+          "GSO-TRAKS-SHINE": "44"
+        }
+      },
+      "L45": {
+        "default_consolidation": {
+          "45": []
+        },
+        "departure_assignments": {
+          "KTRI/PUPDG": "45"
+        },
+        "inbound_assignments": {
+          "GSP-RCTOR-BRISTOL": "45",
+          "TRI-ATL-SMKEY": "45",
+          "ROA-MOPED-BRISTOL": "45"
+        }
       }
     },
     "center": "N036.15.25.378,W081.54.35.546",

--- a/resources/scenarios/ztl_bristol45.json
+++ b/resources/scenarios/ztl_bristol45.json
@@ -1,0 +1,202 @@
+{
+  "artcc": "ZTL",
+  "area": "ZTL Area 1",
+  "name": "ZTL Bristol 45",
+  "default_scenario": "ZTL 45 Bristol Low",
+  "magnetic_adjustment": -7.0,
+  "airports": {
+    "KTRI": {
+      "approaches": {
+        "I3": {
+          "cifp_id": "I23"
+        }
+      },
+      "departure_controller": "T1W",
+      "departure_routes": {
+        "23": {
+          "PUPDG": {
+            "cleared_altitude": 10000,
+            "waypoints": "N036.18.00.564,W082.34.15.100/ho PUPDG",
+            "handoff_controller": "45"
+          }
+        }
+      },
+      "departures": [
+        {
+          "airlines": [
+            {
+              "icao": "DAL"
+            },
+            {
+              "icao": "EDV"
+            }
+          ],
+          "altitude": [
+            18000,
+            20000,
+            22000
+          ],
+          "destination": "KATL",
+          "exit": "PUPDG",
+          "route": "PUPDG ONDRE1"
+        }
+      ]
+    },
+    "KGSP": {
+      "approaches": {
+        "I22": {
+          "cifp_id": "I22"
+        }
+      }
+    },
+    "KROA": {
+      "approaches": {
+        "R34": {
+          "cifp_id": "RY34"
+        }
+      }
+    }
+  },
+  "scenarios": {
+    "ZTL 45 Bristol Low": {
+      "configuration": "L45",
+      "default_map_group": "ZTL",
+      "departure_runways": [
+        {
+          "airport": "KTRI",
+          "runway": "23",
+          "rate": 5
+        }
+      ],
+      "arrival_runways": [
+        {
+          "airport": "KTRI",
+          "runway": "23"
+        },
+        {
+          "airport": "KGSP",
+          "runway": "22"
+        },
+        {
+          "airport": "KROA",
+          "runway": "34"
+        }
+      ],
+      "inbound_rates": {
+        "GSP-RCTOR-BRISTOL": {
+          "KGSP": 6
+        },
+        "TRI-ATL-SMKEY": {
+          "KTRI": 5
+        },
+        "ROA-MOPED-BRISTOL": {
+          "KROA": 4
+        }
+      }
+    }
+  },
+  "inbound_flows": {
+    "GSP-RCTOR-BRISTOL": {
+      "arrivals": [
+        {
+          "airlines": {
+            "KGSP": [
+              {
+                "icao": "AAL",
+                "airport": "KORD"
+              },
+              {
+                "icao": "UAL",
+                "airport": "KEWR"
+              },
+              {
+                "icao": "DAL",
+                "airport": "KDTW"
+              },
+              {
+                "icao": "AAL",
+                "airport": "KPHL"
+              }
+            ]
+          },
+          "initial_controller": "42",
+          "initial_altitude": 24000,
+          "assigned_altitude": 24000,
+          "cruise_altitude": 34000,
+          "initial_speed": 290,
+          "route": "VXV DAJPI LUVTT RCTOR UNMAN",
+          "is_rnav": true,
+          "waypoints": "VXV/ho DAJPI LUVTT RCTOR UNMAN/delete",
+          "airports": [
+            "KGSP"
+          ]
+        }
+      ]
+    },
+    "TRI-ATL-SMKEY": {
+      "arrivals": [
+        {
+          "airports": [
+            "KTRI"
+          ],
+          "airlines": {
+            "KTRI": [
+              {
+                "icao": "DAL",
+                "airport": "KATL"
+              },
+              {
+                "icao": "EDV",
+                "airport": "KATL"
+              },
+              {
+                "icao": "SKW",
+                "airport": "KATL"
+              }
+            ]
+          },
+          "initial_controller": "49",
+          "initial_altitude": 17000,
+          "assigned_altitude": 17000,
+          "cruise_altitude": 21000,
+          "initial_speed": 250,
+          "route": "SMKEY HUCHH SOT HMV",
+          "waypoints": "N035.35.30.000,W083.38.00.000/ho SOT HMV KTRI/delete"
+        }
+      ]
+    },
+    "ROA-MOPED-BRISTOL": {
+      "arrivals": [
+        {
+          "airports": [
+            "KROA"
+          ],
+          "airlines": {
+            "KROA": [
+              {
+                "icao": "PDT",
+                "airport": "KCLT"
+              },
+              {
+                "icao": "JIA",
+                "airport": "KCLT"
+              },
+              {
+                "icao": "N",
+                "fleet": "fastGA",
+                "airport": "KHKY"
+              }
+            ]
+          },
+          "initial_controller": "47",
+          "initial_altitude": 11000,
+          "assigned_altitude": 11000,
+          "cruise_altitude": 17000,
+          "initial_speed": 240,
+          "route": "KRITR FILDS KROA",
+          "waypoints": "KRITR N036.25.30.000,W080.48.30.000/ho FILDS KROA/delete"
+        }
+      ]
+    }
+  }
+}

--- a/resources/scenarios/ztl_moped47.json
+++ b/resources/scenarios/ztl_moped47.json
@@ -1,0 +1,377 @@
+{
+  "artcc": "ZTL",
+  "area": "ZTL Area 1",
+  "name": "ZTL Moped 47",
+  "default_scenario": "ZTL 47 Moped Low - CLT South",
+  "magnetic_adjustment": -7.0,
+  "airports": {
+    "KCLT": {
+      "departure_controller": "C1W",
+      "departure_routes": {
+        "18L": {
+          "KRITR": {
+            "cleared_altitude": 16000,
+            "sid": "KRITR8",
+            "waypoints": "N035.15.09.214,W081.16.06.577/ho JDEAN",
+            "handoff_controller": "47"
+          },
+          "CLAWD": {
+            "cleared_altitude": 16000,
+            "sid": "WEAZL7",
+            "waypoints": "N035.15.09.214,W081.16.06.577/ho WHFRD WEAZL",
+            "handoff_controller": "47"
+          }
+        },
+        "1R": {
+          "KRITR": {
+            "cleared_altitude": 16000,
+            "sid": "KRITR8",
+            "waypoints": "N035.22.41.000,W080.59.25.200/ho JDEAN",
+            "handoff_controller": "47"
+          },
+          "CLAWD": {
+            "cleared_altitude": 16000,
+            "sid": "WEAZL7",
+            "waypoints": "N035.22.41.000,W080.59.25.200/ho WHFRD WEAZL",
+            "handoff_controller": "47"
+          }
+        }
+      },
+      "departures": [
+        {
+          "airlines": [
+            {
+              "icao": "AAL"
+            },
+            {
+              "icao": "SWA"
+            }
+          ],
+          "altitude": [
+            29000,
+            31000,
+            33000,
+            35000,
+            37000
+          ],
+          "destination": "KBWI",
+          "exit": "KRITR",
+          "route": "KRITR FILDS N036.47.15.000,W080.43.30.000/delete"
+        },
+        {
+          "airlines": [
+            {
+              "icao": "AAL"
+            }
+          ],
+          "altitude": [
+            29000,
+            31000,
+            33000
+          ],
+          "destination": "KPIT",
+          "exit": "KRITR",
+          "route": "KRITR FILDS N036.47.15.000,W080.43.30.000/delete"
+        },
+        {
+          "airlines": [
+            {
+              "icao": "JIA"
+            }
+          ],
+          "altitude": [
+            29000,
+            31000,
+            33000
+          ],
+          "destination": "KABE",
+          "exit": "KRITR",
+          "route": "KRITR FILDS N036.47.15.000,W080.43.30.000/delete"
+        },
+        {
+          "airlines": [
+            {
+              "icao": "DLH"
+            }
+          ],
+          "altitude": [
+            35000,
+            37000,
+            39000
+          ],
+          "destination": "EDDM",
+          "exit": "KRITR",
+          "route": "KRITR FILDS N036.47.15.000,W080.43.30.000/delete"
+        },
+        {
+          "airlines": [
+            {
+              "icao": "AAL"
+            },
+            {
+              "icao": "DAL"
+            }
+          ],
+          "altitude": [
+            32000,
+            34000
+          ],
+          "destination": "KSLC",
+          "exit": "CLAWD",
+          "route": "CLAWD N036.52.30.000,W081.11.30.000/delete"
+        },
+        {
+          "airlines": [
+            {
+              "icao": "AAL"
+            },
+            {
+              "icao": "EDV"
+            }
+          ],
+          "altitude": [
+            33000,
+            35000,
+            37000
+          ],
+          "destination": "KJFK",
+          "exit": "CLAWD",
+          "route": "CLAWD N036.52.30.000,W081.11.30.000/delete"
+        },
+        {
+          "airlines": [
+            {
+              "icao": "AAL"
+            }
+          ],
+          "altitude": [
+            34000,
+            36000
+          ],
+          "destination": "KMSY",
+          "exit": "CLAWD",
+          "route": "CLAWD N036.52.30.000,W081.11.30.000/delete"
+        }
+      ],
+      "approaches": {
+        "I8L": {
+          "cifp_id": "I18L"
+        },
+        "I1L": {
+          "cifp_id": "I1L"
+        }
+      }
+    },
+    "KGSO": {
+      "approaches": {
+        "I5L": {
+          "cifp_id": "I5L"
+        }
+      }
+    },
+    "KGSP": {
+      "approaches": {
+        "I22": {
+          "cifp_id": "I22"
+        }
+      }
+    }
+  },
+  "inbound_flows": {
+    "PARQR6": {
+      "arrivals": [
+        {
+          "airlines": {
+            "KCLT": [
+              {
+                "icao": "AAL",
+                "airport": "KIAD"
+              },
+              {
+                "icao": "JIA",
+                "airport": "KDCA"
+              },
+              {
+                "icao": "RPA",
+                "airport": "KPHL"
+              }
+            ]
+          },
+          "initial_controller": "43",
+          "initial_altitude": 24000,
+          "initial_speed": 270,
+          "cruise_altitude": 33000,
+          "star": "PARQR6",
+          "route": "/. PARQR6",
+          "is_rnav": true,
+          "cleared_altitude": 11000,
+          "waypoints": "WILUM/a24000+/ho SUZNN/a17000+ PARQR/a20000-/s250 NCOMA/a11000 BOATN CAMPR/delete"
+        }
+      ]
+    },
+    "PARQR6-N": {
+      "arrivals": [
+        {
+          "airlines": {
+            "KCLT": [
+              {
+                "icao": "AAL",
+                "airport": "KIAD"
+              },
+              {
+                "icao": "JIA",
+                "airport": "KDCA"
+              },
+              {
+                "icao": "RPA",
+                "airport": "KPHL"
+              }
+            ]
+          },
+          "initial_controller": "43",
+          "initial_altitude": 24000,
+          "initial_speed": 270,
+          "cruise_altitude": 33000,
+          "star": "PARQR6",
+          "route": "/. PARQR6",
+          "is_rnav": true,
+          "cleared_altitude": 12000,
+          "waypoints": "WILUM/a24000+/ho SUZNN/a17000+ PARQR/a20000-/s250 PAYKN/a12000-15000 THACK/a12000 BBQEE CEDOX VALLL/delete"
+        }
+      ]
+    },
+    "GSP-JUNNR-MOPED": {
+      "arrivals": [
+        {
+          "airports": [
+            "KGSP"
+          ],
+          "airlines": {
+            "KGSP": [
+              {
+                "icao": "UAL",
+                "airport": "KEWR"
+              },
+              {
+                "icao": "AAL",
+                "airport": "KPHL"
+              }
+            ]
+          },
+          "initial_controller": "29",
+          "initial_altitude": 23000,
+          "assigned_altitude": 17000,
+          "initial_speed": 290,
+          "cruise_altitude": 23000,
+          "route": "GMONY WAMUR JUNNR OPENS YELKS KWOOD TANCE BURGG",
+          "waypoints": "GMONY WAMUR/ho JUNNR OPENS/a17000 YELKS KWOOD TANCE BURGG/delete"
+        }
+      ]
+    },
+    "GSO-TRAKS": {
+      "arrivals": [
+        {
+          "airports": [
+            "KGSO"
+          ],
+          "airlines": {
+            "KGSO": [
+              {
+                "icao": "AAL",
+                "airport": "KORD"
+              },
+              {
+                "icao": "UAL",
+                "airport": "KEWR"
+              },
+              {
+                "icao": "DAL",
+                "airport": "KDTW"
+              }
+            ]
+          },
+          "initial_controller": "45",
+          "initial_altitude": 21000,
+          "initial_speed": 290,
+          "cruise_altitude": 21000,
+          "route": "BURGG MURKY KHAOS TRAKS DEMNZ",
+          "waypoints": "BURGG MURKY/ho KHAOS TRAKS DEMNZ/delete"
+        }
+      ]
+    }
+  },
+  "scenarios": {
+    "ZTL 47 Moped Low - CLT South": {
+      "configuration": "L47",
+      "departure_runways": [
+        {
+          "airport": "KCLT",
+          "runway": "18L",
+          "rate": 8
+        }
+      ],
+      "arrival_runways": [
+        {
+          "airport": "KCLT",
+          "runway": "18L"
+        },
+        {
+          "airport": "KGSP",
+          "runway": "22"
+        },
+        {
+          "airport": "KGSO",
+          "runway": "5L"
+        }
+      ],
+      "inbound_rates": {
+        "PARQR6": {
+          "KCLT": 8
+        },
+        "GSP-JUNNR-MOPED": {
+          "KGSP": 3
+        },
+        "GSO-TRAKS": {
+          "KGSO": 4
+        }
+      },
+      "default_map_group": "ZTL"
+    },
+    "ZTL 47 Moped Low - CLT North": {
+      "configuration": "L47",
+      "departure_runways": [
+        {
+          "airport": "KCLT",
+          "runway": "1R",
+          "rate": 8
+        }
+      ],
+      "arrival_runways": [
+        {
+          "airport": "KCLT",
+          "runway": "1L"
+        },
+        {
+          "airport": "KGSP",
+          "runway": "22"
+        },
+        {
+          "airport": "KGSO",
+          "runway": "5L"
+        }
+      ],
+      "inbound_rates": {
+        "PARQR6-N": {
+          "KCLT": 8
+        },
+        "GSP-JUNNR-MOPED": {
+          "KGSP": 3
+        },
+        "GSO-TRAKS": {
+          "KGSO": 4
+        }
+      },
+      "default_map_group": "ZTL"
+    }
+  }
+}

--- a/resources/scenarios/ztl_shine44.json
+++ b/resources/scenarios/ztl_shine44.json
@@ -1,0 +1,352 @@
+{
+  "artcc": "ZTL",
+  "area": "ZTL Area 1",
+  "name": "ZTL Shine 44",
+  "default_scenario": "ZTL 44 Shine Low - CLT South",
+  "magnetic_adjustment": -7.0,
+  "airports": {
+    "KCLT": {
+      "approaches": {
+        "I8L": {
+          "cifp_id": "I18L"
+        },
+        "I1L": {
+          "cifp_id": "I1L"
+        }
+      },
+      "departure_controller": "C1W",
+      "departure_routes": {
+        "18L": {
+          "CUBIM": {
+            "cleared_altitude": 16000,
+            "sid": "JOJJO7",
+            "waypoints": "WAYDS/ho LONEE JOJJO WLLGO BENBY TIELR CUBIM/delete",
+            "handoff_controller": "44"
+          },
+          "DOOGE": {
+            "cleared_altitude": 16000,
+            "sid": "JOJJO7",
+            "waypoints": "WAYDS/ho LONEE JOJJO MTCHL DOOGE/delete",
+            "handoff_controller": "44"
+          },
+          "NOONN": {
+            "cleared_altitude": 16000,
+            "sid": "JOJJO7",
+            "waypoints": "WAYDS/ho LONEE JOJJO WLLGO BENBY SLEPP/delete",
+            "handoff_controller": "44"
+          }
+        },
+        "1R": {
+          "CUBIM": {
+            "cleared_altitude": 16000,
+            "sid": "JOJJO7",
+            "waypoints": "WAYDS/ho LONEE JOJJO WLLGO BENBY TIELR CUBIM/delete",
+            "handoff_controller": "44"
+          },
+          "DOOGE": {
+            "cleared_altitude": 16000,
+            "sid": "JOJJO7",
+            "waypoints": "WAYDS/ho LONEE JOJJO MTCHL DOOGE/delete",
+            "handoff_controller": "44"
+          },
+          "NOONN": {
+            "cleared_altitude": 16000,
+            "sid": "JOJJO7",
+            "waypoints": "WAYDS/ho LONEE JOJJO WLLGO BENBY SLEPP/delete",
+            "handoff_controller": "44"
+          }
+        }
+      },
+      "departures": [
+        {
+          "airlines": [
+            {
+              "icao": "AAL"
+            },
+            {
+              "icao": "DAL"
+            }
+          ],
+          "altitude": [
+            33000,
+            35000
+          ],
+          "destination": "KSLC",
+          "exit": "CUBIM",
+          "route": "CUBIM ENGRA EMBRR BAYLI ELYNA LMN WRNCH LNK YANKI HANKI CKW CARTR1"
+        },
+        {
+          "airlines": [
+            {
+              "icao": "AAL"
+            },
+            {
+              "icao": "UAL"
+            }
+          ],
+          "altitude": [
+            32000,
+            34000
+          ],
+          "destination": "KORD",
+          "exit": "DOOGE",
+          "route": "DOOGE"
+        },
+        {
+          "airlines": [
+            {
+              "icao": "AAL"
+            },
+            {
+              "icao": "DAL"
+            }
+          ],
+          "altitude": [
+            33000,
+            35000
+          ],
+          "destination": "KDTW",
+          "exit": "NOONN",
+          "route": "NOONN"
+        }
+      ]
+    },
+    "KGSP": {
+      "departure_controller": "31",
+      "departure_routes": {
+        "22": {
+          "JLENA": {
+            "assigned_altitude": 17000,
+            "sid": "BWALL2",
+            "is_rnav": true,
+            "waypoints": "HALJO ALYSA/ho BWALL",
+            "handoff_controller": "44"
+          }
+        }
+      },
+      "departures": [
+        {
+          "airlines": [
+            {
+              "icao": "UAL"
+            },
+            {
+              "icao": "AAL"
+            }
+          ],
+          "altitude": [
+            33000,
+            35000
+          ],
+          "destination": "KORD",
+          "exit": "JLENA",
+          "route": "JLENA DOOGE/ho42 HEVAN BONNT/delete"
+        },
+        {
+          "airlines": [
+            {
+              "icao": "DAL"
+            }
+          ],
+          "altitude": [
+            32000,
+            34000
+          ],
+          "destination": "KDTW",
+          "exit": "JLENA",
+          "route": "JLENA HMV/ho42 SUBWY HTROD/delete"
+        },
+        {
+          "airlines": [
+            {
+              "icao": "SWA"
+            }
+          ],
+          "altitude": [
+            32000,
+            34000
+          ],
+          "destination": "KMDW",
+          "exit": "JLENA",
+          "route": "JLENA HVQ/ho42 APE FWA/delete"
+        },
+        {
+          "airlines": [
+            {
+              "icao": "AAL"
+            }
+          ],
+          "altitude": [
+            33000,
+            35000
+          ],
+          "destination": "KCMH",
+          "exit": "JLENA",
+          "route": "JLENA MCGNS/ho42 SCRLT/delete"
+        }
+      ]
+    }
+  },
+  "inbound_flows": {
+    "FILPZ6": {
+      "arrivals": [
+        {
+          "airlines": {
+            "KCLT": [
+              {
+                "icao": "AAL",
+                "airport": "KBNA"
+              },
+              {
+                "icao": "AAL",
+                "airport": "KORD"
+              },
+              {
+                "icao": "UAL",
+                "airport": "KDEN"
+              },
+              {
+                "icao": "DAL",
+                "airport": "KBNA"
+              }
+            ]
+          },
+          "initial_controller": "42",
+          "initial_altitude": 29000,
+          "initial_speed": 270,
+          "cruise_altitude": 35000,
+          "star": "FILPZ6",
+          "route": "/. FILPZ6",
+          "is_rnav": true,
+          "cleared_altitude": 7000,
+          "waypoints": "COMDY/a29000 BLAYQ/a24000+/s270 PHAYE/a24000+/s270/ho JJENY/a19000-27000 FILPZ/a16000+/s270 GLAXI/a12000-14000/s250 JOBOT/a11000/s250 ERHRT/a10000- FISHN/a7000/s210/delete"
+        }
+      ]
+    },
+    "FILPZ6-N": {
+      "arrivals": [
+        {
+          "airlines": {
+            "KCLT": [
+              {
+                "icao": "AAL",
+                "airport": "KBNA"
+              },
+              {
+                "icao": "AAL",
+                "airport": "KORD"
+              },
+              {
+                "icao": "UAL",
+                "airport": "KDEN"
+              },
+              {
+                "icao": "DAL",
+                "airport": "KBNA"
+              }
+            ]
+          },
+          "initial_controller": "42",
+          "initial_altitude": 33000,
+          "initial_speed": 270,
+          "cruise_altitude": 35000,
+          "star": "FILPZ6",
+          "route": "/. FILPZ6",
+          "is_rnav": true,
+          "cleared_altitude": 10000,
+          "waypoints": "COMDY/a33000 BLAYQ/a24000+/s270 PHAYE/a24000+/s270/ho JJENY/a19000-27000 FILPZ/a16000+/s270 ADOWN/a12000-19000/s250 INWAL/a11000-15000/s250 JELNO/a10000-11000 CEDOX/a10000/s210 VALLL/delete"
+        }
+      ]
+    },
+    "GSO-TRAKS-SHINE": {
+      "overflights": [
+        {
+          "airlines": [
+            {
+              "icao": "AAL",
+              "departure_airport": "KORD",
+              "arrival_airport": "KGSO"
+            },
+            {
+              "icao": "UAL",
+              "departure_airport": "KEWR",
+              "arrival_airport": "KGSO"
+            },
+            {
+              "icao": "DAL",
+              "departure_airport": "KDTW",
+              "arrival_airport": "KGSO"
+            }
+          ],
+          "initial_controller": "45",
+          "initial_altitude": 21000,
+          "assigned_altitude": 21000,
+          "initial_speed": 290,
+          "waypoints": "BURGG/ho MURKY KHAOS TRAKS DEMNZ/delete"
+        }
+      ]
+    }
+  },
+  "scenarios": {
+    "ZTL 44 Shine Low - CLT South": {
+      "configuration": "L44",
+      "arrival_runways": [
+        {
+          "airport": "KCLT",
+          "runway": "18L"
+        }
+      ],
+      "inbound_rates": {
+        "FILPZ6": {
+          "KCLT": 8
+        },
+        "GSO-TRAKS-SHINE": {
+          "overflights": 4
+        }
+      },
+      "default_map_group": "ZTL",
+      "departure_runways": [
+        {
+          "airport": "KCLT",
+          "runway": "18L",
+          "rate": 6
+        },
+        {
+          "airport": "KGSP",
+          "runway": "22",
+          "rate": 6
+        }
+      ]
+    },
+    "ZTL 44 Shine Low - CLT North": {
+      "configuration": "L44",
+      "arrival_runways": [
+        {
+          "airport": "KCLT",
+          "runway": "1L"
+        }
+      ],
+      "inbound_rates": {
+        "FILPZ6-N": {
+          "KCLT": 8
+        },
+        "GSO-TRAKS-SHINE": {
+          "overflights": 4
+        }
+      },
+      "default_map_group": "ZTL",
+      "departure_runways": [
+        {
+          "airport": "KCLT",
+          "runway": "1R",
+          "rate": 6
+        },
+        {
+          "airport": "KGSP",
+          "runway": "22",
+          "rate": 6
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Adds standalone scenarios for the ZTL Area 1 low sectors:

Moped 47 (L47)
Shine 44 (L44)
Bristol 45 (L45)

Includes sector-specific arrival/departure flows, handoff logic, altitude procedures, and traffic based on the current ZTL SOP/LOAs and real-world routings.

All three scenarios were tested locally in Vice for traffic flow, handoffs, altitude behavior, and handoff deletion.