### PR TITLE
p80: update to current charts, fix runway assignment and go-arounds

### DIFF
--- a/resources/configurations/ZSE/P80.json
+++ b/resources/configurations/ZSE/P80.json
@@ -44,13 +44,19 @@
   "facility_adaptations": {
     "configurations": {
       "KPD": {
+        "go_around_assignments": {
+          "KPDX/28R": "1N",
+          "KPDX/10L": "1N",
+          "KPDX/28L": "1D",
+          "KPDX/10R": "1D"
+        },
         "inbound_assignments": {
           "HELNS": "1N",
-          "HHOOD5East": "1N",
+          "HHOODEast": "1N",
           "Hawaii": "1D",
-          "KRATR2East": "1N",
-          "OCITY3East": "1D",
-          "TMBERS3East": "1D",
+          "KRATREast": "1N",
+          "OCITYEast": "1D",
+          "TMBRSEast": "1D",
           "TOU": "1N",
           "V112.W": "1N",
           "V165.S": "1N"
@@ -66,33 +72,45 @@
         }
       },
       "KP1": {
+        "go_around_assignments": {
+          "KPDX": "1F"
+        },
         "inbound_assignments": {
-          "HHOOD5East_Final": "1F",
-          "KRATR2East_Final": "1F",
-          "TMBERS3East_Final": "1F"
+          "HHOODEast_Final": "1F",
+          "KRATREast_Final": "1F",
+          "TMBRSEast_Final": "1F"
         },
         "default_consolidation": {
           "1F": []
         }
       },
       "KP2": {
+        "go_around_assignments": {
+          "KPDX": "1F"
+        },
         "inbound_assignments": {
-          "HHOOD5West_Final": "1F",
-          "KRATR2West_Final": "1F",
-          "TMBERS3West_Final": "1F"
+          "HHOODWest_Final": "1F",
+          "KRATRWest_Final": "1F",
+          "TMBRSWest_Final": "1F"
         },
         "default_consolidation": {
           "1F": []
         }
       },
       "KP3": {
+        "go_around_assignments": {
+          "KPDX/28R": "1N",
+          "KPDX/10L": "1N",
+          "KPDX/28L": "1D",
+          "KPDX/10R": "1D"
+        },
         "inbound_assignments": {
           "HELNS": "1N",
-          "HHOOD5West": "1N",
+          "HHOODWest": "1N",
           "Hawaii": "1D",
-          "KRATR2West": "1N",
-          "OCITY3West": "1D",
-          "TMBERS3West": "1D",
+          "KRATRWest": "1N",
+          "OCITYWest": "1D",
+          "TMBRSWest": "1D",
           "TOU": "1N",
           "V112.W": "1N",
           "V165.S": "1N"

--- a/resources/scenarios/p80.json
+++ b/resources/scenarios/p80.json
@@ -2638,7 +2638,7 @@
         }
       ]
     },
-    "HHOOD5East": {
+    "HHOODEast": {
       "arrivals": [
         {
           "waypoints": "SODDA/a17000+/s280 RABBI/a13000+/s270/ho HHOOD/a9000-15000/s250 BEEVS BLRUN SSDEE/a9000-11000 THEID/a8000-10000/s240 EMZEY/a7000-8000/s230 CIZZL/a6000+/s210/h281",
@@ -2728,7 +2728,7 @@
         }
       ]
     },
-    "HHOOD5East_Final": {
+    "HHOODEast_Final": {
       "arrivals": [
         {
           "waypoints": "EMZEY/a7000+/s230 CIZZL/a6000+/s210/h281/ho",
@@ -3044,10 +3044,10 @@
         }
       ]
     },
-    "HHOOD5West": {
+    "HHOODWest": {
       "arrivals": [
         {
-          "waypoints": "SODDA/a17000+/s280 RABBI/a13000+/s270/ho HHOOD/a9000-15000/s250 BEEVS/a7100+ BLRUN SHAFR/a6700/s210/flyover KPDX",
+          "waypoints": "SODDA/a17000+/s280 RABBI/a13000+/s270/ho HHOOD/a9000-15000/s250 BEEVS/a7100+/s230 BLRUN SHAFR/a6700/s210/flyover KPDX",
           "cruise_altitude": 34000,
           "route": "/. HHOOD",
           "star": "HHOOD6",
@@ -3114,7 +3114,7 @@
         }
       ]
     },
-    "HHOOD5West_Final": {
+    "HHOODWest_Final": {
       "arrivals": [
         {
           "waypoints": "HHOOD/a9000-15000/s250 N045.32.15.516,W121.54.26.180/ho SHAFR/a6700/s210/h259",
@@ -3430,10 +3430,11 @@
         }
       ]
     },
-    "KRATR2East": {
+    "KRATREast": {
       "arrivals": [
         {
-          "waypoints": "BUWZO HELNS/a11000+/ho KRATR/a10000-13000 HYKER/a7000-9000 VOODU/a5000/s210 DOUHH NNUTT/h278",
+          "waypoints": "BUWZO HELNS/a11000+/ho KRATR/a10000-13000 HYKER/a7000-9000 VEEGN/a5000/s210 DOUHH NNUTT/a5000/flyover/h278",
+          "star": "KRATR3",
           "cruise_altitude": 34000,
           "route": "/. BUWZO",
           "initial_controller": "C32",
@@ -3479,10 +3480,10 @@
         }
       ]
     },
-    "KRATR2East_Final": {
+    "KRATREast_Final": {
       "arrivals": [
         {
-          "waypoints": "VOODU/a5000/s210/ho DOUHH NNUTT/h278",
+          "waypoints": "VEEGN/a5000/s210/ho DOUHH NNUTT/a5000/flyover/h278",
           "cruise_altitude": 34000,
           "star": "KRATR3",
           "initial_controller": "1N",
@@ -3570,10 +3571,11 @@
         }
       ]
     },
-    "KRATR2West": {
+    "KRATRWest": {
       "arrivals": [
         {
-          "waypoints": "BUWZO HELNS/a11000+/ho KRATR/a10000-13000 HYKER/a7000-9000 LIQWD/a6000 SSSUN/s210 SHYNE/h108",
+          "waypoints": "BUWZO HELNS/a11000+/ho KRATR/a10000-13000 HYKER/a7000-9000 BOOSR/a6000/s210 RALEE/a6000/flyover/h100",
+          "star": "KRATR3",
           "cruise_altitude": 34000,
           "route": "/. BUWZO",
           "scratchpad": "RKR",
@@ -3619,10 +3621,10 @@
         }
       ]
     },
-    "KRATR2West_Final": {
+    "KRATRWest_Final": {
       "arrivals": [
         {
-          "waypoints": "LIQWD/a6000 N045.43.30.282,W122.25.23.831/ho SSSUN/s210 SHYNE/h108",
+          "waypoints": "BOOSR/a6000/s210/ho RALEE/a6000/flyover/h100",
           "cruise_altitude": 34000,
           "star": "KRATR3",
           "initial_controller": "1N",
@@ -3631,7 +3633,7 @@
           "initial_speed": 250,
           "speed_restriction": 210,
           "scratchpad": "I8R",
-          "expect_approach": "I8L",
+          "expect_approach": "I8R",
           "airports": ["KPDX"],
           "airlines": {
             "KPDX": [
@@ -3710,10 +3712,11 @@
         }
       ]
     },
-    "OCITY3East": {
+    "OCITYEast": {
       "arrivals": [
         {
           "waypoints": "MOXEE PORTL N044.48.40.289,W122.41.15.494/ho VANTZ/a12000/s250 OCITY/a7000+/h280",
+          "star": "OCITY3",
           "cruise_altitude": 34000,
           "route": "/. MOXEE",
           "initial_controller": "C06",
@@ -4008,10 +4011,11 @@
         }
       ]
     },
-    "OCITY3West": {
+    "OCITYWest": {
       "arrivals": [
         {
           "waypoints": "MOXEE PORTL N044.48.40.289,W122.41.15.494/ho VANTZ/a12000/s250 OCITY/a7000+/h100",
+          "star": "OCITY3",
           "cruise_altitude": 34000,
           "route": "/. MOXEE",
           "initial_controller": "C06",
@@ -4306,10 +4310,11 @@
         }
       ]
     },
-    "TMBERS3East": {
+    "TMBRSEast": {
       "arrivals": [
         {
-          "waypoints": "TMBRS/a12000+/s270/ho VANTZ/a11000-15000/s250 FLOWR/a7000-9000 FFULL/a7000-9000 SSAIL/a6000-8000 BBREW PUBBB/a5000/s210/h281",
+          "waypoints": "TMBRS/a12000+/s270/ho VANTZ/a11000-15000/s250 FLOWR/a7000-9000 FFULL/a7000-9000 SSAIL/a6000-8000 HAZEE/a5000/s210 BBREW PUBBB/a5000/flyover/h281",
+          "star": "TMBRS4",
           "cruise_altitude": 34000,
           "route": "/. TMBRS",
           "initial_controller": "C06",
@@ -4694,10 +4699,10 @@
         }
       ]
     },
-    "TMBERS3East_Final": {
+    "TMBRSEast_Final": {
       "arrivals": [
         {
-          "waypoints": "SSAIL/a6000-8000 N045.28.18.266,W122.45.55.178/ho MYCRO/a5000/s210 BBREW PUBBB/h305",
+          "waypoints": "SSAIL/a6000-8000 N045.28.18.266,W122.45.55.178/ho HAZEE/a5000/s210 BBREW PUBBB/a5000/flyover/h281",
           "cruise_altitude": 34000,
           "star": "TMBRS4",
           "initial_controller": "1D",
@@ -5010,10 +5015,11 @@
         }
       ]
     },
-    "TMBERS3West": {
+    "TMBRSWest": {
       "arrivals": [
         {
-          "waypoints": "TMBRS/a12000+/s270/ho VANTZ/a11000-15000/s250 FLOWR/a7000-9000 ROAGE/a4000+/s210/h103",
+          "waypoints": "TMBRS/a12000+/s270/ho VANTZ/a11000-15000/s250 FLOWR/a7000-9000 WIDMR/a5000-6000/s230 WHEAT KOLCH/a5000/s210/flyover/h103",
+          "star": "TMBRS4",
           "cruise_altitude": 34000,
           "route": "/. TMBRS",
           "initial_controller": "C06",
@@ -5329,10 +5335,10 @@
         }
       ]
     },
-    "TMBERS3West_Final": {
+    "TMBRSWest_Final": {
       "arrivals": [
         {
-          "waypoints": "FLOWR/a7000-9000 N045.20.24.165,W122.33.37.227/ho ROAGE/a4000+/s210/h103",
+          "waypoints": "FLOWR/a7000-9000 N045.20.24.165,W122.33.37.227/ho WIDMR/a5000-6000/s230 WHEAT KOLCH/a5000/s210/flyover/h103",
           "cruise_altitude": 34000,
           "star": "TMBRS4",
           "initial_controller": "1D",
@@ -5674,10 +5680,10 @@
         "1F": ["Final (West)"]
       },
       "inbound_rates": {
-        "HHOOD5West": {
+        "HHOODWest": {
           "KPDX": 6
         },
-        "KRATR2West": {
+        "KRATRWest": {
           "KPDX": 4
         },
         "Hawaii": {
@@ -5693,10 +5699,10 @@
         "TOU": {
           "KPDX": 2
         },
-        "TMBERS3West": {
+        "TMBRSWest": {
           "KPDX": 7
         },
-        "OCITY3West": {
+        "OCITYWest": {
           "KPDX": 0
         },
         "V165.S": {
@@ -5754,10 +5760,10 @@
         }
       ],
       "inbound_rates": {
-        "HHOOD5East": {
+        "HHOODEast": {
           "KPDX": 6
         },
-        "KRATR2East": {
+        "KRATREast": {
           "KPDX": 4
         },
         "Hawaii": {
@@ -5773,10 +5779,10 @@
         "TOU": {
           "KPDX": 2
         },
-        "TMBERS3East": {
+        "TMBRSEast": {
           "KPDX": 7
         },
-        "OCITY3East": {
+        "OCITYEast": {
           "KPDX": 0
         },
         "V165.S": {
@@ -5827,13 +5833,13 @@
         }
       ],
       "inbound_rates": {
-        "HHOOD5West_Final": {
+        "HHOODWest_Final": {
           "KPDX": 5
         },
-        "KRATR2West_Final": {
+        "KRATRWest_Final": {
           "KPDX": 5
         },
-        "TMBERS3West_Final": {
+        "TMBRSWest_Final": {
           "KPDX": 5
         }
       },
@@ -5858,13 +5864,13 @@
         }
       ],
       "inbound_rates": {
-        "HHOOD5East_Final": {
+        "HHOODEast_Final": {
           "KPDX": 5
         },
-        "KRATR2East_Final": {
+        "KRATREast_Final": {
           "KPDX": 5
         },
-        "TMBERS3East_Final": {
+        "TMBRSEast_Final": {
           "KPDX": 5
         }
       },


### PR DESCRIPTION
- fix KRATRWest_Final expect_approach: pilots were assigned the ILS 28L while the scratchpad showed I8R; the east flow and the north-side downwind geometry both point to the north runway
- TMBRS4: west transition FLOWR..WIDMR..WHEAT..KOLCH replaces the old ROAGE leg; east adds HAZEE and the PUBBB flyover, replacing MYCRO
- KRATR3: BOOSR/RALEE legs west, VEEGN/NNUTT east, replacing LIQWD/SSSUN/SHYNE and VOODU
- HHOOD6: charted 230K at BEEVS
- add spoken STAR labels to the KRATR, TMBRS, and OCITY flows so pilots announce the arrival on check-in
- drop revision numbers from flow keys (HHOOD, KRATR, TMBRS, OCITY), following the existing HELNS key; the spoken labels carry the current revision so future chart updates no longer require key renames
- add go_around_assignments: the final-only configurations (KP1/KP2) had neither go-around nor departure assignments, so the go-around controller lookup fell through to the current controller (the tower) and go-arounds never returned to the final controller. KP1/KP2 now send go-arounds to 1F; the combined configurations get the per-runway split from the P80 SOP (north runway to NORTH, south to HOOD)